### PR TITLE
[belswissbank] provide incomeBankID and outcomeBankID instead of combined id for transfer transactions

### DIFF
--- a/plugins/belswissbank/main.js
+++ b/plugins/belswissbank/main.js
@@ -66,12 +66,15 @@ var main = (function (_, utils, BSB, ZenMoney, errors) {
                 var isNonAmbiguousPair = transactions.length === 2;
                 if (isNonAmbiguousPair) {
                     var sorted = _.sortBy(transactions, _.property('income'));
-                    var outcomeTransaction = _.omit(sorted[0], 'income', 'incomeAccount');
-                    var incomeTransaction = _.omit(sorted[1], 'outcome', 'outcomeAccount');
+                    var outcomeTransaction = sorted[0];
+                    var incomeTransaction = sorted[1];
                     transactionReplacements[outcomeTransaction.id] = _.defaults.apply(_, [
-                        {id: outcomeTransaction.id + '+' + incomeTransaction.id},
-                        incomeTransaction,
-                        outcomeTransaction
+                        {
+                            incomeBankID: incomeTransaction.id,
+                            outcomeBankID: outcomeTransaction.id
+                        },
+                        _.omit(incomeTransaction, 'id', 'outcome', 'outcomeAccount'),
+                        _.omit(outcomeTransaction, 'id', 'income', 'incomeAccount')
                     ]);
                     transactionReplacements[incomeTransaction.id] = null;
                 } else {


### PR DESCRIPTION
motivated by @skvav 

replace synthetic `id` for merged transfer transactions with separate `incomeBankID` and `outcomeBankID`

sample transfer transaction diff 
```diff
-      "id": "12377125+12377126",
+      "incomeBankID": "12377126",
+      "outcomeBankID": "12377125",
```