### PR TITLE
[bootloader] implementation

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -25,7 +25,7 @@ const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 5000;
 const https = process.env.HTTPS === "true";
 choosePort(HOST, DEFAULT_PORT)
     .then(port => {
-        const webpackConfig = createWebpackConfig({production: false});
+        const webpackConfig = createWebpackConfig({production: process.env.PRODUCTION === "true"});
         const urls = prepareUrls(https ? "https" : "http", HOST, port);
         const compiler = createCompiler(webpack, webpackConfig, params.pluginName, urls, fs.existsSync(paths.yarnLockFile));
         const serverConfig = createDevServerConfig({allowedHost: urls.lanUrlForConfig, host: HOST, https});

--- a/src/plugins/bootloader/ZenmoneyManifest.xml
+++ b/src/plugins/bootloader/ZenmoneyManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>bootloader</id>
+    <version>1.0.0</version>
+    <build>1</build>
+    <company>0</company>
+    <modular>true</modular>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <description>Loader for plugins hosted on external host. Use with caution only for development purposes!</description>
+</provider>

--- a/src/plugins/bootloader/index.js
+++ b/src/plugins/bootloader/index.js
@@ -1,0 +1,12 @@
+export function main() {
+    const {scriptUrl, preferencesJson} = ZenMoney.getPreferences();
+    const preferences = JSON.parse(preferencesJson);
+    ZenMoney.getPreferences = () => preferences;
+    const body = ZenMoney.requestGet(scriptUrl);
+    const status = ZenMoney.getLastStatusCode();
+    console.assert(status === 200, "non-success status received for url", {status, scriptUrl, body});
+    // eslint-disable-next-line no-eval
+    eval(body);
+    console.assert(global.main !== main, "loaded script should override main function");
+    global.main();
+}

--- a/src/plugins/bootloader/preferences.xml
+++ b/src/plugins/bootloader/preferences.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+            key="scriptUrl"
+            obligatory="true"
+            title="Script URL"
+            dialogTitle="Script URL"
+            positiveButtonText="Ok"
+            negativeButtonText="Cancel"
+            summary="|scriptUrl|{@s}"
+    >
+    </EditTextPreference>
+    <EditTextPreference
+            key="preferencesJson"
+            obligatory="true"
+            title="Preferences JSON"
+            defaultValue="{}"
+            dialogTitle="Preferences accessible in loaded plugin"
+            positiveButtonText="Ok"
+            negativeButtonText="Cancel"
+            summary="|preferencesJson|{@s}"
+    >
+    </EditTextPreference>
+</PreferenceScreen>


### PR DESCRIPTION
adds ability to load plugin straight from developer host

use
PRODUCTION=true PORT=%port-to-bind% HOST=%host-to-bind% to start building plugin as a standalone package

plugin will be compiled and available on %host-to-bind%:%port-to-bind%/index.js