### PR TITLE
fix dates interpretation issue: manually added transactions are all before imported from bank

### DIFF
--- a/src/common/adapters.js
+++ b/src/common/adapters.js
@@ -48,17 +48,28 @@ export function provideScrapeDates(fn) {
     };
 }
 
+export function convertTimestampToDate(timestamp) {
+    // used mobile interpreter implementation as a reference
+    const millis = timestamp < 10000000000
+        ? timestamp * 1000
+        : timestamp;
+    return new Date(millis);
+}
+
 export function postProcessTransaction(transaction) {
     if (ZenMoney.features.dateProcessing) {
         return transaction;
     }
-    if (!(transaction.date instanceof Date)) {
+    let date = (typeof transaction.date === "number")
+        ? convertTimestampToDate(transaction.date)
+        : transaction.date;
+    if (!(date instanceof Date)) {
         return transaction;
     }
     return {
         ...transaction,
-        date: new Date(transaction.date.valueOf() - transaction.date.getTimezoneOffset() * MS_IN_MINUTE),
-        created: transaction.date,
+        date: new Date(date.valueOf() - date.getTimezoneOffset() * MS_IN_MINUTE),
+        created: date,
     };
 }
 

--- a/src/common/adapters.js
+++ b/src/common/adapters.js
@@ -1,4 +1,4 @@
-import {isValidDate} from "./dates";
+import {formatZenMoneyDate, isValidDate} from "./dates";
 
 const MS_IN_MINUTE = 60 * 1000;
 const MS_IN_DAY = 24 * 60 * MS_IN_MINUTE;
@@ -57,7 +57,7 @@ export function postProcessTransaction(transaction) {
     }
     return {
         ...transaction,
-        date: new Date(transaction.date.valueOf() - transaction.date.getTimezoneOffset() * MS_IN_MINUTE),
+        date: formatZenMoneyDate(transaction.date),
     };
 }
 

--- a/src/common/adapters.js
+++ b/src/common/adapters.js
@@ -58,6 +58,7 @@ export function postProcessTransaction(transaction) {
     return {
         ...transaction,
         date: new Date(transaction.date.valueOf() - transaction.date.getTimezoneOffset() * MS_IN_MINUTE),
+        created: transaction.date,
     };
 }
 

--- a/src/common/adapters.js
+++ b/src/common/adapters.js
@@ -1,4 +1,4 @@
-import {formatZenMoneyDate, isValidDate} from "./dates";
+import {isValidDate} from "./dates";
 
 const MS_IN_MINUTE = 60 * 1000;
 const MS_IN_DAY = 24 * 60 * MS_IN_MINUTE;
@@ -57,7 +57,7 @@ export function postProcessTransaction(transaction) {
     }
     return {
         ...transaction,
-        date: formatZenMoneyDate(transaction.date),
+        date: new Date(transaction.date.valueOf() - transaction.date.getTimezoneOffset() * MS_IN_MINUTE),
     };
 }
 

--- a/src/common/adapters.test.js
+++ b/src/common/adapters.test.js
@@ -160,24 +160,24 @@ describe("provideScrapeDates", () => {
 });
 
 describe("postProcessTransactions", () => {
-    const withTimezoneOffset = (date, offsetInMinutes) => {
-        date.getTimezoneOffset = () => offsetInMinutes;
-        return date;
-    };
     const processDate = (date) => postProcessTransaction({date}).date;
     const assertIsUntouched = (date) => expect(processDate(date)).toBe(date);
 
     it("should fix dates if dateProcessing feature is not implemented", () => {
         global.ZenMoney = {features: {}};
-        expect(processDate(withTimezoneOffset(new Date("2010-01-01T00:00:00+05:00"), -300))).toEqual(new Date("2010-01-01T00:00:00Z"));
-        expect(processDate(withTimezoneOffset(new Date("2010-01-01T00:00:00-05:00"), 300))).toEqual(new Date("2010-01-01T00:00:00Z"));
-        
+        expect(processDate(new Date(2010, 0, 0, 23, 59, 59))).toEqual("2009-12-31");
+        expect(processDate(new Date(2010, 0, 1, 0, 0, 0))).toEqual("2010-01-01");
+        expect(processDate(new Date(2010, 0, 1, 23, 59, 59))).toEqual("2010-01-01");
+        expect(processDate(new Date(2010, 0, 2, 0, 0, 0))).toEqual("2010-01-02");
+        assertIsUntouched(Date.now());
+
         global.ZenMoney = {features: {dateProcessing: true}};
-        assertIsUntouched(withTimezoneOffset(new Date("2010-01-01T00:00:00+05:00"), -300));
-        assertIsUntouched(withTimezoneOffset(new Date("2010-01-01T00:00:00-05:00"), 300));
+        assertIsUntouched(new Date("2010-01-01T00:00:00+05:00"));
+        assertIsUntouched(new Date("2010-01-01T00:00:00-05:00"));
         assertIsUntouched("2010-01-01");
         assertIsUntouched(null);
         assertIsUntouched(undefined);
+        assertIsUntouched(Date.now());
     });
 });
 

--- a/src/common/adapters.test.js
+++ b/src/common/adapters.test.js
@@ -160,24 +160,24 @@ describe("provideScrapeDates", () => {
 });
 
 describe("postProcessTransactions", () => {
+    const withTimezoneOffset = (date, offsetInMinutes) => {
+        date.getTimezoneOffset = () => offsetInMinutes;
+        return date;
+    };
     const processDate = (date) => postProcessTransaction({date}).date;
     const assertIsUntouched = (date) => expect(processDate(date)).toBe(date);
 
     it("should fix dates if dateProcessing feature is not implemented", () => {
         global.ZenMoney = {features: {}};
-        expect(processDate(new Date(2010, 0, 0, 23, 59, 59))).toEqual("2009-12-31");
-        expect(processDate(new Date(2010, 0, 1, 0, 0, 0))).toEqual("2010-01-01");
-        expect(processDate(new Date(2010, 0, 1, 23, 59, 59))).toEqual("2010-01-01");
-        expect(processDate(new Date(2010, 0, 2, 0, 0, 0))).toEqual("2010-01-02");
-        assertIsUntouched(Date.now());
-
+        expect(processDate(withTimezoneOffset(new Date("2010-01-01T00:00:00+05:00"), -300))).toEqual(new Date("2010-01-01T00:00:00Z"));
+        expect(processDate(withTimezoneOffset(new Date("2010-01-01T00:00:00-05:00"), 300))).toEqual(new Date("2010-01-01T00:00:00Z"));
+        
         global.ZenMoney = {features: {dateProcessing: true}};
-        assertIsUntouched(new Date("2010-01-01T00:00:00+05:00"));
-        assertIsUntouched(new Date("2010-01-01T00:00:00-05:00"));
+        assertIsUntouched(withTimezoneOffset(new Date("2010-01-01T00:00:00+05:00"), -300));
+        assertIsUntouched(withTimezoneOffset(new Date("2010-01-01T00:00:00-05:00"), 300));
         assertIsUntouched("2010-01-01");
         assertIsUntouched(null);
         assertIsUntouched(undefined);
-        assertIsUntouched(Date.now());
     });
 });
 

--- a/src/common/dates.js
+++ b/src/common/dates.js
@@ -8,10 +8,7 @@ export function formatCommentDateTime(date) {
     if (!isValidDate(date)) {
         throw new Error("valid date should be provided");
     }
-    return formatZenMoneyDate(date) + " " +
+    return [date.getFullYear(), date.getMonth() + 1, date.getDate()].map(toAtLeastTwoDigitsString).join("-") + " " +
         [date.getHours(), date.getMinutes(), date.getSeconds()].map(toAtLeastTwoDigitsString).join(":");
 }
 
-export function formatZenMoneyDate(date) {
-    return [date.getFullYear(), date.getMonth() + 1, date.getDate()].map(toAtLeastTwoDigitsString).join("-");
-}

--- a/src/common/dates.js
+++ b/src/common/dates.js
@@ -8,7 +8,10 @@ export function formatCommentDateTime(date) {
     if (!isValidDate(date)) {
         throw new Error("valid date should be provided");
     }
-    return [date.getFullYear(), date.getMonth() + 1, date.getDate()].map(toAtLeastTwoDigitsString).join("-") + " " +
+    return formatZenMoneyDate(date) + " " +
         [date.getHours(), date.getMinutes(), date.getSeconds()].map(toAtLeastTwoDigitsString).join(":");
 }
 
+export function formatZenMoneyDate(date) {
+    return [date.getFullYear(), date.getMonth() + 1, date.getDate()].map(toAtLeastTwoDigitsString).join("-");
+}


### PR DESCRIPTION
seems like transactions added by UI internally have 00:00:00 time set
transactions from bank with provided time are now always sorted as "newer" than all newer manually added ones in UI

now we're automatically cropping time to make bank transactions order the same way as manually added in list

note: when feature `dateProcessing` will be implemented, transactions added by UI must have valid time set to ensure correct ordering inside day