### PR TITLE
[alfabank] replace Object.entries usages with _.toPairs

### DIFF
--- a/src/common/mergeTransfers.js
+++ b/src/common/mergeTransfers.js
@@ -3,7 +3,7 @@ import {convertReadableTransactionToReadableTransferSide} from "./converters";
 
 export function mergeTransfers({items, isTransferItem, makeGroupKey, selectTransactionId, selectReadableTransaction}) {
     const {1: singles = [], 2: pairs = [], collisiveBuckets = []} = _.groupBy(
-        Object.entries(_.groupBy(items.filter(isTransferItem), (x) => makeGroupKey(x))),
+        _.toPairs(_.groupBy(items.filter(isTransferItem), (x) => makeGroupKey(x))),
         ([transferId, items]) => items.length > 2 ? "collisiveBuckets" : items.length,
     );
     if (singles.length > 0) {

--- a/src/plugins/alfabank/preferences.js
+++ b/src/plugins/alfabank/preferences.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 const cardExpirationDateRegExp = /^(\d{2})\/?(\d{2})$/;
 
 export function normalizeCardExpirationDate(cardExpirationDate) {
@@ -17,7 +19,7 @@ export function normalizePhoneNumber(phoneNumber) {
 export function normalizePreferences(preferences) {
     const {cardNumber, cardExpirationDate, phoneNumber} = preferences;
     // FIXME must be checked in a wrapper
-    Object.entries({cardNumber, cardExpirationDate, phoneNumber}).forEach(([key, value]) => {
+    _.toPairs({cardNumber, cardExpirationDate, phoneNumber}).forEach(([key, value]) => {
         if (!value) {
             // FIXME must use InvalidPreferencesError here, but InvalidPreferencesError android handler is buggy
             throw new TemporaryError(`preference key ${key} must be set`);


### PR DESCRIPTION
 (Object.entries is not polyfilled)