### PR TITLE
[alfabank] stabilization

### DIFF
--- a/src/common/accounts.js
+++ b/src/common/accounts.js
@@ -1,3 +1,5 @@
+import _ from "lodash";
+
 function getLast4Digits(id, ignoreCurrentSanitizing) {
     id = id.toString().trim();
     if (/\d\d\d\d$/.test(id) && (ignoreCurrentSanitizing || !/[^\d*]/.test(id))) {
@@ -7,11 +9,13 @@ function getLast4Digits(id, ignoreCurrentSanitizing) {
     }
 }
 
-function sanitizeSyncId(id) {
-    id = id.toString().trim();
+export function maybeSanitizeSyncIdMaybeNot(id) {
     return id.length > 9 && !/[^\d*]/.test(id) ? "*****" + id.substring(5) : id;
 }
 
+/**
+ * @deprecated try using stricter ensureSyncIDsAreUniqueButSanitized instead
+ */
 export function convertAccountSyncID(accounts, ignoreCurrentSanitizing) {
     const accountsByLast4Digits = {};
     for (const account of accounts) {
@@ -32,7 +36,7 @@ export function convertAccountSyncID(accounts, ignoreCurrentSanitizing) {
         for (let id of account.syncID) {
             const key = account.instrument + "_" + getLast4Digits(id, ignoreCurrentSanitizing);
             const group = accountsByLast4Digits[key];
-            id = group.length > 1 ? sanitizeSyncId(id) : getLast4Digits(id, ignoreCurrentSanitizing);
+            id = group.length > 1 ? maybeSanitizeSyncIdMaybeNot(id) : getLast4Digits(id, ignoreCurrentSanitizing);
             if (syncID.indexOf(id) < 0) {
                 syncID.push(id);
             }
@@ -42,6 +46,10 @@ export function convertAccountSyncID(accounts, ignoreCurrentSanitizing) {
     return accounts;
 }
 
+/**
+ * @deprecated no kittens will die if you inline _.toPairs(accounts).filter(([key, account]) => key === account.id) in plugin
+ * (this logic is neither generic, nor it is named correctly - it actually filters stuff)
+ */
 export function convertAccountMapToArray(accounts) {
     const filtered = [];
     for (const id in accounts) {
@@ -51,4 +59,35 @@ export function convertAccountMapToArray(accounts) {
         }
     }
     return filtered;
+}
+
+const assertReplacementsAreUnique = (replacementPairs) => {
+    const duplicates = _.toPairs(_.countBy(replacementPairs, ([syncID, replacement]) => replacement))
+        .filter(([replacement, count]) => count !== 1);
+    console.assert(duplicates.length === 0, "invariant: syncID replacementPairs have duplicates", {duplicates});
+};
+
+export function ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId}) {
+    const replacementsByInstrument = _.mapValues(_.groupBy(accounts, (x) => x.instrument), (accounts, instrument) => {
+        const flattenedAccounts = _.flatMap(accounts, ({syncID, ...rest}) => {
+            console.assert(Array.isArray(syncID), "account.syncID must be array");
+            return syncID.map((singleSyncID) => {
+                console.assert(typeof singleSyncID === "string", "account.syncID must be array of strings, met not a string: " + JSON.stringify(singleSyncID));
+                return ({singleSyncID, ...rest});
+            });
+        });
+        const flattenedAccountsByLast4Digits = _.groupBy(flattenedAccounts, (account) => {
+            console.assert(/\d{4}$/.test(account.singleSyncID), "syncID must end with last4, but was: " + account.singleSyncID);
+            return account.singleSyncID.slice(-4);
+        });
+        const syncIDReplacementPairs = _.flatMap(
+            _.toPairs(flattenedAccountsByLast4Digits),
+            ([last4, flattenedAccountsSharingKey]) => flattenedAccountsSharingKey.length === 1
+                ? [[flattenedAccountsSharingKey[0].singleSyncID, last4]]
+                : flattenedAccountsSharingKey.map((x) => [x.singleSyncID, sanitizeSyncId(x.singleSyncID)]),
+        );
+        assertReplacementsAreUnique(syncIDReplacementPairs);
+        return _.fromPairs(syncIDReplacementPairs);
+    });
+    return accounts.map((account) => ({...account, syncID: account.syncID.map((syncID) => replacementsByInstrument[account.instrument][syncID] || syncID)}));
 }

--- a/src/common/accounts.js
+++ b/src/common/accounts.js
@@ -9,8 +9,14 @@ function getLast4Digits(id, ignoreCurrentSanitizing) {
     }
 }
 
-export function maybeSanitizeSyncIdMaybeNot(id) {
-    return id.length > 9 && !/[^\d*]/.test(id) ? "*****" + id.substring(5) : id;
+export function sanitizeSyncId(id) {
+    if (id.includes("*") || id.length < 16) {
+        return id;
+    }
+    if (id.length === 16) {
+        return id.slice(0, 6) + "******" + id.slice(12, 16);
+    }
+    return "*****" + id.substring(5);
 }
 
 /**
@@ -36,7 +42,7 @@ export function convertAccountSyncID(accounts, ignoreCurrentSanitizing) {
         for (let id of account.syncID) {
             const key = account.instrument + "_" + getLast4Digits(id, ignoreCurrentSanitizing);
             const group = accountsByLast4Digits[key];
-            id = group.length > 1 ? maybeSanitizeSyncIdMaybeNot(id) : getLast4Digits(id, ignoreCurrentSanitizing);
+            id = group.length > 1 ? sanitizeSyncId(id) : getLast4Digits(id, ignoreCurrentSanitizing);
             if (syncID.indexOf(id) < 0) {
                 syncID.push(id);
             }

--- a/src/common/accounts.js
+++ b/src/common/accounts.js
@@ -68,7 +68,9 @@ const assertReplacementsAreUnique = (replacementPairs) => {
 };
 
 export function ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId}) {
-    const replacementsByInstrument = _.mapValues(_.groupBy(accounts, (x) => x.instrument), (accounts, instrument) => {
+    console.assert(Array.isArray(accounts), "accounts must be array");
+    console.assert(typeof sanitizeSyncId === "function", "sanitizeSyncId must be function");
+    const replacementsByInstrument = _.mapValues(_.groupBy(accounts, (x) => x.instrument), (accounts) => {
         const flattenedAccounts = _.flatMap(accounts, ({syncID, ...rest}) => {
             console.assert(Array.isArray(syncID), "account.syncID must be array");
             return syncID.map((singleSyncID) => {

--- a/src/common/accounts.test.js
+++ b/src/common/accounts.test.js
@@ -1,21 +1,21 @@
-import {convertAccountSyncID} from "./accounts";
+import {ensureSyncIDsAreUniqueButSanitized, maybeSanitizeSyncIdMaybeNot} from "./accounts";
 
-describe("convertAccountSyncID", () => {
-    it("should truncate syncID to last 4 digits if there is no intersection between accounts", () => {
+describe("ensureSyncIDsAreUniqueButSanitized", () => {
+    it("truncate syncID to last4 digits if there is no intersection between accounts", () => {
         const accounts = [
             {syncID: ["0001", "111120"]},
-            {syncID: ["0002", "222"]},
+            {syncID: ["0002", "2222"]},
             {syncID: ["0003"]},
         ];
         const expected = [
             {syncID: ["0001", "1120"]},
-            {syncID: ["0002", "222"]},
+            {syncID: ["0002", "2222"]},
             {syncID: ["0003"]},
         ];
-        expect(convertAccountSyncID(accounts)).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
     });
 
-    it("should truncate syncID to last 4 digits if there is intersection between accounts with different instruments", () => {
+    it("truncates syncID to last 4 digits if there is intersection between accounts with different instruments", () => {
         const accounts = [
             {syncID: ["0001", "121120"], instrument: "RUB"},
             {syncID: ["0002", "111120"], instrument: "USD"},
@@ -26,10 +26,10 @@ describe("convertAccountSyncID", () => {
             {syncID: ["0002", "1120"], instrument: "USD"},
             {syncID: ["0003"]},
         ];
-        expect(convertAccountSyncID(accounts)).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
     });
 
-    it("should sanitize syncID if there is intersection", () => {
+    it("doesn't trim, but sanitizes syncID to guarantee id uniqueness between accounts with the same instrument", () => {
         const accounts = [
             {syncID: ["0001", "00000121120"], instrument: "RUB"},
             {syncID: ["0002", "00000111120"], instrument: "RUB"},
@@ -40,10 +40,10 @@ describe("convertAccountSyncID", () => {
             {syncID: ["0002", "*****111120"], instrument: "RUB"},
             {syncID: ["0003"]},
         ];
-        expect(convertAccountSyncID(accounts)).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
     });
 
-    it("should leave full syncID if there is intersection but syncID are short", () => {
+    it("leaves full syncID if there is intersection but syncID are short", () => {
         const accounts = [
             {syncID: ["0001", "121120"], instrument: "RUB"},
             {syncID: ["0002", "111120"], instrument: "RUB"},
@@ -54,6 +54,6 @@ describe("convertAccountSyncID", () => {
             {syncID: ["0002", "111120"], instrument: "RUB"},
             {syncID: ["0003"]},
         ];
-        expect(convertAccountSyncID(accounts)).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
     });
 });

--- a/src/common/accounts.test.js
+++ b/src/common/accounts.test.js
@@ -1,4 +1,4 @@
-import {ensureSyncIDsAreUniqueButSanitized, maybeSanitizeSyncIdMaybeNot} from "./accounts";
+import {ensureSyncIDsAreUniqueButSanitized, sanitizeSyncId} from "./accounts";
 
 describe("ensureSyncIDsAreUniqueButSanitized", () => {
     it("truncate syncID to last4 digits if there is no intersection between accounts", () => {
@@ -12,7 +12,7 @@ describe("ensureSyncIDsAreUniqueButSanitized", () => {
             {syncID: ["0002", "2222"]},
             {syncID: ["0003"]},
         ];
-        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: sanitizeSyncId})).toEqual(expected);
     });
 
     it("truncates syncID to last 4 digits if there is intersection between accounts with different instruments", () => {
@@ -26,7 +26,7 @@ describe("ensureSyncIDsAreUniqueButSanitized", () => {
             {syncID: ["0002", "1120"], instrument: "USD"},
             {syncID: ["0003"]},
         ];
-        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: sanitizeSyncId})).toEqual(expected);
     });
 
     it("doesn't trim, but sanitizes syncID to guarantee id uniqueness between accounts with the same instrument", () => {
@@ -36,11 +36,11 @@ describe("ensureSyncIDsAreUniqueButSanitized", () => {
             {syncID: ["0003"]},
         ];
         const expected = [
-            {syncID: ["0001", "*****121120"], instrument: "RUB"},
-            {syncID: ["0002", "*****111120"], instrument: "RUB"},
+            {syncID: ["0001", "sanitized(00000121120)"], instrument: "RUB"},
+            {syncID: ["0002", "sanitized(00000111120)"], instrument: "RUB"},
             {syncID: ["0003"]},
         ];
-        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: (x) => `sanitized(${x})`})).toEqual(expected);
     });
 
     it("leaves full syncID if there is intersection but syncID are short", () => {
@@ -54,6 +54,28 @@ describe("ensureSyncIDsAreUniqueButSanitized", () => {
             {syncID: ["0002", "111120"], instrument: "RUB"},
             {syncID: ["0003"]},
         ];
-        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: maybeSanitizeSyncIdMaybeNot})).toEqual(expected);
+        expect(ensureSyncIDsAreUniqueButSanitized({accounts, sanitizeSyncId: sanitizeSyncId})).toEqual(expected);
+    });
+});
+
+describe("sanitizeSyncId", () => {
+    it("doesn't touch ids shorter than 16 chars (already sanitized?)", () => {
+        const tinyId = "00000121120";
+        expect(sanitizeSyncId(tinyId)).toEqual(tinyId);
+        const shortId = "123456789012345";
+        expect(sanitizeSyncId(shortId)).toEqual(shortId);
+    });
+
+    it("doesn't touch anything with * present (already sanitized?)", () => {
+        const cardId = "123456789*123456";
+        expect(sanitizeSyncId(cardId)).toEqual(cardId);
+    });
+
+    it("cuts first 5 chars if id is longer than 16 chars (looks like an account id)", () => {
+        expect(sanitizeSyncId("12345678901234567")).toEqual("*****678901234567");
+    });
+
+    it("cuts [6..12)-indexed chars if id length is 16 chars (looks like a card number)", () => {
+        expect(sanitizeSyncId("1234567890123456")).toEqual("123456******3456");
     });
 });

--- a/src/common/adapters.js
+++ b/src/common/adapters.js
@@ -54,7 +54,7 @@ export function provideScrapeDates(fn) {
     };
 }
 
-function assertAccountIdsAreUnique(accounts) {
+export function assertAccountIdsAreUnique(accounts) {
     _.toPairs(_.countBy(accounts, (x) => x.id))
         .filter(([id, count]) => count > 1)
         .forEach(([id, count]) => {

--- a/src/plugins/alfabank/__snapshots__/converters.test.js.snap
+++ b/src/plugins/alfabank/__snapshots__/converters.test.js.snap
@@ -9,7 +9,7 @@ Array [
     "sides": Array [
       Object {
         "account": Object {
-          "id": "7890",
+          "id": "x7890",
         },
         "amount": 1000,
         "id": "1",
@@ -17,7 +17,7 @@ Array [
       },
       Object {
         "account": Object {
-          "id": "0987",
+          "id": "x0987",
         },
         "amount": -1000,
         "id": "2",
@@ -33,7 +33,7 @@ exports[`convertApiMovementsToReadableTransactions guesses missing sender accoun
 Array [
   Object {
     "account": Object {
-      "id": "4444",
+      "id": "x4444",
     },
     "comment": null,
     "date": 2018-05-22T09:00:00.000Z,

--- a/src/plugins/alfabank/api.js
+++ b/src/plugins/alfabank/api.js
@@ -161,11 +161,19 @@ export async function register({deviceId, cardNumber, cardExpirationDate, phoneN
     const confirmationCode = await ZenMoney.readLine("Введите код из СМС сообщения", {inputType: "number"});
     const {redirectUrl} = await finishCustomerRegistration({confirmationCode, queryRedirectParams, previousMultiFactorResponseParams});
     const redirectedResponse = await fetchJson(redirectUrl, {
-        sanitizeRequestLog: true,
-        sanitizeResponseLog: true,
+        sanitizeRequestLog: {url: true},
+        sanitizeResponseLog: {url: true},
     });
-    const [, accessToken] = redirectedResponse.url.match(/access_token=(.+?)&/);
-    const [, refreshToken] = redirectedResponse.url.match(/refresh_token=(.+?)&/);
+    const accessTokenMatch = redirectedResponse.url.match(/access_token=(.+?)&/);
+    if (!accessTokenMatch) {
+        throw new Error(`redirect url does not contain access_token param: ` + redirectedResponse.url);
+    }
+    const refreshTokenMatch = redirectedResponse.url.match(/refresh_token=(.+?)&/);
+    if (!refreshTokenMatch) {
+        throw new Error(`redirect url does not contain refresh_token param: ` + redirectedResponse.url);
+    }
+    const [, accessToken] = accessTokenMatch;
+    const [, refreshToken] = refreshTokenMatch;
     return {accessToken, refreshToken};
 }
 

--- a/src/plugins/alfabank/converters.js
+++ b/src/plugins/alfabank/converters.js
@@ -175,7 +175,7 @@ function complementSides(apiMovements) {
     const relatedMovementsByReferenceLookup = _.fromPairs(_.toPairs(_.groupBy(apiMovements, x => {
         delete x.actions;
         return x.reference;
-    })).filter(([key, items]) => key !== "HOLD" && items.length === 2));
+    })).filter(([key, items]) => key !== "HOLD" && !key.startsWith("CASHIN") && items.length === 2));
     return apiMovements.map((apiMovement) => {
         const relatedMovements = relatedMovementsByReferenceLookup[apiMovement.reference];
         if (!relatedMovements) {

--- a/src/plugins/alfabank/converters.js
+++ b/src/plugins/alfabank/converters.js
@@ -129,10 +129,11 @@ function findMovementAccountTuple(apiMovement, accountTuples) {
             return nonOwnSharedAccountTuples[0];
         }
     }
-    throw new Error(formatWithCustomInspectParams(
-        `cannot determine ${parsedAmount > 0 ? "recipient" : "sender"} account id`,
+    console.warn(
+        `cannot extract ${parsedAmount > 0 ? "recipient" : "sender"} account id (no single candidate), ignoring movement`,
         {apiMovement, candidatesLast4Chars},
-    ));
+    );
+    return null;
 }
 
 export const normalizeIsoDate = (isoDate) => isoDate.replace(/([+-])(\d{2})(\d{2})$/, "$1$2:$3");

--- a/src/plugins/alfabank/converters.js
+++ b/src/plugins/alfabank/converters.js
@@ -226,6 +226,9 @@ export function convertApiMovementsToReadableTransactions(apiMovements, accountT
             if (readableTransaction.type !== "transaction") {
                 return false;
             }
+            if (!isPossiblyTransfer({reference})) {
+                return false;
+            }
             if (description.startsWith("Внутрибанковский перевод между счетами")) {
                 return true;
             }

--- a/src/plugins/alfabank/converters.js
+++ b/src/plugins/alfabank/converters.js
@@ -24,7 +24,7 @@ function convertCreditApiAccount(apiAccount) {
             available: parseApiAmount(trimPostfix(availableWithInstrument, instrumentPostfix)),
             creditLimit: parseApiAmount(trimPostfix(creditLimitWithInstrument, instrumentPostfix)),
         };
-    } else if (typeWithDashAndInstrument.startsWith("Кредит наличными")) {
+    } else if (typeWithDashAndInstrument.startsWith("Кредит наличными") || typeWithDashAndInstrument.startsWith("Потребительский кредит")) {
         return {
             startBalance: 0,
             balance: parseApiAmount(apiAccount.amount),

--- a/src/plugins/alfabank/converters.js
+++ b/src/plugins/alfabank/converters.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import {ensureSyncIDsAreUniqueButSanitized} from "../../common/accounts";
+import {ensureSyncIDsAreUniqueButSanitized, sanitizeSyncId} from "../../common/accounts";
 import {asCashTransfer, formatComment} from "../../common/converters";
 import {mergeTransfers} from "../../common/mergeTransfers";
 import {formatWithCustomInspectParams} from "../../consoleAdapter";
@@ -58,7 +58,7 @@ export function toZenmoneyAccount(apiAccount) {
 export const convertApiAccountsToAccountTuples = (apiAccounts) => {
     const zenMoneyAccounts = ensureSyncIDsAreUniqueButSanitized({
         accounts: apiAccounts.map(toZenmoneyAccount),
-        sanitizeSyncId: (syncID) => syncID.slice(-8),
+        sanitizeSyncId,
     });
     return apiAccounts.map((apiAccount, index) => {
         const zenMoneyAccount = zenMoneyAccounts[index];

--- a/src/plugins/alfabank/converters.test.js
+++ b/src/plugins/alfabank/converters.test.js
@@ -1,4 +1,10 @@
-import {convertApiMovementsToReadableTransactions, normalizeIsoDate, parseApiMovementDescription, toZenmoneyAccount} from "./converters";
+import {
+    convertApiAccountsToAccountTuples,
+    convertApiMovementsToReadableTransactions,
+    normalizeIsoDate,
+    parseApiMovementDescription,
+    toZenmoneyAccount,
+} from "./converters";
 
 describe("toZenmoneyAccount", () => {
     it("maps api credit card account", () => {
@@ -152,10 +158,10 @@ describe("convertApiMovementsToReadableTransactions", () => {
                 },
             },
         ];
-        expect(convertApiMovementsToReadableTransactions(apiMovements, [
-            {number: "x7890"},
-            {number: "x0987"},
-        ])).toMatchSnapshot();
+        expect(convertApiMovementsToReadableTransactions(apiMovements, convertApiAccountsToAccountTuples([
+            {number: "x7890", amount: "1 008.40"},
+            {number: "x0987", amount: "2 016.80"},
+        ]))).toMatchSnapshot();
     });
 
     it("guesses missing sender account info with single non-own shared account", () => {
@@ -189,9 +195,9 @@ describe("convertApiMovementsToReadableTransactions", () => {
                 anotherClientInfo: {clientName: "test(anotherClientInfo.clientName)", clientPhone: "test(anotherClientInfo.clientPhone)"},
             },
         ];
-        expect(convertApiMovementsToReadableTransactions(apiMovements, [
-            {number: "x4444", sharedAccountInfo: {isOwn: false}},
-        ])).toMatchSnapshot();
+        expect(convertApiMovementsToReadableTransactions(apiMovements, convertApiAccountsToAccountTuples([
+            {number: "x4444", amount: "1 024.00", sharedAccountInfo: {isOwn: false}},
+        ]))).toMatchSnapshot();
         expect(() => convertApiMovementsToReadableTransactions(apiMovements, [])).toThrow("cannot determine sender account id");
     });
 });

--- a/src/plugins/alfabank/converters.test.js
+++ b/src/plugins/alfabank/converters.test.js
@@ -198,6 +198,6 @@ describe("convertApiMovementsToReadableTransactions", () => {
         expect(convertApiMovementsToReadableTransactions(apiMovements, convertApiAccountsToAccountTuples([
             {number: "x4444", amount: "1 024.00", sharedAccountInfo: {isOwn: false}},
         ]))).toMatchSnapshot();
-        expect(() => convertApiMovementsToReadableTransactions(apiMovements, [])).toThrow("cannot determine sender account id");
+        expect(convertApiMovementsToReadableTransactions(apiMovements, [])).toEqual([]);
     });
 });

--- a/src/plugins/alfabank/converters.test.js
+++ b/src/plugins/alfabank/converters.test.js
@@ -27,9 +27,9 @@ describe("toZenmoneyAccount", () => {
         })).toEqual({
             "type": "ccard",
             "title": "Счёт кредитной карты",
-            "id": "3210",
+            "id": "98765432109876543210",
             "syncID": [
-                "3210",
+                "98765432109876543210",
             ],
             "instrument": "RUR",
             "available": 15294.21,
@@ -57,9 +57,9 @@ describe("toZenmoneyAccount", () => {
         })).toEqual({
             "type": "ccard",
             "title": "Большой кредит",
-            "id": "3210",
+            "id": "98765432109876543210",
             "syncID": [
-                "3210",
+                "98765432109876543210",
             ],
             "instrument": "RUR",
             "startBalance": 0,
@@ -76,9 +76,9 @@ describe("toZenmoneyAccount", () => {
         })).toEqual({
             "type": "ccard",
             "title": "Текущий счёт",
-            "id": "6789",
+            "id": "01234567890123456789",
             "syncID": [
-                "6789",
+                "01234567890123456789",
             ],
             "instrument": "RUR",
             "balance": 8936.66,

--- a/src/plugins/alfabank/index.js
+++ b/src/plugins/alfabank/index.js
@@ -1,7 +1,7 @@
 import {toZenmoneyTransaction} from "../../common/converters";
 import {generateUUID} from "../../common/utils";
 import {assertLoginIsSuccessful, getAccessToken, getAccountsWithAccountDetailsCreditInfo, getAllCommonMovements, isExpiredLogin, login, register} from "./api";
-import {convertApiMovementsToReadableTransactions, toZenmoneyAccount} from "./converters";
+import {convertApiAccountsToAccountTuples, convertApiMovementsToReadableTransactions} from "./converters";
 import {normalizePreferences} from "./preferences";
 
 export async function scrape({preferences, fromDate, toDate}) {
@@ -59,10 +59,11 @@ export async function scrape({preferences, fromDate, toDate}) {
         getAccountsWithAccountDetailsCreditInfo({sessionId, deviceId: pluginData.deviceId}),
         getAllCommonMovements({sessionId, deviceId: pluginData.deviceId, startDate: fromDate, endDate: toDate}),
     ]);
-    const readableTransactions = convertApiMovementsToReadableTransactions(apiMovements.reverse(), apiAccounts);
+    const accountTuples = convertApiAccountsToAccountTuples(apiAccounts);
+    const readableTransactions = convertApiMovementsToReadableTransactions(apiMovements.reverse(), accountTuples);
     console.debug({readableTransactions});
     return {
-        accounts: apiAccounts.map(toZenmoneyAccount),
+        accounts: accountTuples.map((x) => x.zenMoneyAccount),
         transactions: readableTransactions.map(toZenmoneyTransaction),
     };
 }

--- a/src/plugins/alfabank/preferences.js
+++ b/src/plugins/alfabank/preferences.js
@@ -6,7 +6,7 @@ export function normalizeCardExpirationDate(cardExpirationDate) {
     const match = cardExpirationDate.match(cardExpirationDateRegExp);
     if (!match) {
         // FIXME must use InvalidPreferencesError here, but InvalidPreferencesError android handler is buggy
-        throw new TemporaryError(`cardExpirationDate ${cardExpirationDate} is invalid: use MM/YY format, e.g. 01/21`);
+        throw new TemporaryError(`cardExpirationDate ${cardExpirationDate} is invalid: use MMYY format, e.g. 0121`);
     }
     const [, mm, yy] = match;
     return `${mm}/${yy}`;

--- a/src/plugins/alfabank/preferences.test.js
+++ b/src/plugins/alfabank/preferences.test.js
@@ -3,10 +3,10 @@ import {normalizeCardExpirationDate, normalizePhoneNumber} from "./preferences";
 test("normalizeCardExpirationDate", () => {
     expect(normalizeCardExpirationDate("01/21")).toEqual("01/21");
     expect(normalizeCardExpirationDate("0121")).toEqual("01/21");
-    expect(() => normalizeCardExpirationDate("")).toThrow("use MM/YY format");
-    expect(() => normalizeCardExpirationDate("12")).toThrow("use MM/YY format");
-    expect(() => normalizeCardExpirationDate("121")).toThrow("use MM/YY format");
-    expect(() => normalizeCardExpirationDate("12121")).toThrow("use MM/YY format");
+    expect(() => normalizeCardExpirationDate("")).toThrow("use MMYY format");
+    expect(() => normalizeCardExpirationDate("12")).toThrow("use MMYY format");
+    expect(() => normalizeCardExpirationDate("121")).toThrow("use MMYY format");
+    expect(() => normalizeCardExpirationDate("12121")).toThrow("use MMYY format");
 });
 
 test("normalizePhoneNumber", () => {

--- a/src/plugins/alfabank/preferences.xml
+++ b/src/plugins/alfabank/preferences.xml
@@ -17,10 +17,10 @@
         inputType="phone"
         title="Срок действия карты"
         dialogTitle="Срок действия карты"
-        dialogMessage="Пример: 01/21"
+        dialogMessage="Формат: ММГГ, пример: 0121"
         positiveButtonText="ОК"
         negativeButtonText="Отмена"
-        summary="|Пример: 01/21|{@s}"
+        summary="|Формат: ММГГ, пример: 0121|{@s}"
     />
     <EditTextPreference
         key="phoneNumber"


### PR DESCRIPTION
- [x] increase account.id uniqueness
- [x] make transfers grouping stricter (no deposits/cashins with same references now)
- [x] ignore movements without sender/recipient info
- [x] ignore movements without matching apiAccount
- [x] handle new known credit types
- [x] figure out correct syncID sanitize algorithm (lastN mod 4 / asterisking or smth else)