### PR TITLE
[alfabank] ignore non-transfer operation transaction type

### DIFF
--- a/src/plugins/alfabank/converters.js
+++ b/src/plugins/alfabank/converters.js
@@ -191,6 +191,7 @@ const neverLosingDataMergeCustomizer = function(valueInA, valueInB, key, objA, o
 export const isPossiblyTransfer = ({reference}) => {
     return reference !== "HOLD"
         && reference !== ""
+        && !reference.startsWith("OP1ED")
         && !reference.startsWith("CASHIN")
         // U\d{2}A, AQ\d prefixes are common for all deposits creation/destroy/percentages
         && !reference.startsWith("U")


### PR DESCRIPTION
fixes `Assertion failed: one side must be sender (outcome)` reported by 546606