### PR TITLE
[Tinkoff bank] Функционал игнорирования карт при импорте

### DIFF
--- a/src/plugins/tinkoff/index.js
+++ b/src/plugins/tinkoff/index.js
@@ -35,8 +35,10 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground })
       if (!inAccounts(tAccount, accounts)) return
     }
 
-    // учитываем только успешные операции
-    if ((t.status && t.status === 'FAILED') || t.accountAmount.value === 0) { return }
+    const cardId = t.cardNumber.substr(t.cardNumber.length - 4)
+
+    // учитываем только успешные операции с карт, которые не были добавлены в игнор
+    if (preferences.ignoreCards.indexOf(cardId) !== -1 || (t.status && t.status === 'FAILED') || t.accountAmount.value === 0) { return }
 
     const tran = convertTransaction(t, tAccount)
 

--- a/src/plugins/tinkoff/preferences.xml
+++ b/src/plugins/tinkoff/preferences.xml
@@ -32,4 +32,14 @@
 		summary="|гггг-мм-дд|{@s}"
 		obligatory="true">
 	</EditTextPreference>
+	<EditTextPreference
+		key="ignoreCards"
+		title="Список карт, с которых не нужно добавлять операции"
+		dialogTitle="Список карт"
+		dialogMessage="Последние 4 цифры номеров карт, с которых не нужно добавлять операции (через запятую)"
+		summary="|Номера карт|{@s}"
+		positiveButtonText="ОК"
+		negativeButtonText="Отмена"
+		obligatory="false">
+	</EditTextPreference>
 </PreferenceScreen>


### PR DESCRIPTION
Пользуюсь Тинькофф банком, недавно выпустил к своему счету вторую карту (счет один, карты две) и столкнулся с проблемой, что операции импортируются с обеих карт, что мне не нужно, в итоге приходится постоянно удалять эти операции - это очень не удобно и приводит к ошибкам.

Придумал вот такое решение, очень надеюсь, что вы примите эти изменения, спасибо за внимание.