### PR TITLE
[Tinkoff bank] Функционал добавления номера карты в комментарий операции

### DIFF
--- a/src/plugins/tinkoff/converters.js
+++ b/src/plugins/tinkoff/converters.js
@@ -210,7 +210,7 @@ export function convertTransaction (transaction, accountId) {
 
     } else {
       if (tran.comment) tran.comment += ` (${payee})`
-      else tran.commen = tran.payee
+      else tran.comment = tran.payee
     }
   }
 

--- a/src/plugins/tinkoff/index.js
+++ b/src/plugins/tinkoff/index.js
@@ -38,8 +38,14 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground })
     // учитываем только успешные операции
     if ((t.status && t.status === 'FAILED') || t.accountAmount.value === 0) { return }
 
+    const cardId = t.cardNumber.substr(t.cardNumber.length - 4)
     const tran = convertTransaction(t, tAccount)
 
+    // При необходимости добавляем номер карты в комментарий к операции
+    if (preferences.cardIdInComment) {
+      if (tran.comment) tran.comment = '*' + cardId + ' ' + tran.comment
+      else tran.comment = '*' + cardId
+    }
     // Внутренний ID операции
     const tranId = t.payment && t.payment.paymentId
     // если есть paymentId, объединяем по нему, отделяя комиссии от переводов

--- a/src/plugins/tinkoff/preferences.xml
+++ b/src/plugins/tinkoff/preferences.xml
@@ -32,4 +32,9 @@
 		summary="|гггг-мм-дд|{@s}"
 		obligatory="true">
 	</EditTextPreference>
+	<CheckBoxPreference
+		key="cardIdInComment"
+		title="Добавлять в комментарий к операции номер карты"
+		obligatory="false">
+	</CheckBoxPreference>
 </PreferenceScreen>


### PR DESCRIPTION
По мотивам проблемы, описанной в https://github.com/zenmoney/ZenPlugins/pull/270

Считаю, что такой функционал очень поможет в моем или похожем случае, и никому точно не помешает, ведь будет возможность фильтровать операции в разрезе карт.

Плюс поправил опечатку.

Пусть это и решает задачу, "которая вряд ли будет нужна большинству пользователей", но разве это означает, что стоит забыть о той, небольшой части пользователей (с подпиской кстати)?
И в отличии от моего первого варианта, логика импорта нарушена не будет, будет просто больше информации, которую включать никто не заставляет.