### PR TITLE
[Priorbank] Fix/priorbank sync error

### DIFF
--- a/src/plugins/priorbank/__snapshots__/index.test.js.snap
+++ b/src/plugins/priorbank/__snapshots__/index.test.js.snap
@@ -31,6 +31,8 @@ Object {
       "date": 2016-12-31T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "BLR",
@@ -55,6 +57,8 @@ Object {
       "date": 2016-12-31T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": null,
@@ -76,6 +80,8 @@ Object {
       "date": 2017-01-02T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": null,
@@ -97,6 +103,8 @@ Object {
       "date": 2017-01-02T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": null,
@@ -118,6 +126,8 @@ Object {
       "date": 2017-01-05T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "NLD",
@@ -140,6 +150,8 @@ Object {
       "date": 2017-01-07T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "BLR",
@@ -176,6 +188,8 @@ Object {
       "date": 2017-01-07T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "BLR",
@@ -209,6 +223,8 @@ Object {
       "date": 2017-01-08T21:00:00.000Z,
       "hold": true,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "BLR",
@@ -231,6 +247,8 @@ Object {
       "date": 2017-01-09T21:00:00.000Z,
       "hold": true,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "BLR",
@@ -256,6 +274,8 @@ Object {
       "date": 2017-01-09T21:00:00.000Z,
       "hold": false,
       "merchant": Object {
+        "city": null,
+        "country": null,
         "location": null,
         "mcc": null,
         "title": "BLR",

--- a/src/plugins/priorbank/converters.js
+++ b/src/plugins/priorbank/converters.js
@@ -90,7 +90,9 @@ export const convertApiAbortedTransactionToReadableTransaction = ({ accountId, a
     merchant: {
       title: details.payee,
       mcc: null,
-      location: null
+      location: null,
+      city: null,
+      country: null
     },
     comment: joinCommentLines([
       details.comment,
@@ -130,7 +132,9 @@ const convertApiTransactionToReadableTransaction = (apiTransaction) => {
       merchant: {
         title: details.payee,
         mcc: null,
-        location: null
+        location: null,
+        city: null,
+        country: null
       },
       comment: joinCommentLines([
         details.comment,


### PR DESCRIPTION
Ошибка при попытке синхронизации:
Scrape error:
[RUE] Assertion failed: merchant.city must be defined String: { movements: 
   [ { id: null,
       account: { id: '67693231' },
       invoice: null,
       sum: -2,
       fee: 0 },
     [length]: 1 ],
  date: Fri Apr 05 2019 00:00:00 GMT+0300 (Moscow Standard Time),
  hold: false,
  merchant: 
   { title: 'BLR Minsk PTS 777 AVTOMOBILNYY PARK',
     mcc: null,
     location: null },
  comment: null }
(The message above will never be displayed on production UI; use TemporaryError or InvalidPreferencesError if you want to show meaningful message to user)
    at console.assert (webpack:///./src/consoleAdapter.js?:27:13)
    at toZenmoneyTransaction (webpack:///./src/common/converters.js?:183:15)
    at eval (webpack:///./src/common/adapters.js?:136:173)
    at Array.map (<anonymous>)
    at patchTransactions (webpack:///./src/common/adapters.js?:136:51)
    at eval (webpack:///./src/common/adapters.js?:183:33)