### PR TITLE
[bgpb] make account.id stable; implement isAccountSkipped filtering

### DIFF
--- a/src/plugins/bgpb/__tests__/converters/accounts.test.js
+++ b/src/plugins/bgpb/__tests__/converters/accounts.test.js
@@ -1,6 +1,9 @@
 import { convertAccount } from '../../converters'
 
 describe('convertAccount', () => {
+  beforeEach(() => {
+    global.ZenMoney = { isAccountSkipped: () => false }
+  })
   const bankCard = {
     'Id': '11161311-117d11',
     'No': '529911******1111',
@@ -15,7 +18,6 @@ describe('convertAccount', () => {
     'ExtraData': 'cb727d83-2d8a-4c54-898f-6d45f0eba713'
   }
   it('maps bank card to zenmoney one', () => {
-    global.ZenMoney = { isAccountSkipped: () => false }
     expect(convertAccount(bankCard)).toEqual({
       id: '11161311',
       transactionsAccId: null,

--- a/src/plugins/bgpb/__tests__/converters/accounts.test.js
+++ b/src/plugins/bgpb/__tests__/converters/accounts.test.js
@@ -1,58 +1,54 @@
 import { convertAccount } from '../../converters'
 
 describe('convertAccount', () => {
-  var tt = [
-    {
-      name: 'bank card',
-      rawData: {
-        'Id': '11161311-117d11',
-        'No': '529911******1111',
-        'ProductType': 'MS',
-        'ProductTypeName': 'Карточка',
-        'Subclass': 'Расчетная карточка &quot;Премиальная&quot; MasterCard World',
-        'Expired': '20230630',
-        'Currency': '840',
-        'CustomName': 'Расчетная карточка',
-        'Icon': 'NFC_MC_BDW',
-        'BankId': 'cb727d83-2d8a-4c54-898f-6d45f0eba713',
-        'ExtraData': 'cb727d83-2d8a-4c54-898f-6d45f0eba713'
-      },
-      expected: {
-        id: '11161311-117d11',
-        transactionsAccId: null,
-        type: 'card',
-        title: 'Расчетная карточка*1111',
-        currencyCode: '840',
-        cardNumber: '529911******1111',
-        instrument: 'USD',
-        balance: 0,
-        syncID: ['1111'],
-        productType: 'MS'
-      }
-    },
-    {
-      name: 'another bank',
-      rawData: {
-        'Id': '11161311-117d12',
-        'No': '529911******1112',
-        'ProductType': 'NON_ONUS',
-        'ProductTypeName': 'Карточка Другого банка',
-        'Subclass': 'Расчетная карточка &quot;Премиальная&quot; MasterCard World',
-        'Expired': '20230630',
-        'Currency': '840',
-        'CustomName': 'Расчетная карточка',
-        'Icon': 'NON_ONUS_VISA',
-        'BankId': 'cb727d83-2d8a-4c54-898f-6d45f0eba713',
-        'ExtraData': 'cb727d83-2d8a-4c54-898f-6d45f0eba713'
-      },
-      expected: null
-    }
-  ]
-  tt.forEach(function (tc) {
-    it(tc.name, () => {
-      const account = convertAccount(tc.rawData)
-
-      expect(account).toEqual(tc.expected)
+  const bankCard = {
+    'Id': '11161311-117d11',
+    'No': '529911******1111',
+    'ProductType': 'MS',
+    'ProductTypeName': 'Карточка',
+    'Subclass': 'Расчетная карточка &quot;Премиальная&quot; MasterCard World',
+    'Expired': '20230630',
+    'Currency': '840',
+    'CustomName': 'Расчетная карточка',
+    'Icon': 'NFC_MC_BDW',
+    'BankId': 'cb727d83-2d8a-4c54-898f-6d45f0eba713',
+    'ExtraData': 'cb727d83-2d8a-4c54-898f-6d45f0eba713'
+  }
+  it('maps bank card to zenmoney one', () => {
+    global.ZenMoney = { isAccountSkipped: () => false }
+    expect(convertAccount(bankCard)).toEqual({
+      id: '11161311',
+      transactionsAccId: null,
+      type: 'card',
+      title: 'Расчетная карточка*1111',
+      currencyCode: '840',
+      cardNumber: '529911******1111',
+      instrument: 'USD',
+      balance: 0,
+      syncID: ['1111'],
+      productId: '11161311-117d11',
+      productType: 'MS'
     })
+  })
+
+  it('maps skipped card to nothing', () => {
+    global.ZenMoney = { isAccountSkipped: (accountId) => accountId === '11161311' }
+    expect(convertAccount(bankCard)).toBeNull()
+  })
+
+  it('maps another bank card to nothing', () => {
+    expect(convertAccount({
+      'Id': '11161311-117d12',
+      'No': '529911******1112',
+      'ProductType': 'NON_ONUS',
+      'ProductTypeName': 'Карточка Другого банка',
+      'Subclass': 'Расчетная карточка &quot;Премиальная&quot; MasterCard World',
+      'Expired': '20230630',
+      'Currency': '840',
+      'CustomName': 'Расчетная карточка',
+      'Icon': 'NON_ONUS_VISA',
+      'BankId': 'cb727d83-2d8a-4c54-898f-6d45f0eba713',
+      'ExtraData': 'cb727d83-2d8a-4c54-898f-6d45f0eba713'
+    })).toBeNull()
   })
 })

--- a/src/plugins/bgpb/api.js
+++ b/src/plugins/bgpb/api.js
@@ -221,7 +221,7 @@ export async function fetchTransactionsAccId (sid, account) {
 
   let res = await fetchApi('sou/xml_online.admin',
     '<BS_Request>\r\n' +
-    '   <GetActions ProductId="' + account.id + '"/>\r\n' +
+    '   <GetActions ProductId="' + account.productId + '"/>\r\n' +
     '   <RequestType>GetActions</RequestType>\r\n' +
     '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
     '   <TerminalId>41742991</TerminalId>\r\n' +
@@ -312,7 +312,7 @@ export async function fetchFullTransactions (sid, accounts, fromDate, toDate = n
   return transactions
 }
 
-export async function fetchLastTransactions (sid, accounts) {
+export async function fetchLastTransactions (sid) {
   console.log('>>> Загрузка списка последних транзакций...')
   const transactions = (await fetchApiJson('push-history/api/andorid_5.17.1/v1/getHistory', {
     method: 'POST',

--- a/src/plugins/bgpb/index.js
+++ b/src/plugins/bgpb/index.js
@@ -22,7 +22,7 @@ export async function scrape ({ preferences, fromDate, toDate }) {
 
   const transactionsStatement = (await bank.fetchFullTransactions(token, accounts, fromDate, toDate))
     .map(transaction => converters.convertTransaction(transaction, accounts))
-  const transactionsLast = (await bank.fetchLastTransactions(token, accounts))
+  const transactionsLast = (await bank.fetchLastTransactions(token))
     .map(transaction => converters.convertLastTransaction(transaction, accounts))
     .filter(function (op) {
       if (op === null) {


### PR DESCRIPTION
ProductId каждую новую сессию меняет свою правую часть, отделенную дефисом, в то время как реализация функциональности skip account рассчитывает на постоянство этого id.
Как результат, до фикса аккаунты не скипались и дублировались в списке:
<img width="386" alt="Screenshot 2019-05-13 at 22 09 31" src="https://user-images.githubusercontent.com/2434839/57647568-f3c38a00-75cb-11e9-9bee-1f08d747e2ce.png">

+ уменьшается количество запросов (теперь не делаем таковые для скипнутых аккаунтов)