### PR TITLE
[bgpb] handle invalid 0 mcc, sync asserts with native app

### DIFF
--- a/src/common/converters.js
+++ b/src/common/converters.js
@@ -197,7 +197,7 @@ export function toZenmoneyTransaction (readableTransaction, accountsByIdLookup) 
       result.payee = fullTitle
     }
 
-    console.assert(mcc === null || _.isNumber(mcc), 'merchant.mcc must be defined Number:', readableTransaction)
+    console.assert(mcc === null || (_.isNumber(mcc) && mcc > 0), 'merchant.mcc must be null or integer number > 0', readableTransaction)
     result.mcc = mcc
 
     console.assert(location === null || _.isPlainObject(location),

--- a/src/plugins/bgpb/converters.js
+++ b/src/plugins/bgpb/converters.js
@@ -131,9 +131,9 @@ function parsePayee (transaction, apiTransaction) {
   if (!apiTransaction.place && !apiTransaction.payeeLastTransaction) {
     return false
   }
-
+  const mcc = Number(apiTransaction.mcc)
   transaction.merchant = {
-    mcc: isFinite(apiTransaction.mcc) ? Number(apiTransaction.mcc) : null,
+    mcc: isNaN(mcc) || mcc === 0 ? null : mcc,
     location: null
   }
   if (apiTransaction.payeeLastTransaction) {


### PR DESCRIPTION
`[ZP] Exception: __ [TMC] Invalid transaction 2019-05-06 1:25:00 pm +0000. merchant.mcc must be null or integer number > 0`

assert на mcc со стороны iOS app строже чем используемые в разработке