### PR TITLE
[bnbank] Fix last transaction fetching

### DIFF
--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -148,12 +148,12 @@ export async function fetchLastCardTransactions (token, account) {
     }
   }, response => response.body)
   var operations = []
-  if (response.PS_ERIP.GetExtractCardResponse.BPC.OperationList.length > 1) {
+  if (response.PS_ERIP.GetExtractCardResponse.BPC.OperationList.oper_count > 1) {
     operations = flatMap(response.PS_ERIP.GetExtractCardResponse.BPC.OperationList.oper, d => {
       d.accountNumber = account.id
       return d
     })
-  } else if (response.PS_ERIP.GetExtractCardResponse.BPC.OperationList.length === 1) {
+  } else if (response.PS_ERIP.GetExtractCardResponse.BPC.OperationList.oper_count === 1) {
     let oper = response.PS_ERIP.GetExtractCardResponse.BPC.OperationList.oper
     oper.accountNumber = account.id
     operations.push(oper)

--- a/src/plugins/bnbank/index.js
+++ b/src/plugins/bnbank/index.js
@@ -11,11 +11,14 @@ export async function scrape ({ preferences, fromDate, toDate }) {
   for (let i = 0; i < cards.length; i++) {
     lastTransactions = lastTransactions.concat(await bank.fetchLastCardTransactions(token, cards[i]))
   }
-  const deposits = accounts.deposits
-    .map(converters.convertDeposit)
-    .filter(account => account !== null)
+  var preparedAccounts = cards
+  if (accounts.deposits) {
+    const deposits = accounts.deposits
+      .map(converters.convertDeposit)
+      .filter(account => account !== null)
+    preparedAccounts = cards.concat(deposits)
+  }
 
-  const preparedAccounts = cards.concat(deposits)
   const transactions = (await bank.fetchTransactions(token, preparedAccounts, fromDate, toDate))
     .map(transaction => converters.convertTransaction(transaction, preparedAccounts))
   lastTransactions = lastTransactions


### PR DESCRIPTION
- Исправлена загрузка последних операций по карточкам
- Исправлена ситуация, когда работали только те аккаунты, где были депозиты. Вообще я удивлен что никто ни разу не пожаловался что синхронизация для "обычных" аккаунтов вообще не работала столько месяцев