### PR TITLE
[kapitalbank-uz] Bugfixes, refactor and improvements

### DIFF
--- a/src/plugins/kapitalbank-uz/api.js
+++ b/src/plugins/kapitalbank-uz/api.js
@@ -146,7 +146,7 @@ export async function getUzcardCards () {
 
   console.assert(response.ok, 'unexpected uzcard response', response)
 
-  return response.body.data.map(convertCard)
+  return response.body.data.map(convertCard).filter(card => card !== null)
 }
 
 /**
@@ -169,7 +169,7 @@ export async function getHumoCards () {
 
   console.assert(response.ok, 'unexpected humo response', response)
 
-  return response.body.data.map(convertCard)
+  return response.body.data.map(convertCard).filter(card => card !== null)
 }
 
 /**
@@ -192,7 +192,7 @@ export async function getVisaCards () {
 
   console.assert(response.ok, 'unexpected visa response', response)
 
-  return response.body.data.map(convertCard)
+  return response.body.data.map(convertCard).filter(card => card !== null)
 }
 
 /**
@@ -348,7 +348,7 @@ export async function getVisaCardsTransactions (cards, fromDate, toDate) {
       console.assert(response.ok, 'unexpected visa/history response', response)
 
       transactions = transactions.concat(response.body.data.map(transaction =>
-        convertVisaCardTransaction(card.id, transaction)))
+        convertVisaCardTransaction(card.id, transaction)).filter(transaction => transaction !== null))
     }
   }
 

--- a/src/plugins/kapitalbank-uz/converters.js
+++ b/src/plugins/kapitalbank-uz/converters.js
@@ -39,20 +39,26 @@ export function convertWallet (wallet) {
 /**
  * Конвертер карты из формата банка в формат Дзенмани
  *
- * @param card карта в формате банка
+ * @param rawCard карта в формате банка
  * @returns карта в формате Дзенмани
  */
-export function convertCard (card) {
-  return {
-    id: String(card.id),
-    title: card.title,
-    syncID: [String(card.id), card.account, card.pan.slice(-4)],
+export function convertCard (rawCard) {
+  const card = {
+    id: String(rawCard.id),
+    title: rawCard.title,
+    syncID: [String(rawCard.id), rawCard.pan.slice(-4)],
 
-    instrument: card.currency.name,
+    instrument: rawCard.currency.name,
     type: 'ccard',
 
-    balance: card.balance / 100
+    balance: rawCard.balance / 100
   }
+
+  if (rawCard.account) {
+    card.syncID.push(rawCard.account)
+  }
+
+  return card
 }
 
 /**

--- a/src/plugins/kapitalbank-uz/converters.js
+++ b/src/plugins/kapitalbank-uz/converters.js
@@ -134,6 +134,10 @@ export function convertHumoCardTransaction (cardId, rawTransaction) {
 export function convertVisaCardTransaction (cardId, rawTransaction) {
   const amount = Number(rawTransaction.amount)
 
+  if (amount === 0) {
+    return null
+  }
+
   const transaction = {
     payee: rawTransaction.merchantName,
     date: rawTransaction.transDate

--- a/src/plugins/kapitalbank-uz/converters.js
+++ b/src/plugins/kapitalbank-uz/converters.js
@@ -92,7 +92,7 @@ export function convertUzcardCardTransaction (cardId, rawTransaction) {
  * @returns транзакция в формате Дзенмани
  */
 export function convertHumoCardTransaction (cardId, rawTransaction) {
-  const amount = Number(rawTransaction.amount.replace(' ', '').replace(',', '.'))
+  const amount = Number(rawTransaction.amount.replaceAll(' ', '').replace(',', '.'))
 
   const transaction = {
     payee: rawTransaction.merchantName,

--- a/src/plugins/kapitalbank-uz/converters.js
+++ b/src/plugins/kapitalbank-uz/converters.js
@@ -43,6 +43,10 @@ export function convertWallet (wallet) {
  * @returns карта в формате Дзенмани
  */
 export function convertCard (rawCard) {
+  if (rawCard.state !== 'ACTIVE') {
+    return null
+  }
+
   const card = {
     id: String(rawCard.id),
     title: rawCard.title,


### PR DESCRIPTION
Исправил:
- Ошибку корректировки в нулевой баланс во время downtime'ов на стороне процессингового центра. Такие карты будут пропускаться.
- Ошибку при загрузке карт, выпущенных другим банком, но добавленных в интернет-банкинг. У них отсутствует информация о номере картсчета, поэтому один из `syncID` сохранялся как `java.lang.Object@c54bbae`. Теперь проверяется наличие номера картсчета и сохраняется в `syncID` если имеется.
- Ошибку при загрузке истории карт, где сумма транзакции имеет два и более пробела-разделителя. Например, `1 000 000`. Теперь удаляются все пробелы-разделители.
- Ошибку при загрузке истории карт VISA, при снятии определенной суммы и моментальном возврате таким образом, что сумма транзакции из банка возвращается `0.00`. Такие транзакции будут пропускаться.

\+ немного рефакторинга.