### PR TITLE
[ineco] set charset and check some debug info

### DIFF
--- a/src/plugins/ineco/converters.js
+++ b/src/plugins/ineco/converters.js
@@ -134,7 +134,9 @@ export const parseTransactions = (ah, account, csv) => {
     trans.push(tr)
   }
 
-  console.log(`scraped ${trans.length} transactions for account ${account.id}`)
+  console.log(`scraped ${trans.length} transactions for account ${account.id}`, {
+    csv: csv.substr(0, 100)
+  })
 
   return trans
 }

--- a/src/plugins/ineco/session.js
+++ b/src/plugins/ineco/session.js
@@ -35,7 +35,8 @@ export class Session {
       redirect: 'manual',
       stringify: stringify,
       headers: this._prepareHeaders({
-        'Content-Type': 'application/x-www-form-urlencoded'
+        'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+        'Accept-Charset': 'utf-8;'
       }),
       body: data
     })


### PR DESCRIPTION
локально все работает корректно, но на мобильном - нет
по логам видно что все запросы проходят и возвращают данные, но, судя по логам, на мобильном данные приходят юникодными символами (/u0000) из-за чего парсер не работает
добавил кодировку в заголовки и дополнительно залогировал часть ответа, чтоб было понятно если проблема сохранится