### PR TITLE
[ineco] clean unexpected empty unicode character on mobile devices

### DIFF
--- a/src/plugins/ineco/session.js
+++ b/src/plugins/ineco/session.js
@@ -26,7 +26,7 @@ export class Session {
 
     this._storeCookies(response)
 
-    return this._returnResponseBody(response, options)
+    return this._returnResponseBody(response)
   }
 
   async postForm (url, data = {}) {
@@ -97,6 +97,15 @@ export class Session {
       return this.get(response.headers.location.replace(this._domain, ''))
     }
 
-    return response.body
+    let body = response.body
+
+    if (response.headers['content-disposition'] && response.headers['content-disposition'].substr(0, 11) === 'attachment;') {
+      /* for some reasons on mobile devices posting form for a file gives unexpected '\u0000'
+       * after every body char in response. deleting them
+       */
+      body = body.replace(/\\u0000/g, '')
+    }
+
+    return body
   }
 }


### PR DESCRIPTION
локально все работает корректно, но на мобильном - нет
по логам видно что все запросы проходят и возвращают данные, но, судя по логам, на мобильном данные приходят юникодными строками (\u0000) из-за чего парсер не работает
пробую убрать данную последовательность из ответа