### PR TITLE
[kapitalbank-uz] Get Visa transactions bugfix

### DIFF
--- a/src/plugins/kapitalbank-uz/converters.js
+++ b/src/plugins/kapitalbank-uz/converters.js
@@ -195,7 +195,7 @@ export function convertVisaCardTransaction (card, rawTransaction) {
         account: { id: card.id },
         invoice: invoice.instrument === card.instrument ? null : invoice,
         sum: invoice.instrument === card.instrument ? invoice.sum + fee : null,
-        fee: fee
+        fee: 0
       }
     ],
     comment: null

--- a/src/plugins/kapitalbank-uz/converters.js
+++ b/src/plugins/kapitalbank-uz/converters.js
@@ -173,7 +173,7 @@ export function convertVisaCardTransaction (card, rawTransaction) {
   }
 
   const invoice = {
-    sum: amount,
+    sum: amount + fee,
     instrument: rawTransaction.currency.name
   }
 
@@ -194,7 +194,7 @@ export function convertVisaCardTransaction (card, rawTransaction) {
         id: null,
         account: { id: card.id },
         invoice: invoice.instrument === card.instrument ? null : invoice,
-        sum: invoice.instrument === card.instrument ? invoice.sum : null,
+        sum: invoice.instrument === card.instrument ? invoice.sum + fee : null,
         fee: fee
       }
     ],


### PR DESCRIPTION
При получении операций, где сумма комиссии превышает сумму расхода, вылетает exception. Решили с @skvav, что самым простым решением будет включение комиссии в сумму расхода.