### PR TITLE
[bnbank] fix transaction currency and amount

### DIFF
--- a/src/plugins/bnbank/__tests__/converters/transactions/transaction.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/transaction.test.js
@@ -6,7 +6,7 @@ describe('convertTransaction', () => {
     id: '2007549330000000',
     type: card,
     title: 'Личные, BYN - "Maxima Plus"',
-    currencyCode: 933,
+    currencyCode: '933',
     instrument: codeToCurrencyLookup[933],
     balance: 99.9,
     syncID: ['2007549330000000'],
@@ -218,6 +218,42 @@ describe('convertTransaction', () => {
         ],
         merchant: null,
         comment: null
+      }
+    },
+    {
+      name: 'operation in USD',
+      transaction: {
+        accountNumber: '2007549330000000',
+        accountType: '1',
+        cardPAN: '1*** **** **** 1234',
+        merchantId: '1234',
+        operationAmount: 3.49,
+        operationCurrency: '840',
+        operationDate: 1635058305000,
+        operationPlace: 'APPLE.COM/BILL',
+        operationSign: '-1',
+        transactionAmount: 8.64,
+        transactionAuthCode: '342346',
+        transactionCurrency: '933'
+      },
+      expectedTransaction: {
+        hold: false,
+        date: new Date(1635058305000),
+        movements: [
+          {
+            id: null,
+            account: { id: '2007549330000000' },
+            sum: -8.64,
+            fee: 0,
+            invoice: null
+          }
+        ],
+        merchant: {
+          fullTitle: 'APPLE.COM/BILL',
+          location: null,
+          mcc: null,
+        },
+        comment: '3.49 USD'
       }
     }
   ]

--- a/src/plugins/bnbank/__tests__/converters/transactions/transfer.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/transfer.test.js
@@ -6,7 +6,7 @@ describe('convertTransaction', () => {
     id: '2007549330000000',
     type: card,
     title: 'Личные, BYN - "Maxima Plus"',
-    currencyCode: 933,
+    currencyCode: '933',
     instrument: codeToCurrencyLookup[933],
     balance: 99.9,
     syncID: ['2007549330000000'],

--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -75,7 +75,7 @@ describe('scrape', () => {
           fee: 0,
           id: null,
           invoice: null,
-          sum: -1.4
+          sum: -0.64
         }]
       },
       {
@@ -120,7 +120,7 @@ describe('scrape', () => {
           fee: 0,
           id: null,
           invoice: null,
-          sum: -437
+          sum: -200
         }]
       },
       {
@@ -287,7 +287,7 @@ function mockCardAccountStatement () {
           operationName: 'Зачисление дохода от предпринимательской деятельности',
           transactionDate: 1547019480000,
           operationDate: 1547019480000,
-          transactionAmount: 0.0,
+          transactionAmount: 3000.0,
           transactionCurrency: '933',
           operationAmount: 3000.0,
           operationCurrency: '933',

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -97,6 +97,14 @@ export function convertTransaction (json, accounts) {
     parsePayee
   ].some(parser => parser(transaction, json))
 
+  // добавляем к коментарию сумму и валюту операции (для случая когда валюта операции отличается)
+  if (json.operationCurrency !== account.currencyCode) {
+    transaction.comment = [
+      `${json.operationAmount} ${codeToCurrencyLookup[json.operationCurrency]}`,
+      transaction.comment
+    ].join(' ').trim()
+  }
+
   return transaction
 }
 
@@ -135,7 +143,7 @@ function getMovement (json, account) {
     id: null,
     account: { id: account.id },
     invoice: null,
-    sum: (json.operationCode && json.operationCode === 3) || (json.operationSign === '-1') ? -json.operationAmount : json.operationAmount,
+    sum: (json.operationCode && json.operationCode === 3) || (json.operationSign === '-1') ? -json.transactionAmount : json.transactionAmount,
     fee: 0
   }
   if (json.operationName && json.operationName.indexOf('Удержано подоходного налога') >= 0) {


### PR DESCRIPTION
It's the wrong amount in a case when the currency of payment differs from the account currency.

Before fix:
transaction api response:
<img width="410" alt="Screenshot 2021-10-24 at 17 09 40" src="https://user-images.githubusercontent.com/1436683/138677412-d5b5262b-7bd8-40ba-a7c4-6e129bb93028.png">
transaction info in list:
<img width="263" alt="Screenshot 2021-10-24 at 17 11 58" src="https://user-images.githubusercontent.com/1436683/138677567-e4ab9b35-b1fd-4e82-90ce-66885fb774e7.png">

After fix:
<img width="265" alt="Screenshot 2021-10-24 at 17 12 53" src="https://user-images.githubusercontent.com/1436683/138677626-8b5d60de-a97b-4c0b-be22-010b7648b791.png">

Also was added a useful comment with the initial payment amount and currency


