### PR TITLE
[belswissbank] revert: now sum=figureOutAccountRestsDelta (gives less corrections)

### DIFF
--- a/src/plugins/belswissbank/__tests__/BSB.test.js
+++ b/src/plugins/belswissbank/__tests__/BSB.test.js
@@ -1,4 +1,4 @@
-import { formatBsbSmsApiDate, formatBsbArchiveApiDate, isRejectedTransaction } from '../BSB'
+import { figureOutAccountRestsDelta, formatBsbSmsApiDate, formatBsbArchiveApiDate, isRejectedTransaction } from '../BSB'
 
 describe('formatBsbCardsApiDate', () => {
   it('should return DD.MM.YYYY string considering bank UTC+3 timezone shift', () => {
@@ -33,5 +33,56 @@ describe('formatBsbPaymentsApiDate', () => {
 describe('isRejectedTransaction', () => {
   it('should trim corrupted transactionType', () => {
     expect(isRejectedTransaction({ transactionType: 'Отказ ' })).toBe(true)
+  })
+})
+
+describe('figureOutAccountRestsDelta', () => {
+  it('should do its best in aggressive environment with null accountRest', () => {
+    const transactions = [
+      { accountRest: 900, transactionCurrency: 'USD', transactionAmount: 100, transactionType: 'Товары и услуги', colour: 2 },
+      { accountRest: null, transactionCurrency: 'USD', transactionAmount: 200, transactionType: 'Товары и услуги', colour: 2 },
+      { accountRest: null, transactionCurrency: 'USD', transactionAmount: 300, transactionType: 'Товары и услуги', colour: 2 },
+      { accountRest: 0, transactionCurrency: 'USD', transactionAmount: 400, transactionType: 'Товары и услуги', colour: 2 },
+      { accountRest: null, transactionCurrency: 'USD', transactionAmount: 1000, transactionType: 'Зачисление', colour: 1 },
+      { accountRest: 750, transactionCurrency: 'EUR', transactionAmount: 200, transactionType: 'Товары и услуги', colour: 2 },
+      { accountRest: null, transactionCurrency: 'EUR', transactionAmount: 300, transactionType: 'Товары и услуги', colour: 2 },
+      { accountRest: 0, transactionCurrency: 'USD', transactionAmount: 400, transactionType: 'Товары и услуги', colour: 2 }
+    ]
+    const accountCurrency = 'USD'
+    expect(figureOutAccountRestsDelta({ index: 0, transactions, accountCurrency })).toBe(null)
+    expect(figureOutAccountRestsDelta({ index: 1, transactions, accountCurrency })).toBe(-200)
+    expect(figureOutAccountRestsDelta({ index: 2, transactions, accountCurrency })).toBe(-300)
+    expect(figureOutAccountRestsDelta({ index: 3, transactions, accountCurrency })).toBe(-400)
+    expect(figureOutAccountRestsDelta({ index: 4, transactions, accountCurrency })).toBe(1000)
+    expect(figureOutAccountRestsDelta({ index: 5, transactions, accountCurrency })).toBe(-250)
+    expect(figureOutAccountRestsDelta({ index: 6, transactions, accountCurrency })).toBe(null)
+    expect(figureOutAccountRestsDelta({ index: 7, transactions, accountCurrency })).toBe(null)
+  })
+
+  it('should check that index is in range', () => {
+    const transactions = [
+      { accountRest: 900, transactionCurrency: 'USD', transactionAmount: 100, transactionType: 'Товары и услуги' }
+    ]
+    const accountCurrency = 'USD'
+    expect(() => figureOutAccountRestsDelta({ index: -1, transactions, accountCurrency })).toThrow()
+    expect(() => figureOutAccountRestsDelta({ index: 1, transactions, accountCurrency })).toThrow()
+  })
+
+  it('should handle ambiguous amounts signs', () => {
+    const transactions = [
+      {
+        transactionType: 'Товары и услуги',
+        transactionAmount: 1,
+        transactionCurrency: 'BYN',
+        accountRest: 11.46
+      },
+      {
+        transactionType: 'Товары и услуги',
+        transactionAmount: 10,
+        transactionCurrency: 'BYN',
+        accountRest: 27.93
+      }
+    ]
+    expect(figureOutAccountRestsDelta({ index: 1, transactions, accountCurrency: 'USD' })).toBeNull()
   })
 })


### PR DESCRIPTION
But fall back to `sum: null` feature instead of dropping transactions having smsTx.accountRest=null. And statement is joined as well, that should eventually give close to zero balance corrections.