### PR TITLE
[bnbank] fix: add license agreement argument

### DIFF
--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -41,12 +41,13 @@ export async function login (login, password) {
   const res = await fetchApiJson('session/login', {
     method: 'POST',
     body: {
-      applicID: '1.53',
+      applicID: '1.53.1',
       clientKind: '0',
       browser: ZenMoney.device.manufacturer, // Build.DEVICE
       browserVersion: `${ZenMoney.device.model} (${ZenMoney.device.manufacturer})`, // Build.MODEL + " (" + Build.PRODUCT + ")"
       platform: 'Android',
       platformVersion: '10',
+      agreement: true,
       deviceUDID: deviceID,
       login,
       password


### PR DESCRIPTION
Hotfix: you can't sync BNB bank since 29.11, because of the next error:
Ответ банка: Чтобы продолжить использовать приложе…, кнопку согласия с Политикой конфиденциальности.

Added parameter, fixed (checked) :)