### PR TITLE
[ininal-tr] Fix time ranges in transaction fetching

### DIFF
--- a/src/plugins/ininal-tr/api.ts
+++ b/src/plugins/ininal-tr/api.ts
@@ -287,11 +287,10 @@ export class IninalApi {
   }
 
   public async fetchAccountTransactions (session: Session, accountNumber: string, fromDate: Date, toDate?: Date): Promise<AccountTransaction[]> {
-    // if toDate is not provided, set it to start of the next day
+    // if toDate is not provided, set it to the end of the current day
     if (!toDate) {
       toDate = new Date()
-      toDate.setDate(toDate.getDate() + 1)
-      toDate.setHours(0, 0, 0, 0)
+      toDate.setHours(23, 59, 59, 999)
     }
 
     const rawResponse = await this.fetchApi(

--- a/src/plugins/ininal-tr/api.ts
+++ b/src/plugins/ininal-tr/api.ts
@@ -340,13 +340,17 @@ export class IninalApi {
     return generateUUID().toUpperCase()
   }
 
+  // ininal API accepts date in Turkey time zone
   private formatDateRangeBoundary (date: Date): string {
-    const year = date.getUTCFullYear()
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0')
-    const day = String(date.getUTCDate()).padStart(2, '0')
-    const hours = String(date.getUTCHours()).padStart(2, '0')
-    const minutes = String(date.getUTCMinutes()).padStart(2, '0')
-    const seconds = String(date.getUTCSeconds()).padStart(2, '0')
+    const timeZone = 'Europe/Istanbul'
+    const locale = 'en-US'
+
+    const year = date.toLocaleString(locale, { timeZone, year: 'numeric' })
+    const month = date.toLocaleString(locale, { timeZone, month: '2-digit' })
+    const day = date.toLocaleString(locale, { timeZone, day: '2-digit' })
+    const hours = date.toLocaleString(locale, { timeZone, hour: '2-digit', hour12: false })
+    const minutes = date.toLocaleString(locale, { timeZone, minute: '2-digit' })
+    const seconds = date.toLocaleString(locale, { timeZone, second: '2-digit' })
     const milliseconds = String(date.getUTCMilliseconds()).padStart(3, '0')
 
     return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}.${milliseconds}`


### PR DESCRIPTION
1) форматировать время в часовом поясе Europe/Istanbul, а не UTC -- API ожидает время именно в Турецком часовом поясе
2) чуть переделал дефолтное значение toDate, чтобы больше соответствовало оригинальному приложению