### PR TITLE
[vakifbank-tr] Fix incorrect fee

### DIFF
--- a/src/plugins/vakifbank-tr/converters.ts
+++ b/src/plugins/vakifbank-tr/converters.ts
@@ -65,7 +65,7 @@ export function convertVakifPdfStatementTransaction (accountId: string, rawTrans
           movements: [
             {
               account: { id: accountId },
-              fee: feeTransaction == null ? 0 : (parseFormattedNumber(feeTransaction.amount) * -1),
+              fee: feeTransaction == null ? 0 : parseFormattedNumber(feeTransaction.amount),
               id: transaction.statementUid,
               sum: parseFormattedNumber(transaction.amount),
               invoice: null


### PR DESCRIPTION
В вакифбанке при переводе создаётся доп. транзакция на комиссию, сумма из которой записывается в дзенмани не отдельной транзакцией, а в поле `fee`. Это значение должно быть положительным.