### PR TITLE
[raiffeisen-business-rs] Add initial support for Raiffeisen Bank Serbia Business

### DIFF
--- a/src/plugins/raiffeisen-business-rs/ZenmoneyManifest.xml
+++ b/src/plugins/raiffeisen-business-rs/ZenmoneyManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>raiffeisen-rs</id>
+    <version>1.0</version>
+    <build>1</build>
+    <company>15810</company>
+    <modular>true</modular>
+    <codeRequired>false</codeRequired>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <description></description>
+</provider>

--- a/src/plugins/raiffeisen-business-rs/__tests__/converters/accounts/account.test.ts
+++ b/src/plugins/raiffeisen-business-rs/__tests__/converters/accounts/account.test.ts
@@ -1,0 +1,94 @@
+import { convertAccounts } from '../../../converters'
+
+describe('convertAccount', () => {
+  it('converts accounts', () => {
+    expect(convertAccounts([
+      {
+        ShortAccountNumber: '265163031000946641',
+        ProductDescriptionAL: null,
+        AccountType: 'Transakcioni depoziti preduzetnika',
+        IsEbankingAccount: null,
+        OrganizationUnit: '163',
+        ItemTypeOfLastChange: null,
+        CurrencyCode: 'RSD',
+        CurrencyCodeNumeric: '941',
+        AccountNumber: '265163031000946641',
+        BlockedAmount: null,
+        AccountCustomName: null,
+        fwStatus: 1,
+        LastChangeDate: null,
+        LastChangedAmount: null,
+        SubsystemProductID: null,
+        fwNamespace: 'SagaBG.SeP.CorporateOutput',
+        Status: null,
+        IBANNumber: null,
+        BankAccountID: 40002001,
+        RetailAccountNumber: null,
+        AccountStatusDescription: 'aktivan',
+        Balance: 23484.52,
+        AccountStatus: '0',
+        OrderTypeName: null,
+        Group: 'Dinarski račun',
+        ID: -1,
+        Blocked: 'N',
+        ProductDescriptionEN: null,
+        ProductCodeCore: '501',
+        AvailableBalance: 6208.95,
+        fwType: 'aoCorporateAccountBalancePreview'
+      },
+      {
+        ShortAccountNumber: '265100000039246639',
+        ProductDescriptionAL: null,
+        AccountType: 'Devizni tekući računi preduzetnika',
+        IsEbankingAccount: null,
+        OrganizationUnit: '163',
+        ItemTypeOfLastChange: null,
+        CurrencyCode: 'USD',
+        CurrencyCodeNumeric: '840',
+        AccountNumber: '265100000039246639',
+        BlockedAmount: null,
+        AccountCustomName: null,
+        fwStatus: 1,
+        LastChangeDate: null,
+        LastChangedAmount: null,
+        SubsystemProductID: null,
+        fwNamespace: 'SagaBG.SeP.CorporateOutput',
+        Status: null,
+        IBANNumber: 'RS35265100000039246639',
+        BankAccountID: 50022000,
+        RetailAccountNumber: null,
+        AccountStatusDescription: 'aktivan',
+        Balance: 10450,
+        AccountStatus: '0',
+        OrderTypeName: null,
+        Group: 'Devizni račun',
+        ID: -1,
+        Blocked: 'N',
+        ProductDescriptionEN: null,
+        ProductCodeCore: '120',
+        AvailableBalance: 10450,
+        fwType: 'aoCorporateAccountBalancePreview'
+      }
+    ])).toEqual([
+      {
+        ProductCodeCore: '501',
+        balance: 6208.95,
+        creditLimit: 0,
+        id: '265163031000946641RSD',
+        instrument: 'RSD',
+        syncIds: ['265163031000946641RSD'],
+        title: '265163031000946641RSD',
+        type: 'checking'
+      },
+      {
+        ProductCodeCore: '120',
+        balance: 10450,
+        creditLimit: 0,
+        id: '265100000039246639USD',
+        instrument: 'USD',
+        syncIds: ['265100000039246639USD'],
+        title: '265100000039246639USD',
+        type: 'checking'
+      }])
+  })
+})

--- a/src/plugins/raiffeisen-business-rs/__tests__/converters/transactions/income.test.ts
+++ b/src/plugins/raiffeisen-business-rs/__tests__/converters/transactions/income.test.ts
@@ -1,0 +1,82 @@
+import { convertTransaction } from '../../../converters'
+
+describe('FX income', () => {
+  it('FX income', () => {
+    expect(convertTransaction({
+      ShortAccountNumber: '265100000039246639',
+      fwType: 'aoCorporateForeignAccountTurnover',
+      ComplaintNumber: '33916800273000002',
+      AccountType: 'Devizni tekući računi preduzetnika',
+      CreditTurnover: 5000,
+      OrganizationUnit: '163',
+      ID: -1,
+      DebtorCreditorName: 'SOME MERCHANT',
+      PaymentCodeDescription: 'Računarske usluge',
+      ProcessedDate: '2024-01-03T00:00:00',
+      CurrentBalance: 10450,
+      NominalInflowAmount: 5000,
+      CurrencyCodeNumeric: '840',
+      CurrencyCode: 'USD',
+      NewBalance: 10450,
+      Trnben: 'SOME MERCHANT',
+      fwStatus: 1,
+      ClientDescription: 'Devizno knjigovodstvo',
+      ToDate: '2024-02-10T00:00:00',
+      CreditAmount: 5000,
+      ContractYear: '-1',
+      fwNamespace: 'SagaBG.SeP.CorporateOutput',
+      FormCode: '60',
+      IBANNumber: 'RS35265100000039246639',
+      ClientAddress: 'KRALJICE KATARINE 12A',
+      DetailType: 'L',
+      ContractNumber: '-1',
+      AmountTotal: 15800,
+      DebitAmount: 0,
+      PreviousBalance: 11000,
+      Reference: '1101129842884',
+      PaymentCode: ' 302',
+      AccountNumber: '265100000039246639',
+      FromDate: '2024-01-01T00:00:00',
+      DebitTurnover: 5550,
+      CompanyIdentityNumber: '4166460428',
+      Description: 'Knjiženje priliva po loro doznaci za pravna lica',
+      BankAccount: '50022000',
+      ClientLocality: '11030 BEOGRAD-ČUKARICA',
+      Note: 'INVOICE XXXXX 24/01/03',
+      ValueDate: '2024-01-03T00:00:00',
+      ChargeBearer: null,
+      DomesticAmount: 535000.5,
+      ReferenceNumber: null,
+      TransactionType: '310111',
+      RequestedValueDate: null,
+      InoBankCommission: null,
+      ProductCodeCore: '120',
+      ItemAmount: '5,000.00',
+      RequestYear: null,
+      RequestNumber: null,
+      ClientName: 'SOME NAME',
+      TransactionDescription: '\r\nNBS: Slog 60\r\nOsnov 302  5,000.00\r\n Računarske usluge\r\nIznos upucen od strane ino partnera 5,000.00',
+      PBO: null
+    })).toEqual({
+      comment: 'Knjiženje priliva po loro doznaci za pravna lica',
+      date: new Date('2024-01-03T00:00:00'),
+      hold: false,
+      merchant: {
+        fullTitle: 'SOME MERCHANT',
+        location: null,
+        mcc: null
+      },
+      movements: [
+        {
+          account: {
+            id: '265100000039246639USD'
+          },
+          fee: 0,
+          id: '1101129842884',
+          invoice: null,
+          sum: 5000
+        }
+      ]
+    })
+  })
+})

--- a/src/plugins/raiffeisen-business-rs/__tests__/converters/transactions/payment.test.ts
+++ b/src/plugins/raiffeisen-business-rs/__tests__/converters/transactions/payment.test.ts
@@ -1,0 +1,70 @@
+import { convertTransaction } from '../../../converters'
+
+describe('Payment', () => {
+  it('Payment', () => {
+    expect(convertTransaction({
+      DebitAmount: 676,
+      ComplaintNumber: '10304532419181000004',
+      AccountType: 'Transakcioni depoziti preduzetnika',
+      CreditTurnover: 16073.35,
+      RejectionReason: '810711',
+      ID: -1,
+      DebtorCreditorName: 'SRBIJA VOZ AD SRB BEOGRAD',
+      PaymentCodeDescription: null,
+      CurrentBalance: 23484.52,
+      AccountNumber: '265163031000946641',
+      NewBalance: 23484.52,
+      Trnben: 'SRBIJA VOZ AD SRB BEOGRAD',
+      fwStatus: 1,
+      Locality: null,
+      ToDate: '2024-02-10T00:00:00',
+      CreditAmount: 0,
+      PBO: null,
+      fwNamespace: 'SagaBG.SeP.eBankingRajfModel',
+      ClientName: 'ARSENII KRASNOV PR BEOGRAD',
+      PBZ: null,
+      CreditorModel: null,
+      ClientDescription: 'DINARSKO KNJIGOVODSTVO',
+      PreviousBalance: 14593.17,
+      Reference: '324395963351',
+      PaymentCode: null,
+      FromDate: '2024-02-09T00:00:00',
+      DebitTurnover: 7182,
+      CompanyIdentityNumber: '4166460428',
+      Description: '989115******9886 / Iznos transakcije: 676.00 u valuti RSD  Iznos u obraeunskoj valuti: 676.00 u valuti RSD',
+      ClientLocality: '11030 BEOGRAD-ČUKARICA',
+      end2endID: null,
+      DebtorModel: null,
+      ValueDate: '2024-02-09T00:00:00',
+      ReferenceNumber: null,
+      ClientAddress: 'KRALJICE KATARINE 12A',
+      ProductCodeCore: '501',
+      AmountTotal: 24631.07,
+      DebitCreditAccount: null,
+      fwType: 'aoCorporateDomesticAccountTurnover',
+      Note: null,
+      CurrencyCode: 'RSD',
+      CurrencyCodeNumeric: '941'
+    })).toEqual({
+      comment: '989115******9886 / Iznos transakcije: 676.00 u valuti RSD  Iznos u obraeunskoj valuti: 676.00 u valuti RSD',
+      date: new Date('2024-02-09T00:00:00'),
+      hold: false,
+      merchant: {
+        fullTitle: 'SRBIJA VOZ AD SRB BEOGRAD',
+        location: null,
+        mcc: null
+      },
+      movements: [
+        {
+          account: {
+            id: '265163031000946641RSD'
+          },
+          fee: 0,
+          id: '324395963351',
+          invoice: null,
+          sum: -676
+        }
+      ]
+    })
+  })
+})

--- a/src/plugins/raiffeisen-business-rs/__tests__/converters/transactions/transfer.test.ts
+++ b/src/plugins/raiffeisen-business-rs/__tests__/converters/transactions/transfer.test.ts
@@ -1,0 +1,138 @@
+import { convertTransactions } from '../../../converters'
+
+describe('Test transfer', () => {
+  it('Test transfer', () => {
+    expect(
+      convertTransactions(
+        [
+          {
+            DebitAmount: 0,
+            ComplaintNumber: '1897240037389693000002',
+            AccountType: 'Transakcioni depoziti preduzetnika',
+            CreditTurnover: 588380.85,
+            RejectionReason: '500214',
+            ID: -1,
+            DebtorCreditorName: 'RAIFFEISEN BANKA',
+            PaymentCodeDescription: 'Kupoprodaja deviza',
+            CurrentBalance: 23484.52,
+            AccountNumber: '265163031000946641',
+            NewBalance: 23484.52,
+            Trnben: 'Prodaja deviza',
+            fwStatus: 1,
+            Locality: 'BEOGRAD-NOVI BEOGRAD',
+            ToDate: '2024-02-10T00:00:00',
+            CreditAmount: 21183.8,
+            PBO: '33-931589705508',
+            fwNamespace: 'SagaBG.SeP.eBankingRajfModel',
+            ClientName: 'SOME NAME',
+            PBZ: '95-265100000039246736',
+            CreditorModel: '97',
+            ClientDescription: 'DINARSKO KNJIGOVODSTVO',
+            PreviousBalance: 67223.21,
+            Reference: '5897240037389539',
+            PaymentCode: 286,
+            FromDate: '2024-01-01T00:00:00',
+            DebitTurnover: 632119.54,
+            CompanyIdentityNumber: '4166460428',
+            Description: 'Isplata dinarske protivvrednosti po otkupu USD 200,00 referenca 931589705508',
+            ClientLocality: '11030 BEOGRAD-ČUKARICA',
+            end2endID: null,
+            DebtorModel: '97',
+            ValueDate: '2024-01-03T00:00:00',
+            ReferenceNumber: null,
+            ClientAddress: 'SOME ADDRESS',
+            ProductCodeCore: '501',
+            AmountTotal: 32617.69,
+            DebitCreditAccount: '265110032000000209',
+            fwType: 'aoCorporateDomesticAccountTurnover',
+            Note: null,
+            CurrencyCode: 'RSD',
+            CurrencyCodeNumeric: '941'
+          },
+          {
+            ShortAccountNumber: '265100000039246639',
+            fwType: 'aoCorporateForeignAccountTurnover',
+            ComplaintNumber: '1897240037389480000004',
+            AccountType: 'Devizni tekući računi preduzetnika',
+            CreditTurnover: 5000,
+            OrganizationUnit: '163',
+            ID: -1,
+            DebtorCreditorName: 'ARSENII KRASNOV PR BEOGRAD/RS',
+            PaymentCodeDescription: null,
+            ProcessedDate: '2024-01-03T00:00:00',
+            CurrentBalance: 10450,
+            NominalInflowAmount: null,
+            CurrencyCodeNumeric: '840',
+            CurrencyCode: 'USD',
+            NewBalance: 10450,
+            Trnben: 'Prodaja deviza',
+            fwStatus: 1,
+            ClientDescription: 'Devizno knjigovodstvo',
+            ToDate: '2024-02-10T00:00:00',
+            CreditAmount: 0,
+            ContractYear: null,
+            fwNamespace: 'SagaBG.SeP.CorporateOutput',
+            FormCode: '77',
+            IBANNumber: 'RS35265100000039246639',
+            ClientAddress: 'SOME ADDRESS',
+            DetailType: 'O',
+            ContractNumber: null,
+            AmountTotal: 10800,
+            DebitAmount: 200,
+            PreviousBalance: 11000,
+            Reference: '931589705508',
+            PaymentCode: null,
+            AccountNumber: '265100000039246639',
+            FromDate: '2024-01-01T00:00:00',
+            DebitTurnover: 5550,
+            CompanyIdentityNumber: '4166460428',
+            Description: null,
+            BankAccount: '50022000',
+            ClientLocality: '11030 BEOGRAD-ČUKARICA',
+            Note: 'Isplata protivvrednosti za otkup 200,00 USD po kursu USD=105.919',
+            ValueDate: '2024-01-03T00:00:00',
+            ChargeBearer: null,
+            DomesticAmount: 21400.02,
+            ReferenceNumber: null,
+            TransactionType: '281121',
+            RequestedValueDate: null,
+            InoBankCommission: null,
+            ProductCodeCore: '120',
+            ItemAmount: '200.00',
+            RequestYear: null,
+            RequestNumber: null,
+            ClientName: 'SOME NAME',
+            TransactionDescription: '\r\nNBS: Slog 77',
+            PBO: null
+          }
+        ]
+      )).toEqual([
+      {
+        hold: false,
+        date: new Date('2024-01-02T23:00:00.000Z'),
+        movements: [
+          {
+            id: '5897240037389539',
+            account: {
+              id: '265163031000946641RSD'
+            },
+            invoice: null,
+            sum: 21183.8,
+            fee: 0
+          },
+          {
+            id: '931589705508',
+            account: {
+              id: '265100000039246639USD'
+            },
+            invoice: null,
+            sum: -200,
+            fee: 0
+          }
+        ],
+        merchant: null,
+        comment: 'Isplata dinarske protivvrednosti po otkupu USD 200,00 referenca 931589705508'
+      }
+    ])
+  })
+})

--- a/src/plugins/raiffeisen-business-rs/converters.ts
+++ b/src/plugins/raiffeisen-business-rs/converters.ts
@@ -1,0 +1,98 @@
+import { AccountType, Transaction } from '../../types/zenmoney'
+import { AccountBalanceResponse, GetAccountTransactionsResponse, RaiffAccount } from './models'
+
+const FX_SALES_AND_PURCHASE = '286'
+const TRANSFER_TRANSACTION_TYPES = [FX_SALES_AND_PURCHASE]
+
+export function convertAccounts (apiAccounts: AccountBalanceResponse[]): RaiffAccount[] {
+  const accounts: RaiffAccount[] = []
+  for (const apiAccount of apiAccounts) {
+    const res = convertAccount(apiAccount)
+    if (res != null) {
+      accounts.push(res)
+    }
+  }
+  return accounts
+}
+
+function convertAccount (apiAccount: AccountBalanceResponse): RaiffAccount | null {
+  // Add CurrencyCode for multicurrency accounts
+  const id = apiAccount.AccountNumber + apiAccount.CurrencyCode
+  const account: RaiffAccount = {
+    id,
+    type: AccountType.checking,
+    title: id,
+    instrument: apiAccount.CurrencyCode,
+    balance: apiAccount.AvailableBalance,
+    creditLimit: 0,
+    syncIds: [id],
+    ProductCodeCore: apiAccount.ProductCodeCore
+  }
+  return account
+}
+
+export function convertTransaction (t1: GetAccountTransactionsResponse): Transaction {
+  return {
+    hold: false,
+    date: new Date(t1.ValueDate),
+    movements: [
+      {
+        id: t1.Reference ?? null,
+        account: { id: t1.AccountNumber + t1.CurrencyCode },
+        invoice: null,
+        sum: t1.CreditAmount - t1.DebitAmount,
+        fee: 0
+      }
+    ],
+    merchant: {
+      fullTitle: t1.DebtorCreditorName,
+      mcc: null,
+      location: null
+    },
+    comment: t1.Description ?? t1.Note
+  }
+}
+
+export function convertTransfer (t1: GetAccountTransactionsResponse, t2: GetAccountTransactionsResponse): Transaction {
+  return {
+    hold: false,
+    date: new Date(t1.ValueDate),
+    movements: [
+      {
+        id: t1.Reference,
+        account: { id: t1.AccountNumber + t1.CurrencyCode },
+        invoice: null,
+        sum: t1.CreditAmount - t1.DebitAmount,
+        fee: 0
+      },
+      {
+        id: t2.Reference,
+        account: { id: t2.AccountNumber + t2.CurrencyCode },
+        invoice: null,
+        sum: t2.CreditAmount - t2.DebitAmount,
+        fee: 0
+      }
+    ],
+    merchant: null,
+    comment: t1.Description ?? t1.Note ?? t2.Description ?? t2.Note
+  }
+}
+
+export function convertTransactions (apiTransactions: GetAccountTransactionsResponse[]): Transaction[] {
+  const transactions: Transaction[] = []
+  for (const apiTransaction of apiTransactions) {
+    const hasPairTransaction = apiTransaction.PaymentCode != null && TRANSFER_TRANSACTION_TYPES.includes(apiTransaction.PaymentCode.toString())
+    const pairTransactionIndex = hasPairTransaction
+      ? apiTransactions.findIndex((t) => apiTransaction.PBO?.endsWith(t.Reference))
+      : -1
+
+    if (pairTransactionIndex !== -1) {
+      transactions.push(convertTransfer(apiTransaction, apiTransactions[pairTransactionIndex]))
+      apiTransactions.splice(pairTransactionIndex, 1)
+    } else {
+      transactions.push(convertTransaction(apiTransaction))
+    }
+  }
+
+  return transactions
+}

--- a/src/plugins/raiffeisen-business-rs/fetchApi.ts
+++ b/src/plugins/raiffeisen-business-rs/fetchApi.ts
@@ -1,0 +1,221 @@
+import '../../polyfills/webAssembly'
+import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
+import { InvalidLoginOrPasswordError } from '../../errors'
+import { parse, splitCookiesString } from 'set-cookie-parser'
+import {
+  AccountBalanceResponse,
+  Auth,
+  AuthTicket,
+  GetAccountTransactionsResponse,
+  LegalEntitiesResponse,
+  LegalEntitiesTicket,
+  Preferences
+} from './models'
+import { isArray } from 'lodash'
+import * as argon2 from 'argon2-browser'
+import moment from 'moment'
+
+const baseUrl = 'https://rol.raiffeisenbank.rs/CorporateV4/Protected/Services/'
+
+async function fetchApi (url: string, options?: FetchOptions): Promise<FetchResponse> {
+  return await fetchJson(baseUrl + url,
+    {
+      // needs for android,
+      // for some reason it fails to farse JSON with whitespaces in the beginning
+      parse: (body: string) => JSON.parse(body.trim()),
+      ...options
+    })
+}
+
+async function getSaltedPassword (login: string, password: string): Promise<string> {
+  const salt = login.padEnd(8, '\0')
+  const saltedPassword = await argon2.hash({
+    pass: password,
+    salt,
+    time: 3,
+    mem: 4096,
+    hashLen: 32,
+    type: argon2.ArgonType.Argon2i
+  })
+  return saltedPassword.hashHex
+}
+
+export async function getTicket ({ login, password }: Preferences): Promise<AuthTicket> {
+  const response = await fetchApi('CorporateLoginService.svc/GetTicketUP', {
+    method: 'POST',
+    body: {
+      username: login,
+      password: await getSaltedPassword(login, password)
+    },
+    sanitizeRequestLog: {
+      body: {
+        username: true,
+        password: true
+      }
+    },
+    sanitizeResponseLog: {
+      headers: { 'set-cookie': true },
+      body: true
+    }
+  }) as FetchResponse & { body: AuthTicket}
+
+  if (response.body == null || response.body.length === 0) {
+    throw new InvalidLoginOrPasswordError()
+  }
+
+  return response.body
+}
+
+export async function getLegalEntities (ticket: AuthTicket): Promise<LegalEntitiesResponse> {
+  const response = await fetchApi('CorporateLoginService.svc/GetLegalEntities', {
+    method: 'POST',
+    body: {
+      ticket
+    },
+    sanitizeRequestLog: {
+      headers: { cookie: true },
+      body: {
+        ticket: true
+      }
+    },
+    sanitizeResponseLog: {
+      headers: { 'set-cookie': true },
+      body: {
+        Ticket: true,
+        PrincipalData: true
+      }
+    }
+  }) as FetchResponse & { body: LegalEntitiesResponse }
+
+  if (response.status !== 200) {
+    throw new InvalidLoginOrPasswordError()
+  }
+
+  if (!response.body.Success) {
+    let message = ''
+    if (response.body.UserTempBlocked != null) {
+      message = `User is temporarily blocked for ${response.body.TempBlockPeriodInMinutes} minutes`
+    }
+    throw new InvalidLoginOrPasswordError(message)
+  }
+
+  return response.body
+}
+
+export async function setLegalEntity (legalEntityId: string, lastSuccessfulLogon: string, ticket: LegalEntitiesTicket): Promise<Auth> {
+  const response = await fetchApi('CorporateLoginService.svc/SetLegalEntityWeb', {
+    method: 'POST',
+    body: {
+      authenticationType: 'UsernamePassword',
+      gridName: 'LegalEntityPreviewFlat',
+      loginCertificateID: '',
+      multipleUser: true,
+      lastSuccessfulLogon,
+      legalEntityId,
+      ticket
+    },
+    sanitizeRequestLog: {
+      headers: { cookie: true },
+      body: {
+        ticket: true
+      }
+    },
+    sanitizeResponseLog: {
+      headers: { 'set-cookie': true }
+    }
+  }) as FetchResponse & { headers: { 'set-cookie': string } }
+
+  if (response.status !== 200) {
+    throw new InvalidLoginOrPasswordError()
+  }
+
+  const cookies: string[] = parse(splitCookiesString(response.headers['set-cookie']))
+    .map(cookie => cookie.name + '=' + cookie.value)
+
+  return { cookie: cookies.join(';') }
+}
+
+export async function fetchAllAccounts (auth: Auth): Promise<AccountBalanceResponse[]> {
+  const response = await fetchApi('DataServiceCorporate.svc/GetAllAccountBalance', {
+    method: 'POST',
+    headers: {
+      Cookie: auth.cookie
+    },
+    sanitizeRequestLog: {
+      headers: { cookie: true }
+    },
+    sanitizeResponseLog: {
+      headers: { 'set-cookie': true },
+      body: {
+        AccountNumber: true,
+        IBANNumber: true,
+        AccountID: true,
+        AvailableBalance: true,
+        Balance: true,
+        LastChangeAmount: true,
+        ShortAccountNumber: true
+      }
+    }
+  }) as FetchResponse & { body: AccountBalanceResponse[][] }
+
+  assert(isArray(response.body), 'cant get accounts array', response)
+  return response.body[1]
+}
+
+export async function fetchAccountTransactions (
+  accountNumber: string,
+  productCoreID: string,
+  currencyCode: string,
+  currencyCodeNumeric: string,
+  auth: Auth,
+  fromDate: Date,
+  toDate: Date
+): Promise<GetAccountTransactionsResponse[]> {
+  const response = await fetchApi('DataServiceCorporate.svc/GetAccountTurnover', {
+    method: 'POST',
+    headers: {
+      Cookie: auth.cookie
+    },
+    body: {
+      accountNumber,
+      filterParam: {
+        AccountNumber: accountNumber,
+        FromDate: moment(fromDate).format('DD.MM.YYYY'),
+        ToDate: moment(toDate).format('DD.MM.YYYY'),
+        CurrencyCodeNumeric: currencyCodeNumeric
+      },
+      productCoreID
+    },
+    sanitizeRequestLog: {
+      headers: { cookie: true },
+      body: {
+        accountNumber: true,
+        AccountNumber: true
+      }
+    },
+    sanitizeResponseLog: {
+      headers: { 'set-cookie': true },
+      body: {
+        TransactionID: true,
+        IBANNumber: true,
+        ClientAddress: true,
+        SocialIdentityNumber: true,
+        Reference: true,
+        AccountNumber: true,
+        Note: true,
+        ComplaintNumber: true,
+        ClientName: true,
+        ClientLocality: true,
+        DebitCreditAccount: true
+      }
+    }
+  }) as FetchResponse & { body: GetAccountTransactionsResponse[] }
+
+  assert(isArray(response.body), 'cant get transactions array', response)
+  const transactions = response.body
+  for (const transaction of transactions) {
+    transaction.CurrencyCode = currencyCode
+    transaction.CurrencyCodeNumeric = currencyCodeNumeric
+  }
+  return transactions
+}

--- a/src/plugins/raiffeisen-business-rs/index.ts
+++ b/src/plugins/raiffeisen-business-rs/index.ts
@@ -1,0 +1,52 @@
+import { ScrapeFunc, Transaction } from '../../types/zenmoney'
+import {
+  fetchAllAccounts,
+  fetchAccountTransactions,
+  getTicket,
+  getLegalEntities,
+  setLegalEntity
+} from './fetchApi'
+import { convertAccounts, convertTransactions } from './converters'
+import { Auth, GetAccountTransactionsResponse, LegalEntitiesResponse, Preferences, RaiffAccount } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  toDate = toDate ?? new Date()
+  const authTicket = await getTicket(preferences)
+  const legalEntitiesResponse: LegalEntitiesResponse = await getLegalEntities(authTicket)
+  const legalEntities = legalEntitiesResponse.PrincipalData
+  const activeEntities = legalEntities.filter(legalEntity => legalEntity.IsActive)
+
+  const accounts: RaiffAccount[] = []
+  const transactions: Transaction[] = []
+
+  for (const legalEntity of activeEntities) {
+    const auth: Auth = await setLegalEntity(
+      legalEntity.LegalEntityID.toString(),
+      legalEntitiesResponse.LastSuccessfulLogon,
+      legalEntitiesResponse.Ticket
+    )
+    const fetchedAccounts = await fetchAllAccounts(auth)
+    accounts.push(...convertAccounts(fetchedAccounts))
+
+    const apiTransactions: GetAccountTransactionsResponse[] = []
+    for (const fetchedAccount of fetchedAccounts) {
+      if (accounts.some(account => account.id.startsWith(fetchedAccount.AccountNumber) && ZenMoney.isAccountSkipped(account.id))) {
+        continue
+      }
+      apiTransactions.push(...await fetchAccountTransactions(
+        fetchedAccount.AccountNumber,
+        fetchedAccount.ProductCodeCore,
+        fetchedAccount.CurrencyCode,
+        fetchedAccount.CurrencyCodeNumeric,
+        auth, fromDate, toDate
+      ))
+    }
+
+    transactions.push(...convertTransactions(apiTransactions))
+  }
+
+  return {
+    accounts,
+    transactions
+  }
+}

--- a/src/plugins/raiffeisen-business-rs/models.ts
+++ b/src/plugins/raiffeisen-business-rs/models.ts
@@ -1,0 +1,90 @@
+import { AccountOrCard } from '../../types/zenmoney'
+
+// Stored in persistent storage
+export interface Auth {
+  cookie: string
+}
+
+// Input preferences from schema in preferences.xml
+export interface Preferences {
+  login: string
+  password: string
+}
+
+export interface RaiffAccount extends AccountOrCard {
+  ProductCodeCore: string
+}
+
+export type AuthTicket = string
+export type LegalEntitiesTicket = string
+
+export interface LegalEntitiesResponse {
+  Success: boolean
+  Ticket: LegalEntitiesTicket
+  LastSuccessfulLogon: string
+  PinMustBeChanged: boolean
+  PrincipalData: LegalEntity[]
+  FailedAttempts: number | null
+  WrongPassword: string | null
+  UserTempBlocked: string | null
+  UserBlocked: string | null
+  TempBlockPeriodInMinutes: number | null
+}
+
+export interface LegalEntity {
+  Name: string
+  UserUniqueIdentifier: number
+  LegalEntityID: number
+  IsActive: boolean
+  PrincipalID: number
+}
+
+export interface AccountBalanceResponse {
+  ShortAccountNumber: string
+  ProductDescriptionAL: string | null
+  AccountType: string
+  IsEbankingAccount: string | null
+  OrganizationUnit: string
+  ItemTypeOfLastChange: string | null
+  CurrencyCode: string
+  CurrencyCodeNumeric: string
+  AccountNumber: string
+  BlockedAmount: number | null
+  AccountCustomName: string | null
+  fwStatus: number
+  LastChangeDate: string | null
+  LastChangedAmount: number | null
+  SubsystemProductID: string | null
+  fwNamespace: string
+  Status: string | null
+  IBANNumber: string | null
+  BankAccountID: number
+  RetailAccountNumber: string | null
+  AccountStatusDescription: string
+  Balance: number
+  AccountStatus: string
+  OrderTypeName: string | null
+  Group: string
+  ID: number
+  Blocked: string
+  ProductDescriptionEN: string | null
+  ProductCodeCore: string
+  AvailableBalance: number
+  fwType: string
+}
+
+export interface GetAccountTransactionsResponse {
+  AccountNumber: string
+  Reference: string
+  CreditAmount: number
+  DebitAmount: number
+  Description: string | null
+  Note: string | null
+  DebtorCreditorName: string
+  ValueDate: string
+  CurrencyCode: string
+  CurrencyCodeNumeric: string
+  PaymentCode: string | number | null
+  PBO: string | null
+  [others: string]: string | number | null
+}

--- a/src/plugins/raiffeisen-business-rs/preferences.xml
+++ b/src/plugins/raiffeisen-business-rs/preferences.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="login"
+        obligatory="true"
+        title="Login"
+        dialogTitle="Login"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|User id or login|{@s}"
+    />
+    <EditTextPreference
+        key="password"
+        obligatory="true"
+        inputType="textPassword"
+        title="Password"
+        dialogTitle="Password"
+        dialogMessage="The password from the bank and the pin code from the application are different passwords. If you do not remember your Internet banking password, restore it on the bank's website."
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="||***********"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="From what date to load transactions"
+        defaultValue="2023-01-01T00:00:00.000Z"
+        dialogTitle="From what date to load transactions"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
Поддержка бизнес версии Raiffeisen Bank Serbia
Основано на raiffeisen-rs, апишка похожа, но со своими особенностями

Переводы со счета на счет реализованы для операций продажи валют USD/EUR -> RSD, в обратную сторону нет возможности протестировать.