### PR TITLE
Draft: [postal-savings-rs] Card transactions

### DIFF
--- a/src/plugins/postal-savings-rs/__tests__/converters/transactions/cardTransactions.test.ts
+++ b/src/plugins/postal-savings-rs/__tests__/converters/transactions/cardTransactions.test.ts
@@ -1,0 +1,130 @@
+import { convertCardTransactions } from '../../../converters'
+
+const input = `
+ <tr>
+    <td align="left">05.04.2024</td>
+    <td align="right">-3.282,63</td>
+    <td align="left">RSD</td>
+    <td align="left">09.04.2024</td>
+    <td align="left">Wolt doo                      </td>
+    <td align="right">4870........1234</td>
+</tr>
+<tr>
+    <td align="left">06.04.2024</td>
+    <td align="right">-370,00</td>
+    <td align="left">RSD</td>
+    <td align="left">09.04.2024</td>
+    <td align="left">LP NOVI CAJ VLADIMIR     NOVI </td>
+    <td align="right">4870........1234</td>
+</tr>
+<tr>
+    <td align="left">07.04.2024</td>
+    <td align="right">500,00</td>
+    <td align="left">EUR</td>
+    <td align="left">10.04.2024</td>
+    <td align="left">REFUND U INOSTRANSTVU         </td>
+    <td align="right">4870........1234</td>
+</tr>
+<tr>
+    <td align="left">08.04.2024</td>
+    <td align="right">-210,00</td>
+    <td align="left">RSD</td>
+    <td align="left">10.04.2024</td>
+    <td align="left">TISHLER TOBACCO AND COFFENOVI </td>
+    <td align="right">4870........1234</td>
+</tr>
+<tr>
+    <td align="left">12.04.2024</td>
+    <td align="right">20,00</td>
+    <td align="left">USD</td>
+    <td align="left">          </td>
+    <td align="left">CHATGPT SUBSCRIPTION     +1415</td>
+    <td align="right">4870........1234</td>
+</tr>
+<tr>
+    <td align="left">13.04.2024</td>
+    <td align="right">10.000,00</td>
+    <td align="left">RSD</td>
+    <td align="left">          </td>
+    <td align="left">ATMBPS KAFE RANDEVU      NOVI </td>
+    <td align="right">4870........1234</td>
+</tr>
+<tr>
+    <td align="left">13.04.2024</td>
+    <td align="right">250,00</td>
+    <td align="left">EUR</td>
+    <td align="left">          </td>
+    <td align="left">REFUND U INOSTRANSTVU         </td>
+    <td align="right">4870........1234</td>
+</tr>
+`
+
+describe('convertCardTransactions', () => {
+  it('converts card transactions', () => {
+    expect(convertCardTransactions(input)).toEqual([
+      {
+        date: new Date('2024-04-13T00:00:00.000'),
+        authorizationDate: null,
+        amount: {
+          sum: 250.00,
+          instrument: 'EUR'
+        },
+        merchant: 'REFUND U INOSTRANSTVU'
+      },
+      {
+        date: new Date('2024-04-13T00:00:00.000'),
+        authorizationDate: null,
+        amount: {
+          sum: -10_000.00,
+          instrument: 'RSD'
+        },
+        merchant: 'ATMBPS KAFE RANDEVU'
+      },
+      {
+        date: new Date('2024-04-12T00:00:00.000'),
+        authorizationDate: null,
+        amount: {
+          sum: -20.00,
+          instrument: 'USD'
+        },
+        merchant: 'CHATGPT SUBSCRIPTION'
+      },
+      {
+        date: new Date('2024-04-08T00:00:00.000'),
+        authorizationDate: new Date('2024-04-10T00:00:00.000'),
+        amount: {
+          sum: -210.00,
+          instrument: 'RSD'
+        },
+        merchant: 'TISHLER TOBACCO AND COFFE'
+      },
+      {
+        date: new Date('2024-04-07T00:00:00.000'),
+        authorizationDate: new Date('2024-04-10T00:00:00.000'),
+        amount: {
+          sum: 500.00,
+          instrument: 'EUR'
+        },
+        merchant: 'REFUND U INOSTRANSTVU'
+      },
+      {
+        date: new Date('2024-04-06T00:00:00.000'),
+        authorizationDate: new Date('2024-04-09T00:00:00.000'),
+        amount: {
+          sum: -370.00,
+          instrument: 'RSD'
+        },
+        merchant: 'LP NOVI CAJ VLADIMIR'
+      },
+      {
+        date: new Date('2024-04-05T00:00:00.000'),
+        authorizationDate: new Date('2024-04-09T00:00:00.000'),
+        amount: {
+          sum: -3282.63,
+          instrument: 'RSD'
+        },
+        merchant: 'Wolt doo'
+      }
+    ])
+  })
+})

--- a/src/plugins/postal-savings-rs/__tests__/converters/transactions/exchangeRates.test.ts
+++ b/src/plugins/postal-savings-rs/__tests__/converters/transactions/exchangeRates.test.ts
@@ -1,0 +1,158 @@
+import { convertExchangeRates } from '../../../converters'
+
+const input = `
+<tr>
+            <td align="center" colspan="9">E- BANKING EXCHANGE RATE LIST NO.: 66<br></br>APPLICABLE AS AT: 05.04.2024.</td>
+          </tr>
+          <tr>
+            <td align="center" width="5%" rowspan="2">Currency code</td>
+            <td align="center" width="5%" rowspan="2">Currency designation</td>
+            <td align="center" width="15%" rowspan="2">Country</td>       
+            <td align="center" width="10%" rowspan="2">Unit</td>
+            <td align="center" colspan="3" width="30%">For foreign exchange</td>            
+            <td align="center" colspan="2" width="20%">For foreign cash</td>
+          </tr><tr>
+            <td align="center" width="12%">Buying exchange rate</td>
+<td align="center" width="12%">Middle exchange rate</td>
+            <td align="center" width="12%">Selling exchange rate</td>                 
+            <td align="center" width="12%">Buying exchange rate</td>
+            <td align="center" width="12%">Selling exchange rate</td>
+          </tr>
+
+<tr valign="top">
+<td align="center">978<br></br></td>
+<td align="center">EUR<br></br></td>
+<td align="left"><img src='../slike2/EUR.gif' height="11" width="16"/>&nbsp;E M U          <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">        116.7883<br></br></td>
+<td align="center">        117.1397<br></br></td>
+<td align="center">        117.4911<br></br></td>
+<td align="center">        116.7883<br></br></td>
+<td align="center">        117.6083<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">036<br></br></td>
+<td align="center">AUD<br></br></td>
+<td align="left"><img src='../slike2/AUD.gif' height="11" width="16"/>&nbsp;AUSTRALIJA     <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">         70.0520<br></br></td>
+<td align="center">         71.1188<br></br></td>
+<td align="center">         72.1856<br></br></td>
+<td align="center">         70.0520<br></br></td>
+<td align="center">         72.1856<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">124<br></br></td>
+<td align="center">CAD<br></br></td>
+<td align="left"><img src='../slike2/CAD.gif' height="11" width="16"/>&nbsp;KANADA         <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">         78.5289<br></br></td>
+<td align="center">         79.7248<br></br></td>
+<td align="center">         80.9207<br></br></td>
+<td align="center">         78.5289<br></br></td>
+<td align="center">         80.9207<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">208<br></br></td>
+<td align="center">DKK<br></br></td>
+<td align="left"><img src='../slike2/DKK.gif' height="11" width="16"/>&nbsp;DANSKA         <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">         15.4678<br></br></td>
+<td align="center">         15.7034<br></br></td>
+<td align="center">         15.9390<br></br></td>
+<td align="center">         15.4678<br></br></td>
+<td align="center">         15.9390<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">578<br></br></td>
+<td align="center">NOK<br></br></td>
+<td align="left"><img src='../slike2/NOK.gif' height="11" width="16"/>&nbsp;NORVESKA       <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">          9.9009<br></br></td>
+<td align="center">         10.0517<br></br></td>
+<td align="center">         10.2025<br></br></td>
+<td align="center">          9.9009<br></br></td>
+<td align="center">         10.2025<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">643<br></br></td>
+<td align="center">RUB<br></br></td>
+<td align="left"><img src='../slike2/RUB.gif' height="11" width="16"/>&nbsp;RUSIJA         <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">          1.1140<br></br></td>
+<td align="center">          1.1726<br></br></td>
+<td align="center">          1.2312<br></br></td>
+<td align="center">          0.0000<br></br></td>
+<td align="center">          0.0000<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">752<br></br></td>
+<td align="center">SEK<br></br></td>
+<td align="left"><img src='../slike2/SEK.gif' height="11" width="16"/>&nbsp;SVEDSKA        <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">          9.9941<br></br></td>
+<td align="center">         10.1463<br></br></td>
+<td align="center">         10.2985<br></br></td>
+<td align="center">          9.9941<br></br></td>
+<td align="center">         10.2985<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">756<br></br></td>
+<td align="center">CHF<br></br></td>
+<td align="left"><img src='../slike2/CHF.gif' height="11" width="16"/>&nbsp;SVAJCARSKA     <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">        118.0506<br></br></td>
+<td align="center">        119.8483<br></br></td>
+<td align="center">        121.6460<br></br></td>
+<td align="center">        118.0506<br></br></td>
+<td align="center">        121.6460<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">826<br></br></td>
+<td align="center">GBP<br></br></td>
+<td align="left"><img src='../slike2/GBP.gif' height="11" width="16"/>&nbsp;VEL. BRITANIJA <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">        134.5570<br></br></td>
+<td align="center">        136.6061<br></br></td>
+<td align="center">        138.6552<br></br></td>
+<td align="center">        134.5570<br></br></td>
+<td align="center">        138.6552<br></br></td>
+</tr>
+
+<tr valign="top">
+<td align="center">840<br></br></td>
+<td align="center">USD<br></br></td>
+<td align="left"><img src='../slike2/USD.gif' height="11" width="16"/>&nbsp;S A D          <br></br></td>
+<td align="center">  1<br></br></td>
+<td align="center">        106.5299<br></br></td>
+<td align="center">        108.1522<br></br></td>
+<td align="center">        109.7745<br></br></td>
+<td align="center">        106.5299<br></br></td>
+<td align="center">        109.7745<br></br></td>
+</tr>
+`
+
+describe('convertExchangeRates', () => {
+  it('converts exchange rates', () => {
+    expect(convertExchangeRates(input)).toEqual(new Map([
+      ['EUR', 117.1397],
+      ['AUD', 71.1188],
+      ['CAD', 79.7248],
+      ['DKK', 15.7034],
+      ['NOK', 10.0517],
+      ['RUB', 1.1726],
+      ['SEK', 10.1463],
+      ['CHF', 119.8483],
+      ['GBP', 136.6061],
+      ['USD', 108.1522]
+    ]))
+  })
+})

--- a/src/plugins/postal-savings-rs/__tests__/converters/transactions/payment.test.ts
+++ b/src/plugins/postal-savings-rs/__tests__/converters/transactions/payment.test.ts
@@ -2,10 +2,9 @@ import { convertTransactions } from '../../../converters'
 
 describe('payment', () => {
   it('payment', () => {
-    expect(convertTransactions({
-      id: 123456789,
-      type: 5
-    }, '<tr>\n' +
+    expect(convertTransactions(
+      '1234567895',
+      '<tr>\n' +
     '<td align="right" width="80" nowrap>05.12.2023</td>\n' +
    '<td align="left" width="130" nowrap>ISPLATA VISA&nbsp;NICEFOODS</td>\n' +
    '<td align="right" width="100" nowrap>EUR 978</td>\n' +

--- a/src/plugins/postal-savings-rs/api.ts
+++ b/src/plugins/postal-savings-rs/api.ts
@@ -1,6 +1,7 @@
-import { accountDetailsToId, convertAccount } from './converters'
+import { accountDetailsToId, convertAccount, convertCardTransactions, convertTransactions } from './converters'
 import { AccountDetails, PSAccount } from './models'
-import { fetchAccountData } from './fetchApi'
+import { fetchAccountData, fetchCardTransactions } from './fetchApi'
+import { Transaction } from '../../types/zenmoney'
 
 function accountCardKey (accountId: string): string {
   return `account/${accountId}/card`
@@ -40,4 +41,18 @@ async function readCardNumber (prompt: string): Promise<string | null> {
     }
   }
   return cardNumber === '' || cardNumber === '0' ? null : cardNumber
+}
+
+export async function fetchTransactions (account: PSAccount, fromDate: Date, toDate: Date): Promise<Transaction[]> {
+  const accountTransactions = convertTransactions(account.id, account.rawData)
+
+  if (account.cardNumber !== null) {
+    const cardTransactions = await fetchCardTransactions(account.cardNumber, fromDate, toDate)
+
+    // TODO: Remove after debug
+    console.log(cardTransactions)
+    console.log(convertCardTransactions(cardTransactions))
+  }
+
+  return accountTransactions.filter(transaction => transaction.date >= fromDate && transaction.date <= toDate)
 }

--- a/src/plugins/postal-savings-rs/api.ts
+++ b/src/plugins/postal-savings-rs/api.ts
@@ -1,0 +1,43 @@
+import { accountDetailsToId, convertAccount } from './converters'
+import { AccountDetails, PSAccount } from './models'
+import { fetchAccountData } from './fetchApi'
+
+function accountCardKey (accountId: string): string {
+  return `account/${accountId}/card`
+}
+
+export async function fetchAccount (accountDetails: AccountDetails): Promise<PSAccount> {
+  const accountId = accountDetailsToId(accountDetails)
+  let cardNumber = ZenMoney.getData(accountCardKey(accountId)) as string | null | undefined
+
+  if (cardNumber === undefined) {
+    cardNumber = await readCardNumber(`Enter card number for account ${accountDetails.id} (optional):`)
+    ZenMoney.setData(accountCardKey(accountId), cardNumber)
+    ZenMoney.saveData()
+  }
+
+  const rawData = await fetchAccountData(accountDetails)
+  const account = convertAccount(accountDetails, rawData)
+  if (cardNumber !== null) {
+    account.syncIds.push(cardNumber)
+  }
+
+  return {
+    ...account,
+    cardNumber,
+    rawData
+  }
+}
+
+async function readCardNumber (prompt: string): Promise<string | null> {
+  let cardNumber: string | undefined
+  while (cardNumber === undefined) {
+    const input = (await ZenMoney.readLine(prompt, { inputType: 'number' }) ?? '').replace(/\D/g, '')
+    if (input.length === 16) {
+      cardNumber = input
+    } else {
+      await ZenMoney.alert('Card number should contain exactly 16 digits. You can leave the field empty if you don\'t have a card')
+    }
+  }
+  return cardNumber === '' || cardNumber === '0' ? null : cardNumber
+}

--- a/src/plugins/postal-savings-rs/converters.ts
+++ b/src/plugins/postal-savings-rs/converters.ts
@@ -1,8 +1,8 @@
-import { AccountType, Transaction, Account } from '../../types/zenmoney'
+import { AccountOrCard, AccountType, Transaction } from '../../types/zenmoney'
 import { AccountDetails } from './models'
 import moment from 'moment'
 
-function accountDetailsToId (account: AccountDetails): string {
+export function accountDetailsToId (account: AccountDetails): string {
   return `${account.id}${account.type}`
 }
 
@@ -24,7 +24,7 @@ function descriptionCleanup (s: string): string {
   return strWithoutGarbage.length > 0 ? strWithoutGarbage : decodedStr
 }
 
-export function convertAccount (account: AccountDetails, data: string): Account {
+export function convertAccount (account: AccountDetails, data: string): AccountOrCard {
   const id = accountDetailsToId(account)
 
   const descriptionPattern = /<td>([\w\s]+):<\/td>\s+<td>\d+<\/td>/

--- a/src/plugins/postal-savings-rs/fetchApi.ts
+++ b/src/plugins/postal-savings-rs/fetchApi.ts
@@ -2,6 +2,7 @@ import { FetchResponse, fetch } from '../../common/network'
 import { toAtLeastTwoDigitsString } from '../../common/stringUtils'
 import { InvalidLoginOrPasswordError } from '../../errors'
 import { AccountDetails, Preferences } from './models'
+import moment from 'moment'
 
 const baseUrl = 'https://hb.posted.co.rs/posted/en/'
 
@@ -118,6 +119,16 @@ export async function fetchCardTransactions (cardNumber: string, fromDate: Date,
   const response = await fetchUrl('karttrn.jsp', {
     method: 'POST',
     body: `KOM=K3&H1=${cardNumber}&IRADIO=I2&oddan=${fromDay}&odmes=${fromMonth}&dodan=${toDay}&domes=${toMonth}&god=${year}`
+  })
+
+  return response.body as string
+}
+
+export async function fetchExchangeRates (date: Date | null): Promise<string> {
+  const formattedDate = date !== null ? moment(date).format('DD.MM.YYYY') : ''
+  const response = await fetchUrl('kursl.jsp', {
+    method: 'POST',
+    body: `DATUM=${formattedDate}&check1=on`
   })
 
   return response.body as string

--- a/src/plugins/postal-savings-rs/fetchApi.ts
+++ b/src/plugins/postal-savings-rs/fetchApi.ts
@@ -1,4 +1,5 @@
 import { FetchResponse, fetch } from '../../common/network'
+import { toAtLeastTwoDigitsString } from '../../common/stringUtils'
 import { InvalidLoginOrPasswordError } from '../../errors'
 import { AccountDetails, Preferences } from './models'
 
@@ -100,6 +101,23 @@ export async function fetchAccountData (account: AccountDetails): Promise<string
   const response = await fetchUrl('racsta.jsp', {
     method: 'POST',
     body: `RACUNPSTIP=${account.type}&racun=${account.id}`
+  })
+
+  return response.body as string
+}
+
+export async function fetchCardTransactions (cardNumber: string, fromDate: Date, toDate: Date): Promise<string> {
+  fromDate = fromDate.getFullYear() >= toDate.getFullYear() ? fromDate : new Date(toDate.getFullYear(), 0, 1)
+
+  const fromDay = toAtLeastTwoDigitsString(fromDate.getDate())
+  const fromMonth = toAtLeastTwoDigitsString(fromDate.getMonth() + 1)
+  const toDay = toAtLeastTwoDigitsString(toDate.getDate())
+  const toMonth = toAtLeastTwoDigitsString(toDate.getMonth() + 1)
+  const year = toDate.getFullYear()
+
+  const response = await fetchUrl('karttrn.jsp', {
+    method: 'POST',
+    body: `KOM=K3&H1=${cardNumber}&IRADIO=I2&oddan=${fromDay}&odmes=${fromMonth}&dodan=${toDay}&domes=${toMonth}&god=${year}`
   })
 
   return response.body as string

--- a/src/plugins/postal-savings-rs/index.ts
+++ b/src/plugins/postal-savings-rs/index.ts
@@ -1,7 +1,8 @@
 import { ScrapeFunc, Transaction, Account } from '../../types/zenmoney'
-import { fetchAllAccounts, fetchAuthorization, fetchAccountData } from './fetchApi'
+import { fetchAllAccounts, fetchAuthorization } from './fetchApi'
 import { Preferences } from './models'
-import { convertAccount, convertTransactions } from './converters'
+import { accountDetailsToId, convertTransactions } from './converters'
+import { fetchAccount } from './api'
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
   toDate = toDate ?? new Date()
@@ -12,11 +13,15 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
   const accounts: Account[] = []
   const transactions: Transaction[] = []
 
-  for (const account of fetchedAccounts) {
-    const rawAccountData = await fetchAccountData(account)
-    accounts.push(convertAccount(account, rawAccountData))
-    const filteredTransactions = convertTransactions(account, rawAccountData)
+  for (const accountDetails of fetchedAccounts) {
+    if (ZenMoney.isAccountSkipped(accountDetailsToId(accountDetails))) {
+      continue
+    }
+
+    const account = await fetchAccount(accountDetails)
+    const filteredTransactions = convertTransactions(accountDetails, account.rawData)
       .filter(transaction => transaction.date >= fromDate && (toDate == null || transaction.date <= toDate))
+    accounts.push(account)
     transactions.push(...filteredTransactions)
   }
 

--- a/src/plugins/postal-savings-rs/index.ts
+++ b/src/plugins/postal-savings-rs/index.ts
@@ -1,8 +1,8 @@
 import { ScrapeFunc, Transaction, Account } from '../../types/zenmoney'
 import { fetchAllAccounts, fetchAuthorization } from './fetchApi'
 import { Preferences } from './models'
-import { accountDetailsToId, convertTransactions } from './converters'
-import { fetchAccount } from './api'
+import { accountDetailsToId } from './converters'
+import { fetchAccount, fetchTransactions } from './api'
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
   toDate = toDate ?? new Date()
@@ -19,10 +19,8 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
     }
 
     const account = await fetchAccount(accountDetails)
-    const filteredTransactions = convertTransactions(accountDetails, account.rawData)
-      .filter(transaction => transaction.date >= fromDate && (toDate == null || transaction.date <= toDate))
     accounts.push(account)
-    transactions.push(...filteredTransactions)
+    transactions.push(...await fetchTransactions(account, fromDate, toDate))
   }
 
   return {

--- a/src/plugins/postal-savings-rs/models.ts
+++ b/src/plugins/postal-savings-rs/models.ts
@@ -1,3 +1,5 @@
+import { AccountOrCard } from '../../types/zenmoney'
+
 // Input preferences from schema in preferences.xml
 export interface Preferences {
   login: string
@@ -14,4 +16,9 @@ export enum AccountType {
 export interface AccountDetails {
   id: number
   type: AccountType
+}
+
+export interface PSAccount extends AccountOrCard {
+  cardNumber: string | null
+  rawData: string
 }

--- a/src/plugins/postal-savings-rs/models.ts
+++ b/src/plugins/postal-savings-rs/models.ts
@@ -27,6 +27,7 @@ export interface CardTransaction {
   date: Date
   authorizationDate: Date | null
   amount: Amount
+  accountSum?: number
   merchant: string
 }
 

--- a/src/plugins/postal-savings-rs/models.ts
+++ b/src/plugins/postal-savings-rs/models.ts
@@ -29,3 +29,5 @@ export interface CardTransaction {
   amount: Amount
   merchant: string
 }
+
+export type ExchangeRatesMap = Map<string, number>

--- a/src/plugins/postal-savings-rs/models.ts
+++ b/src/plugins/postal-savings-rs/models.ts
@@ -1,4 +1,4 @@
-import { AccountOrCard } from '../../types/zenmoney'
+import { AccountOrCard, Amount } from '../../types/zenmoney'
 
 // Input preferences from schema in preferences.xml
 export interface Preferences {
@@ -21,4 +21,11 @@ export interface AccountDetails {
 export interface PSAccount extends AccountOrCard {
   cardNumber: string | null
   rawData: string
+}
+
+export interface CardTransaction {
+  date: Date
+  authorizationDate: Date | null
+  amount: Amount
+  merchant: string
 }


### PR DESCRIPTION
Depends on #742

TODO:
- [x] Card number input
- [x] Fetch transactions
- [x] Parse transactions
- [ ] Merge card transactions with account transactions (should fix #740)
  - [x] Fetch exchange rates
  - [x] Implement currency exchange
  - [ ] Match card transaction to account transaction using transaction amount in account currency
- [ ] Paging (maximum is 100 transactions per request)

Nice to have:
- [ ] Assume transactions starting with `ATMPSB` as cash withdrawal with zero fee