### PR TITLE
[tonscan] Add tonscan plugin

### DIFF
--- a/src/plugins/tonscan/ZenmoneyManifest.xml
+++ b/src/plugins/tonscan/ZenmoneyManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>tonscan</id>
+    <version>1.0</version>
+    <build>1</build>
+    <company>-1</company>
+    <modular>true</modular>
+    <codeRequired>false</codeRequired>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <description>TON wallet and Jettons</description>
+</provider>

--- a/src/plugins/tonscan/__tests__/converters/accounts/accounts.test.ts
+++ b/src/plugins/tonscan/__tests__/converters/accounts/accounts.test.ts
@@ -1,0 +1,90 @@
+import { AccountType } from '../../../../../types/zenmoney'
+import { convertWalletToAccount, convertJettonToAccount } from '../../../converters'
+
+describe('convertWalletToAccount', () => {
+  it('should correctly convert ton accounts', async () => {
+    const wallets = [
+      {
+        raw: { address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr', balance: 16793400000 },
+        converted: {
+          id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr',
+          type: AccountType.ccard,
+          title: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr',
+          instrument: 'TON',
+          balance: 16.79,
+          available: 16.79,
+          creditLimit: 0,
+          syncIds: ['UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr']
+        }
+      },
+      {
+        raw: { address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ', balance: 0 },
+        converted: {
+          id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ',
+          type: AccountType.ccard,
+          title: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ',
+          instrument: 'TON',
+          balance: 0,
+          available: 0,
+          creditLimit: 0,
+          syncIds: ['UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ']
+        }
+      }
+    ]
+    for (const { raw, converted } of wallets) {
+      expect(convertWalletToAccount(raw)).toEqual(converted)
+    }
+  })
+})
+
+describe('convertJettonToAccount', () => {
+  it('should correctly convert jetton account', async () => {
+    const wallets = [
+      {
+        raw: {
+          address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sQCC1',
+          balance: 167934000,
+          jetton: '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE',
+          jettonType: 'USDT',
+          title: 'TON Any Jetton Name',
+          owner: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ',
+          decimals: 6
+        },
+        converted: {
+          id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sQCC1',
+          type: AccountType.ccard,
+          title: 'TON Any Jetton Name',
+          instrument: 'USDT',
+          balance: 167.93,
+          available: 167.93,
+          creditLimit: 0,
+          syncIds: ['UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sQCC1']
+        }
+      },
+      {
+        raw: {
+          address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sQQQ1',
+          balance: 171934,
+          jetton: '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621QVX',
+          jettonType: 'MYTICKER',
+          title: 'TON Any Jetton Name 2',
+          owner: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ',
+          decimals: 6
+        },
+        converted: {
+          id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sQQQ1',
+          type: AccountType.ccard,
+          title: 'TON Any Jetton Name 2',
+          instrument: 'MYTICKER',
+          balance: 0.17,
+          available: 0.17,
+          creditLimit: 0,
+          syncIds: ['UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sQQQ1']
+        }
+      }
+    ]
+    for (const { raw, converted } of wallets) {
+      expect(convertJettonToAccount(raw)).toEqual(converted)
+    }
+  })
+})

--- a/src/plugins/tonscan/__tests__/converters/transaction/transaction.test.ts
+++ b/src/plugins/tonscan/__tests__/converters/transaction/transaction.test.ts
@@ -1,0 +1,150 @@
+import { convertTonTransaction, convertJettonTransfer } from '../../../converters'
+
+const otherAddress = 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4sVGcQ'
+
+describe('convertTonTransaction', () => {
+  const walletInfo = {
+    address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr',
+    balance: 0
+  }
+
+  it('should correctly convert TON transaction', () => {
+    const rawTransaction = {
+      transactionId: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+      fromAddress: otherAddress,
+      toAddress: walletInfo.address,
+      quantity: 56793400000,
+      timestamp: 1624118401
+    }
+
+    const convertedTransaction = {
+      hold: false,
+      date: new Date(1624118401 * 1000),
+      movements: [
+        {
+          id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+          account: { id: walletInfo.address },
+          sum: 56.79,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: {
+        fullTitle: otherAddress,
+        mcc: null,
+        location: null
+      },
+      comment: null
+    }
+
+    expect(convertTonTransaction(rawTransaction, walletInfo)).toEqual(convertedTransaction)
+  })
+
+  it('correctly sets the operation sign', () => {
+    const rawTransaction = {
+      transactionId: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+      fromAddress: walletInfo.address,
+      toAddress: otherAddress,
+      quantity: 56793400000,
+      timestamp: 1624118401
+    }
+
+    const result = convertTonTransaction(rawTransaction, walletInfo)
+
+    expect(result?.movements[0].sum).toEqual(-56.79)
+  })
+
+  it('ignores transactions with amount < 0.01', () => {
+    const rawTransaction = {
+      transactionId: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+      fromAddress: otherAddress,
+      toAddress: walletInfo.address,
+      quantity: 1000000, // 0.001 TON
+      timestamp: 1624118401
+    }
+
+    const result = convertTonTransaction(rawTransaction, walletInfo)
+
+    expect(result).toBe(null)
+  })
+})
+
+describe('convertJettonTransfer', () => {
+  const ourAddress = 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h3VWvcr'
+  const jettonInfo = {
+    address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h4syjVB',
+    jetton: '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE',
+    jettonType: 'USDT',
+    title: 'Any Jetton Name',
+    owner: ourAddress,
+    balance: 0,
+    decimals: 6
+  }
+  const anotherJettonInfo = {
+    address: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm14sVVXcZ',
+    jetton: '0:B113A994B5024A16719F69139328EB759596C38A25F59028B1465EFCC3621VFR', // some random address
+    jettonType: 'ANY',
+    title: 'Another Jetton Name 2',
+    owner: ourAddress,
+    balance: 0,
+    decimals: 6
+  }
+  const jettons = [jettonInfo, anotherJettonInfo]
+
+  it('should correctly convert Jetton transfer', () => {
+    const rawTransfer = {
+      jettonAddress: jettonInfo.address,
+      transactionId: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+      fromAddress: otherAddress,
+      toAddress: jettonInfo.address,
+      quantity: 93426000,
+      timestamp: 1624118402
+    }
+    const convertedTransfer = {
+      hold: false,
+      date: new Date(1624118402 * 1000),
+      movements: [
+        {
+          id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+          account: { id: jettonInfo.address },
+          sum: 93.42,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: {
+        fullTitle: otherAddress,
+        mcc: null,
+        location: null
+      },
+      comment: null
+    }
+    expect(convertJettonTransfer(rawTransfer, jettons)).toEqual(convertedTransfer)
+  })
+
+  it('returns null if transfer does not belong to passed jettons', () => {
+    const rawTransfer = {
+      jettonAddress: 'some unknown jetton address',
+      transactionId: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+      fromAddress: otherAddress,
+      toAddress: jettonInfo.address,
+      quantity: 93400000,
+      timestamp: 1624118402
+    }
+
+    expect(convertJettonTransfer(rawTransfer, jettons)).toBe(null)
+  })
+
+  it('skips transactions with amount < 0.01', () => {
+    const rawTransfer = {
+      jettonAddress: jettonInfo.address,
+      transactionId: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm3h2sWVcQ',
+      fromAddress: otherAddress,
+      toAddress: jettonInfo.address,
+      quantity: 1000, // 0.001 USDT
+      timestamp: 1624118402
+    }
+
+    expect(convertJettonTransfer(rawTransfer, jettons)).toBe(null)
+  })
+})

--- a/src/plugins/tonscan/__tests__/tonscan-scrape.test.ts
+++ b/src/plugins/tonscan/__tests__/tonscan-scrape.test.ts
@@ -1,0 +1,118 @@
+import { AccountType } from '../../../types/zenmoney'
+import { mockEndPoints, preferencesMock } from '../mocks'
+
+describe('scrape', () => {
+  jest.mock('../config', () => ({
+    MAX_RPS: 100,
+    SUPPORTED_JETTONS: jest.requireActual('../config').SUPPORTED_JETTONS
+  }))
+
+  it('should hit the mocks and return results', async () => {
+    const { scrape } = require('../index')
+    mockEndPoints()
+
+    const result = await scrape(
+      {
+        preferences: preferencesMock,
+        fromDate: new Date('2024-06-01T00:00:00'),
+        toDate: new Date('2024-06-20T23:59:59'),
+        isFirstRun: false,
+        isInBackground: false
+      }
+    )
+
+    expect(result.accounts).toEqual([
+      {
+        id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr',
+        type: AccountType.ccard,
+        title: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr',
+        instrument: 'TON',
+        balance: 129.82,
+        available: 129.82,
+        creditLimit: 0,
+        syncIds: ['UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr']
+      },
+      {
+        id: 'EQCnDbQfXrcaamtqWgsaAzxG9WNfZ7JcgRsWFZIE1YRNRHYY',
+        type: AccountType.ccard,
+        title: 'TON Tether USDT',
+        instrument: 'USDT',
+        balance: 8,
+        available: 8,
+        creditLimit: 0,
+        syncIds: ['EQCnDbQfXrcaamtqWgsaAzxG9WNfZ7JcgRsWFZIE1YRNRHYY']
+      }
+    ])
+
+    expect(result.transactions).toEqual([
+      {
+        hold: false,
+        date: new Date('2024-06-19T15:28:07.000Z'),
+        movements: [{
+          id: 'vNoHxFdN+bl3wy7g52Tl3Va7eKM71hDLm64g6haL1fQ=',
+          account: { id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr' },
+          invoice: null,
+          sum: 46.19,
+          fee: 0
+        }],
+        merchant: {
+          fullTitle: 'EQChB2eMoFG4ThuEsZ6ehlBPKJXOjNxlR5B7qKZNGIv256Da',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      },
+      {
+        hold: false,
+        date: new Date('2024-06-19T15:28:07.000Z'),
+        movements: [{
+          id: 'udQ9QJFZl+28cVfny6CiZu8n+AYY7VWszp1uKXMMv04=',
+          account: { id: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr' },
+          invoice: null,
+          sum: -41,
+          fee: 0
+        }],
+        merchant: {
+          fullTitle: 'EQChB2eMoFG4ThuEsZ6ehlBPKJXOjNxlR5B7qKZNGIv256Da',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      },
+      {
+        hold: false,
+        date: new Date('2024-06-15T04:14:35.000Z'),
+        movements: [{
+          id: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyQSg=',
+          account: { id: 'EQCnDbQfXrcaamtqWgsaAzxG9WNfZ7JcgRsWFZIE1YRNRHYY' },
+          invoice: null,
+          sum: -10,
+          fee: 0
+        }],
+        merchant: {
+          fullTitle: 'UQBSJYCMq3Jwu1ItUJJ1nAkcrgPvIzJZY8qpfuPEaB4dxZri',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      },
+      {
+        hold: false,
+        date: new Date('2024-06-15T04:14:36.000Z'),
+        movements: [{
+          id: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyQSg=',
+          account: { id: 'EQCnDbQfXrcaamtqWgsaAzxG9WNfZ7JcgRsWFZIE1YRNRHYY' },
+          invoice: null,
+          sum: -26.79,
+          fee: 0
+        }],
+        merchant: {
+          fullTitle: 'UQBSJYCMq3Jwu1ItUJJ1nAkcrgPvIzJZY8qpfuPEaB4dxZri',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      }
+    ])
+  })
+})

--- a/src/plugins/tonscan/api.ts
+++ b/src/plugins/tonscan/api.ts
@@ -1,0 +1,275 @@
+import qs from 'querystring'
+import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
+import get from '../../types/get'
+import { SUPPORTED_JETTONS } from './config'
+import { delay } from '../../common/utils'
+
+const MAX_RPS = 1
+
+export interface Preferences {
+  wallets: string
+}
+
+export interface JettonInfo {
+  address: string
+  ownerWithJettonType: string
+  jetton: string
+  jettonType: string
+  owner: string
+  balance: number
+  decimals: number
+}
+
+export interface WalletInfo {
+  address: string
+  balance: number
+}
+
+export interface TonTransaction {
+  transactionId: string
+  fromAddress: string
+  toAddress: string
+  quantity: number
+  timestamp: number
+}
+
+export interface RawJettonTransfer {
+  transaction_hash: string
+  source: string
+  destination: string
+  amount: number
+  transaction_now: number
+}
+
+export interface JettonTransfer {
+  jettonAddress: string
+  transactionId: string
+  fromAddress: string
+  toAddress: string
+  quantity: number
+  timestamp: number
+}
+
+export interface Msg {
+  hash: string
+  source: string
+  destination: string
+  value: number
+  created_at: number
+}
+
+export interface AddressBook {
+  [key: string]: { user_friendly: string }
+}
+
+export class TonscanApi {
+  private readonly baseUrl: string
+  private activeList: Array<Promise<unknown>> = []
+
+  constructor (options: { baseUrl: string}) {
+    this.baseUrl = options.baseUrl
+  }
+
+  private async fetchApi (
+    url: string,
+    options?: FetchOptions,
+    predicate?: (x: FetchResponse) => boolean
+  ): Promise<FetchResponse> {
+    if (this.activeList.length < MAX_RPS) {
+      const request = this.fetchInner(url, options, predicate)
+
+      const waiter = request
+        .then(async () => await delay(1300))
+        .catch(async () => await delay(1300))
+        .then(() => {
+          this.activeList = this.activeList.filter(item => item !== waiter)
+        })
+
+      this.activeList.push(waiter)
+
+      const result = await request
+
+      return result
+    }
+
+    await Promise.race(this.activeList)
+    return await this.fetchApi(url, options, predicate)
+  }
+
+  private async fetchInner (
+    url: string,
+    options?: FetchOptions,
+    predicate?: (x: FetchResponse) => boolean
+  ): Promise<FetchResponse> {
+    const response = await fetchJson(this.baseUrl + url, options)
+
+    if (predicate) {
+      this.validateResponse(
+        response,
+        response => !get(response.body, 'error') && predicate(response)
+      )
+    }
+
+    return response
+  }
+
+  private validateResponse (
+    response: FetchResponse,
+    predicate?: (x: FetchResponse) => boolean
+  ): void {
+    console.assert(!predicate || predicate(response), 'non-successful response')
+  }
+
+  public async fetchJettons (ownerWalletAddress: string): Promise<JettonInfo[]> {
+    const response = await this.fetchApi(
+      `v3/jetton/wallets?${qs.stringify({
+        owner_address: ownerWalletAddress
+      })}`,
+      undefined,
+      (res) => typeof res.body === 'object' && res.body != null && 'jetton_wallets' in res.body
+    ) as FetchResponse & { body: { jetton_wallets: Array<Record<string, unknown>> } }
+
+    return response.body.jetton_wallets
+      .filter(t => Object.keys(SUPPORTED_JETTONS).includes(t.jetton as string))
+      .map(t => ({
+        address: t.address as string,
+        jetton: t.jetton as string,
+        jettonType: SUPPORTED_JETTONS[t.jetton as string].ticker,
+        decimals: SUPPORTED_JETTONS[t.jetton as string].decimals,
+        owner: ownerWalletAddress,
+        ownerWithJettonType: `${ownerWalletAddress}_${SUPPORTED_JETTONS[t.jetton as string].ticker}`,
+        balance: t.balance as number
+      }))
+  }
+
+  public async fetchWallet (wallet: string): Promise<WalletInfo> {
+    const response = await this.fetchApi(
+      `v3/wallet?${qs.stringify({
+      address: wallet
+      })}`,
+      undefined,
+      (res) => typeof res.body === 'object' && res.body != null && 'balance' in res.body
+    ) as FetchResponse & { body: { balance: string } }
+
+    return {
+      address: wallet,
+      balance: parseFloat(response.body.balance)
+    }
+  }
+
+  public async fetchAddressBook (addresses: string[]): Promise<AddressBook> {
+    const response = await this.fetchApi(
+      `v3/addressBook?${qs.stringify({
+      address: addresses
+      })}`,
+      undefined,
+      (res) => typeof res.body === 'object' && res.body != null
+    ) as FetchResponse & { body: AddressBook }
+
+    return response.body
+  }
+
+  public async fetchTonTransactions (ownerWalletAddress: string, fromDate: Date, toDate?: Date): Promise<TonTransaction[]> {
+    const transactions: TonTransaction[] = []
+    let offset = 0
+    const limit = 30
+
+    while (true) {
+      const response = await this.fetchApi(
+        `v3/transactions?${qs.stringify({
+          account: ownerWalletAddress,
+          start_utime: Math.floor((fromDate).getTime() / 1000),
+          end_utime: Math.floor((toDate ?? new Date()).getTime() / 1000),
+          limit,
+          offset,
+          sort: 'desc'
+        })}`) as FetchResponse & { body: { transactions: Array<{ in_msg: Msg, out_msgs: Msg[] }>, address_book: AddressBook } }
+
+      const incomeTransactions = response.body.transactions.filter(t => t.in_msg?.value > 1)
+      const outcomeTransactions = response.body.transactions.flatMap(t => t.out_msgs).filter(msg => msg.value > 1)
+      const addressBook = response.body.address_book
+
+      transactions.push(...incomeTransactions.map(t => ({
+        transactionId: t.in_msg.hash,
+        fromAddress: addressBook[t.in_msg.source].user_friendly,
+        toAddress: addressBook[t.in_msg.destination].user_friendly,
+        quantity: t.in_msg.value,
+        timestamp: t.in_msg.created_at
+      })))
+
+      transactions.push(...outcomeTransactions.map(t => ({
+        transactionId: t.hash,
+        fromAddress: addressBook[t.source].user_friendly,
+        toAddress: addressBook[t.destination].user_friendly,
+        quantity: t.value,
+        timestamp: t.created_at
+      })))
+
+      if (limit > response.body.transactions.length) {
+        break
+      }
+
+      offset += limit
+    }
+
+    return transactions
+  }
+
+  public async fetchJettonsTransfers (jettons: JettonInfo[], fromDate: Date, toDate?: Date): Promise<JettonTransfer[]> {
+    const transfers: JettonTransfer[] = []
+
+    // fetch each supported jetton transfers separately to avoid fetching all trasnfers of unsupported jettons
+    for (const jetton of jettons) {
+      let offset = 0
+      const limit = 50
+
+      while (true) {
+        const response = await this.fetchApi(
+          `v3/jetton/transfers?${qs.stringify({
+            address: jetton.owner,
+            jetton_master: jetton.jetton,
+            start_utime: Math.floor((fromDate).getTime() / 1000),
+            end_utime: Math.floor((toDate ?? new Date()).getTime() / 1000),
+            limit,
+            offset,
+            sort: 'desc'
+          })}`) as FetchResponse & { body: { jetton_transfers: RawJettonTransfer[] } }
+
+        transfers.push(...response.body.jetton_transfers.map(t => ({
+          jettonAddress: jetton.address,
+          transactionId: t.transaction_hash,
+          fromAddress: t.source,
+          toAddress: t.destination,
+          quantity: t.amount,
+          timestamp: t.transaction_now
+        })))
+
+        if (limit > response.body.jetton_transfers.length) {
+          break
+        }
+
+        offset += limit
+      }
+    }
+
+    if (transfers.length === 0) {
+      return []
+    }
+
+    const uniqueAddresses = [...new Set([...transfers.map(t => t.fromAddress), ...transfers.map(t => t.toAddress)])]
+    const addressBook = await this.fetchAddressBook(uniqueAddresses)
+
+    // replace raw addresses with user_friendly forms
+    const updatedTransfers = transfers.map(t => ({
+      ...t,
+      fromAddress: addressBook[t.fromAddress]?.user_friendly !== undefined ? addressBook[t.fromAddress]?.user_friendly : t.fromAddress,
+      toAddress: addressBook[t.toAddress]?.user_friendly !== undefined ? addressBook[t.toAddress]?.user_friendly : t.toAddress
+    }))
+
+    return updatedTransfers
+  }
+}
+
+export const tonscanApi = new TonscanApi({
+  baseUrl: 'https://toncenter.com/api/'
+})

--- a/src/plugins/tonscan/config.ts
+++ b/src/plugins/tonscan/config.ts
@@ -1,0 +1,9 @@
+interface SupportedJettons {
+  [key: string]: { ticker: string, decimals: number }
+}
+export const SUPPORTED_JETTONS: SupportedJettons = {
+  '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE': {
+    ticker: 'USDT',
+    decimals: 6
+  }
+}

--- a/src/plugins/tonscan/config.ts
+++ b/src/plugins/tonscan/config.ts
@@ -1,9 +1,12 @@
 interface SupportedJettons {
-  [key: string]: { ticker: string, decimals: number }
+  [key: string]: { ticker: string, title: string, decimals: number }
 }
 export const SUPPORTED_JETTONS: SupportedJettons = {
   '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE': {
     ticker: 'USDT',
+    title: 'TON Tether USDT',
     decimals: 6
   }
 }
+
+export const MAX_RPS = 1

--- a/src/plugins/tonscan/converters.ts
+++ b/src/plugins/tonscan/converters.ts
@@ -1,0 +1,104 @@
+import { AccountOrCard, AccountType, Transaction } from '../../types/zenmoney'
+import { WalletInfo, JettonInfo, TonTransaction, JettonTransfer } from './api'
+
+function convertTonFromNano (balance: number): number {
+  return balance / (10 ** 9)
+}
+
+export function convertWalletToAccount (wallet: WalletInfo): AccountOrCard {
+  return {
+    id: wallet.address,
+    type: AccountType.ccard,
+    title: wallet.address,
+    instrument: 'TON',
+    balance: convertTonFromNano(wallet.balance),
+    available: convertTonFromNano(wallet.balance),
+    creditLimit: 0,
+    syncIds: [wallet.address]
+  }
+}
+
+export function convertJettonToAccount (jettonInfo: JettonInfo): AccountOrCard {
+  return {
+    id: jettonInfo.ownerWithJettonType,
+    type: AccountType.ccard,
+    title: jettonInfo.ownerWithJettonType,
+    instrument: jettonInfo.jettonType,
+    balance: jettonInfo.balance / (10 ** jettonInfo.decimals),
+    available: jettonInfo.balance / (10 ** jettonInfo.decimals),
+    creditLimit: 0,
+    syncIds: [jettonInfo.ownerWithJettonType]
+  }
+}
+
+export function convertTonTransaction (transaction: TonTransaction, walletInfo: WalletInfo): Transaction | null {
+  const operationSign = transaction.fromAddress === walletInfo.address ? -1 : 1
+  const sum = convertTonFromNano(operationSign * Number(transaction.quantity))
+  const merchantName = transaction.fromAddress === walletInfo.address ? transaction.toAddress : transaction.fromAddress
+
+  // Skip trash transactions
+  if (Math.abs(sum) < 0.000001) {
+    return null
+  }
+
+  return {
+    hold: false,
+    date: new Date(transaction.timestamp * 1000),
+    movements: [
+      {
+        id: transaction.transactionId,
+        account: { id: walletInfo.address },
+        sum,
+        fee: 0,
+        invoice: null
+      }
+    ],
+    merchant: {
+      fullTitle: merchantName,
+      mcc: null,
+      location: null
+    },
+    comment: null
+  }
+}
+
+export function convertJettonTransfer (transfer: JettonTransfer, jettons: JettonInfo[]): Transaction | null {
+  for (const jetton of jettons) {
+    if (jetton.address !== transfer.jettonAddress) {
+      continue
+    }
+
+    const operationSign = transfer.fromAddress === jetton.owner ? -1 : 1
+    const sum = (operationSign * Number(transfer.quantity)) / (10 ** jetton.decimals)
+    const merchantName = transfer.fromAddress === jetton.owner ? transfer.toAddress : transfer.fromAddress
+
+    // Skip trash transactions
+    if (Math.abs(sum) < 0.00001) {
+      continue
+    }
+
+    return (
+      {
+        hold: false,
+        date: new Date(transfer.timestamp * 1000),
+        movements: [
+          {
+            id: transfer.transactionId,
+            account: { id: jetton.ownerWithJettonType },
+            sum,
+            fee: 0,
+            invoice: null
+          }
+        ],
+        merchant: {
+          fullTitle: merchantName,
+          mcc: null,
+          location: null
+        },
+        comment: null
+      }
+    )
+  }
+
+  return null
+}

--- a/src/plugins/tonscan/index.ts
+++ b/src/plugins/tonscan/index.ts
@@ -1,10 +1,15 @@
 import { Account, ScrapeFunc, Transaction } from '../../types/zenmoney'
-import { Preferences, tonscanApi } from './api'
+import { Preferences, TonscanApi } from './api'
+import { MAX_RPS } from './config'
 import { convertWalletToAccount, convertJettonToAccount, convertTonTransaction, convertJettonTransfer } from './converters'
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
   const accounts: Account[] = []
   const transactions: Transaction[] = []
+  const tonscanApi = new TonscanApi({
+    baseUrl: 'https://toncenter.com/api/',
+    maxRps: MAX_RPS
+  })
 
   await Promise.all(
     preferences.wallets

--- a/src/plugins/tonscan/index.ts
+++ b/src/plugins/tonscan/index.ts
@@ -1,0 +1,46 @@
+import { Account, ScrapeFunc, Transaction } from '../../types/zenmoney'
+import { Preferences, tonscanApi } from './api'
+import { convertWalletToAccount, convertJettonToAccount, convertTonTransaction, convertJettonTransfer } from './converters'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  const accounts: Account[] = []
+  const transactions: Transaction[] = []
+
+  await Promise.all(
+    preferences.wallets
+      .split(',')
+      .map(walletAddress => walletAddress.trim())
+      .map(async (ownerWalletAddress) => {
+        const [wallet, jettons] = await Promise.all([
+          tonscanApi.fetchWallet(ownerWalletAddress),
+          tonscanApi.fetchJettons(ownerWalletAddress)
+        ])
+
+        const [tonTransactions, jettonsTransfers] = await Promise.all([
+          tonscanApi.fetchTonTransactions(ownerWalletAddress, fromDate, toDate),
+          tonscanApi.fetchJettonsTransfers(jettons, fromDate, toDate)
+        ])
+
+        const walletAccounts: Account[] = [
+          convertWalletToAccount(wallet),
+          ...jettons.map((jetton) => convertJettonToAccount(jetton))
+        ]
+
+        const walletTransactions = tonTransactions
+          .map((transaction) => convertTonTransaction(transaction, wallet))
+          .filter((transaction): transaction is Transaction => transaction !== null)
+
+        const jettonsTransactions = jettonsTransfers
+          .map((transaction) => convertJettonTransfer(transaction, jettons))
+          .filter((transaction): transaction is Transaction => transaction !== null)
+
+        accounts.push(...walletAccounts)
+        transactions.push(...walletTransactions)
+        transactions.push(...jettonsTransactions)
+      }))
+
+  return {
+    accounts,
+    transactions
+  }
+}

--- a/src/plugins/tonscan/mocks/index.ts
+++ b/src/plugins/tonscan/mocks/index.ts
@@ -1,0 +1,125 @@
+import fetchMock from 'fetch-mock'
+import { TonRawTransactions, RawJettonTransfer, AddressBook, RawJettons, RawWallet, Preferences } from '../api'
+
+export const preferencesMock: Preferences = {
+  wallets: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr'
+}
+
+export const walletResponseMock: RawWallet = {
+  balance: 129823563643
+}
+
+export const jettonsResponseMock: RawJettons = {
+  jetton_wallets: [
+    {
+      address: '0:A70DB41F5EB71A6A6B6A5A0B1A033C46F5635F67B25C811B16159204D5844D44',
+      balance: 8000000,
+      jetton: '0:B113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE'
+    },
+    {
+      address: '0:A70DB41F5EB71A6A6B6A5A0B1A033C46F5635F67B25C811B16159204D5811D4C',
+      balance: 8000000,
+      jetton: '0:B113A994B5024A16719F69139328EB759596C38A25F59028T146FECDC3641BFB' // Unsupported jetton, will be filtered out
+    }
+  ]
+}
+
+export const tonTransactionResponseMock: TonRawTransactions = {
+  transactions: [
+    {
+      in_msg: {
+        hash: 'vNoHxFdN+bl3wy7g52Tl3Va7eKM71hDLm64g6haL1fQ=',
+        source: '0:A107678CA051B84E1B84B19E9E86504F2895CE8CDC6547907BA8A64D188BF6E7',
+        destination: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+        value: 46190000000,
+        created_at: 1718810887
+      },
+      out_msgs: [
+        {
+          hash: 'udQ9QJFZl+28cVfny6CiZu8n+AYY7VWszp1uKXMMv04=',
+          source: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+          destination: '0:A107678CA051B84E1B84B19E9E86504F2895CE8CDC6547907BA8A64D188BF6E7',
+          value: 41000000000,
+          created_at: 1718810887
+        }
+      ]
+    },
+    {
+      in_msg: {
+        hash: 'vNoHxFdN+bl3wy7g52TlVVa7eKM71hDLm64g6haL1AQ=',
+        source: '0:A107678CA051B84E1B84B19E9E86504F2895CE8CDC6547907BA8A64D188BF6E7',
+        destination: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+        value: 3500000, // 0.0035 TON < 0.01, will be filtered out
+        created_at: 1718810987
+      },
+      out_msgs: []
+    }
+  ],
+  address_book: {
+    '0:A107678CA051B84E1B84B19E9E86504F2895CE8CDC6547907BA8A64D188BF6E7': { user_friendly: 'EQChB2eMoFG4ThuEsZ6ehlBPKJXOjNxlR5B7qKZNGIv256Da' },
+    '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58': { user_friendly: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr' }
+  }
+}
+
+export const jettonsTransfersResponseMock: RawJettonTransfer = {
+  jetton_transfers: [
+    {
+      transaction_hash: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyQSg=',
+      source: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+      destination: '0:5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5',
+      amount: 10000000,
+      transaction_now: 1718424875
+    },
+    {
+      transaction_hash: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyQSg=',
+      source: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+      destination: '0:5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5',
+      amount: 26790000,
+      transaction_now: 1718424876
+    },
+    {
+      transaction_hash: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyVSB=',
+      source: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+      destination: '0:5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5',
+      amount: 2000, // 0.002 USDT < 0.01, will be filtered out
+      transaction_now: 1718424875
+    }
+  ]
+}
+
+export const jettonsAddressBookResponseMock: AddressBook = {
+  '0:A70DB41F5EB71A6A6B6A5A0B1A033C46F5635F67B25C811B16159204D5844D44': { user_friendly: 'EQCnDbQfXrcaamtqWgsaAzxG9WNfZ7JcgRsWFZIE1YRNRHYY' }
+}
+
+export const addressBookResponseMock: AddressBook = {
+  '0:18AA8E2EED51747DAE033C079B93883D941CAD8F65459F2EE9CD7474B6B8ED5D': { user_friendly: 'EQAYqo4u7VF0fa4DPAebk4g9lBytj2VFny7pzXR0trjtXQaO' },
+  '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58': { user_friendly: 'UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr' },
+  '0:5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5': { user_friendly: 'UQBSJYCMq3Jwu1ItUJJ1nAkcrgPvIzJZY8qpfuPEaB4dxZri' }
+}
+
+export function mockEndPoints (): void {
+  fetchMock.once('https://toncenter.com/api/v3/wallet?address=UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr', {
+    status: 200,
+    body: walletResponseMock
+  })
+  fetchMock.once('https://toncenter.com/api/v3/jetton/wallets?owner_address=UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr', {
+    status: 200,
+    body: jettonsResponseMock
+  })
+  fetchMock.once('https://toncenter.com/api/v3/addressBook?address=0%3AA70DB41F5EB71A6A6B6A5A0B1A033C46F5635F67B25C811B16159204D5844D44', {
+    status: 200,
+    body: jettonsAddressBookResponseMock
+  })
+  fetchMock.once('https://toncenter.com/api/v3/transactions?account=UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr&start_utime=1717185600&end_utime=1718913599&limit=30&offset=0&sort=desc', {
+    status: 200,
+    body: tonTransactionResponseMock
+  })
+  fetchMock.once('https://toncenter.com/api/v3/jetton/transfers?address=UQAgNvaIcIodgH_lFKyS5WQLUKeaZXYVcwBNArOm1h1sWGcr&jetton_master=0%3AB113A994B5024A16719F69139328EB759596C38A25F59028B146FECDC3621DFE&start_utime=1717185600&end_utime=1718913599&limit=50&offset=0&sort=desc', {
+    status: 200,
+    body: jettonsTransfersResponseMock
+  })
+  fetchMock.once('https://toncenter.com/api/v3/addressBook?address=0%3A2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58&address=0%3A5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5', {
+    status: 200,
+    body: addressBookResponseMock
+  })
+}

--- a/src/plugins/tonscan/preferences.xml
+++ b/src/plugins/tonscan/preferences.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="wallets"
+        obligatory="true"
+        title="Wallets address"
+        dialogTitle="Wallets address"
+        dialogMessage="Адреса ваших кошельков (user-friendly form, через запятую)"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|wallets|{@s}"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2022-01-01T00:00:00.000Z"
+        dialogTitle="Дата начала загрузки"
+        dialogMessage="Введите дату, с которой загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
## Description
Added plugin for synchronisation with [tonscan.org](https://tonscan.org/)

For now it supports TON and USDT wallets, but its possible to add support for other tokens(aka jettons).  

## Details
It uses [toncenter v3 api](https://toncenter.com/api/v3) which does not require an api key, but limits you with 1 request per second. In this first version I haven't added support for using users's api key and instead added 1.3s delay between requests, so sync can take from 5-7s to tens of seconds depending on number of your transactions. For example it will take ~25s to sync 3 wallets with usdt jetton in each with in total 72 transactions.  
Later I can add support for custom api key to speed up sync.

### Accounts naming and ids
- Ton account name is its user-friendly address, for example `UQC4anInx16uXqoiYlI0vz0dqiTnC6wGr6lL40L-oyzAyzfo`. Same address is used as account id
- Tokens(jettons) accounts have custom titles from `config.ts`, for example for usdt jetton all accounts titles will be `TON Tether USDT`. For id I used user-friendly jetton address(not master address, but one belonging to owner), so each usdt account will be unique.

### Transactions filters
Transactions with amount < 0.01 are filtered out.

Please note that plugin will sync send/return TON transactions used as gas for jettons transactions.
Here is an example:
1. You send 10 usdt, depending on the wallet it will also create -0.1 TON(up to -0.3) transaction as gas for processing the usdt transaction
2. All unused gas will be returned back as an additional transaction, therefore you can see transactions like +0.09 TON

### Numbers truncating
Zenmoney can store only 2 digits after the point, so transactions like 0.01939348 will be truncated to 0.01 without rounding.

## Questions
1. Do I need to explicitly set some timeout for transactions sync? If wallet has dozens of transaction it can take a while. Or you have some high level timeout for plugins?