### PR TITLE
[raiffeisen-business-rs] Fix handling of transactions with no DebtorCreditorName

### DIFF
--- a/src/plugins/raiffeisen-business-rs/converters.ts
+++ b/src/plugins/raiffeisen-business-rs/converters.ts
@@ -45,7 +45,7 @@ export function convertTransaction (t1: GetAccountTransactionsResponse): Transac
       }
     ],
     merchant: {
-      fullTitle: t1.DebtorCreditorName,
+      fullTitle: t1.DebtorCreditorName ?? t1.Trnben ?? 'Unknown',
       mcc: null,
       location: null
     },

--- a/src/plugins/raiffeisen-business-rs/models.ts
+++ b/src/plugins/raiffeisen-business-rs/models.ts
@@ -80,7 +80,8 @@ export interface GetAccountTransactionsResponse {
   DebitAmount: number
   Description: string | null
   Note: string | null
-  DebtorCreditorName: string
+  DebtorCreditorName: string | null
+  Trnben: string | null
   ValueDate: string
   CurrencyCode: string
   CurrencyCodeNumeric: string


### PR DESCRIPTION
For transactions on foreign currency accounts, the DebtorCreditorName may sometimes be null, causing the convertTransaction function to fail. To address this, the fix implements a fallback mechanism that uses Trnben or defaults to 'Unknown' in these scenarios.