### PR TITLE
Add initial support for Bank of Georgia Business

### DIFF
--- a/src/plugins/bankofgeorgia-business-ge/ZenmoneyManifest.xml
+++ b/src/plugins/bankofgeorgia-business-ge/ZenmoneyManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>bankofgeorgia-business-ge</id>
+    <company>0</company>
+    <description>
+        Synchronization plugin for Bank of Georgia Business.
+        At https://bonline.bog.ge/admin/api/ under API Clients section click "+ ADD NEW",
+        choose "Client Credentials Flow", in API Client name type "ZenMoney integration"
+        and choose Internetbank user.
+
+        You will be prompted with OTP, then you will get Client ID and Client Secret.
+
+        Use these value here.
+    </description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <codeRequired>false</codeRequired>
+</provider>

--- a/src/plugins/bankofgeorgia-business-ge/ZenmoneyManifest.xml
+++ b/src/plugins/bankofgeorgia-business-ge/ZenmoneyManifest.xml
@@ -3,14 +3,20 @@
     <id>bankofgeorgia-business-ge</id>
     <company>0</company>
     <description>
-        Synchronization plugin for Bank of Georgia Business.
-        At https://bonline.bog.ge/admin/api/ under API Clients section click "+ ADD NEW",
-        choose "Client Credentials Flow", in API Client name type "ZenMoney integration"
-        and choose Internetbank user.
+        Bank of Georgia Business Plugin
 
-        You will be prompted with OTP, then you will get Client ID and Client Secret.
+        You to use this integration, you will need Client ID, Client Secret and account number you want to sync (e.g. GE06BG0000000000000000).
 
-        Use these value here.
+        To get Client ID and Client Secret:
+        - Log in at https://bonline.bog.ge/
+        - Visit https://bonline.bog.ge/admin/api/
+        - Find the "API Clients" section
+        - Click "+ ADD NEW"
+        - Select "Client Credentials Flow"
+        - Name it "ZenMoney Integration"
+        - Choose yourself as Internetbank user
+        - Enter the one-time password sent to your device
+        - You'll receive a Client ID and Client Secret
     </description>
     <version>1.0</version>
     <build>1</build>

--- a/src/plugins/bankofgeorgia-business-ge/__tests__/converters/accounts/account.test.ts
+++ b/src/plugins/bankofgeorgia-business-ge/__tests__/converters/accounts/account.test.ts
@@ -1,0 +1,42 @@
+import { convertToZenMoneyAccount } from '../../../converters'
+import { Account } from '../../../models'
+import { AccountType } from '../../../../../types/zenmoney'
+
+describe('convertToZenMoneyAccount', () => {
+  it.each([
+    [
+      {
+        id: 'GE29TB7903145061700002USD',
+        currency: 'USD',
+        number: 'GE29TB7903145061700002',
+        balance: 1234.56
+      },
+      {
+        id: 'GE29TB7903145061700002USD',
+        type: AccountType.checking,
+        title: 'BoG Business USD',
+        instrument: 'USD',
+        syncIds: ['GE29TB7903145061700002USD'],
+        balance: 1234.56
+      }
+    ],
+    [
+      {
+        id: 'GE61TB7903145061700001GEL',
+        number: 'GE61TB7903145061700001',
+        currency: 'GEL',
+        balance: 3456.78
+      },
+      {
+        id: 'GE61TB7903145061700001GEL',
+        type: AccountType.checking,
+        title: 'BoG Business GEL',
+        instrument: 'GEL',
+        syncIds: ['GE61TB7903145061700001GEL'],
+        balance: 3456.78
+      }
+    ]
+  ])('converts account', (apiAccount, expectedAccount) => {
+    expect(convertToZenMoneyAccount(apiAccount as Account)).toEqual(expectedAccount)
+  })
+})

--- a/src/plugins/bankofgeorgia-business-ge/__tests__/converters/transactions/transaction.test.ts
+++ b/src/plugins/bankofgeorgia-business-ge/__tests__/converters/transactions/transaction.test.ts
@@ -1,0 +1,311 @@
+import { convertToZenMoneyTransaction } from '../../../converters'
+import { AccountRecord } from '../../../models'
+import { AccountType } from '../../../../../types/zenmoney'
+
+describe('convertToZenMoneyTransaction', () => {
+  it.each([
+    ['outgoing transfer', {
+      Currency: 'GEL',
+      AccountID: 'GE00BG0000000000000000GEL',
+      EntryDate: '2023-01-01T00:00:00',
+      EntryDocumentNumber: '0001',
+      EntryAccountNumber: '00000000000000000000',
+      EntryAmountDebit: 100.0,
+      EntryAmountDebitBase: 100.0,
+      EntryAmountCredit: 0.0,
+      EntryAmountBase: 100.0,
+      EntryAmount: -100.0,
+      EntryComment: 'Tax Payment',
+      EntryDepartment: 'DEPT00',
+      EntryAccountPoint: 'BANK',
+      DocumentProductGroup: 'PMD',
+      DocumentValueDate: '2023-01-01T00:00:00',
+      SenderDetails: {
+        Name: 'COMPANY NAME LLC',
+        Inn: '000000000',
+        AccountNumber: 'GE00BG0000000000000000GEL',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      BeneficiaryDetails: {
+        Name: 'TAX DEPARTMENT',
+        AccountNumber: '000000000',
+        BankCode: 'TRESGE22',
+        BankName: 'STATE TREASURY'
+      },
+      DocumentTreasuryCode: '000000000',
+      DocumentNomination: 'Tax Payment',
+      DocumentInformation: 'Tax Payment',
+      DocumentSourceAmount: 100.0,
+      DocumentSourceCurrency: 'GEL',
+      DocumentDestinationAmount: 100.0,
+      DocumentDestinationCurrency: 'GEL',
+      DocumentReceiveDate: '2023-01-01T00:00:00',
+      DocumentBranch: '000',
+      DocumentDepartment: 'DEPT00',
+      DocumentActualDate: '2023-01-01T00:00:00',
+      DocumentCorrespondentAccountNumber: '000000000',
+      DocumentCorrespondentBankCode: 'TRESGE22',
+      DocumentCorrespondentBankName: 'STATE TREASURY',
+      DocumentKey: '00000000000.0',
+      EntryId: '12300000000.0',
+      DocumentPayerName: 'COMPANY NAME LLC',
+      DocumentPayerInn: '000000000',
+      DocComment: 'TAX DEPARTMENT 000000000: 000000000 STATE TREASURY TRESGE22'
+    }, {
+      hold: false,
+      date: new Date('2023-01-01T00:00:00'),
+      movements: [
+        {
+          id: '12300000000.0',
+          account: { id: 'GE00BG0000000000000000GEL' },
+          sum: -100,
+          fee: 0,
+          invoice: null
+        },
+        {
+          id: null,
+          account: {
+            type: AccountType.checking,
+            instrument: 'GEL',
+            company: { id: 'TAX DEPARTMENT' },
+            syncIds: ['000000000']
+          },
+          sum: 100,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: {
+        country: null,
+        city: null,
+        title: 'TAX DEPARTMENT',
+        mcc: null,
+        location: null
+      },
+      comment: 'Tax Payment'
+    }],
+
+    ['incoming transfer', {
+      Currency: 'USD',
+      AccountID: 'GE00BG0000000000000000USD',
+      EntryDate: '2023-01-02T00:00:00',
+      EntryDocumentNumber: 'PMI000000000',
+      EntryAccountNumber: 'GE00BG0000000000000001USD',
+      EntryAmountDebit: 0.0,
+      EntryAmountCredit: 100.0,
+      EntryAmountCreditBase: 250.0,
+      EntryAmountBase: 250.0,
+      EntryAmount: 100.0,
+      EntryComment: 'Transfer',
+      EntryDepartment: 'DEPT00',
+      EntryAccountPoint: 'BRANCH00',
+      DocumentProductGroup: 'PMI',
+      DocumentValueDate: '2023-01-02T00:00:00',
+      SenderDetails: {
+        Name: 'JOHN DOE',
+        Inn: '000000000',
+        AccountNumber: 'GE00BG0000000000000001USD',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      BeneficiaryDetails: {
+        Name: 'COMPANY NAME LLC',
+        Inn: '000000000',
+        AccountNumber: 'GE00BG0000000000000000USD',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      DocumentNomination: 'Transfer',
+      DocumentInformation: 'Transfer',
+      DocumentSourceAmount: 100.0,
+      DocumentSourceCurrency: 'USD',
+      DocumentDestinationAmount: 100.0,
+      DocumentDestinationCurrency: 'USD',
+      DocumentReceiveDate: '2023-01-02T00:00:00',
+      DocumentBranch: '000',
+      DocumentDepartment: 'DEPT00',
+      DocumentCorrespondentAccountNumber: 'GE00BG0000000000000001USD',
+      DocumentCorrespondentBankCode: 'BANKGE22',
+      DocumentCorrespondentBankName: 'BANK OF GEORGIA',
+      DocumentKey: '00000000000.0',
+      EntryId: '43200000000.0',
+      DocumentPayerName: 'JOHN DOE',
+      DocumentPayerInn: '000000000',
+      DocComment: 'JOHN DOE GE00BG0000000000000001USD BANK OF GEORGIA BANKGE22'
+    }, {
+      hold: false,
+      date: new Date('2023-01-02T00:00:00'),
+      movements: [
+        {
+          id: '43200000000.0',
+          account: { id: 'GE00BG0000000000000000USD' },
+          sum: 100,
+          invoice: null,
+          fee: 0
+        },
+        {
+          id: null,
+          account: {
+            type: AccountType.checking,
+            instrument: 'USD',
+            company: { id: 'JOHN DOE' },
+            syncIds: ['GE00BG0000000000000001USD']
+          },
+          invoice: null,
+          sum: -100,
+          fee: 0
+        }
+      ],
+      merchant: {
+        country: null,
+        city: null,
+        title: 'COMPANY NAME LLC',
+        mcc: null,
+        location: null
+      },
+      comment: 'Transfer'
+    }],
+
+    ['exchange', {
+      Currency: 'GEL',
+      AccountID: 'GE00BG0000000000000000GEL',
+      EntryDate: '2023-01-03T00:00:00',
+      EntryDocumentNumber: '0000000000000000',
+      EntryAccountNumber: '00000000000000000000',
+      EntryAmountDebit: 0.0,
+      EntryAmountCredit: 100.0,
+      EntryAmountCreditBase: 100.0,
+      EntryAmountBase: 100.0,
+      EntryAmount: 100.0,
+      EntryComment: 'Currency exchange. Rate: 2.500 Counter amount: USD40.00. Conversion',
+      EntryDepartment: 'DEPT00',
+      EntryAccountPoint: 'BRANCH00',
+      DocumentProductGroup: 'CCO',
+      SenderDetails: {
+        Name: 'COMPANY NAME LLC',
+        Inn: '000000000',
+        AccountNumber: 'GE00BG0000000000000000USD',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      BeneficiaryDetails: {
+        Name: 'COMPANY NAME LLC',
+        Inn: '000000000',
+        AccountNumber: 'GE00BG0000000000000000GEL',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      DocumentNomination: 'Conversion',
+      DocumentInformation: 'Conversion',
+      DocumentSourceAmount: 100.0,
+      DocumentSourceCurrency: 'GEL',
+      DocumentDestinationAmount: 40.00,
+      DocumentDestinationCurrency: 'USD',
+      DocumentReceiveDate: '2023-01-03T00:00:00',
+      DocumentBranch: '000',
+      DocumentDepartment: 'DEPT00',
+      DocumentActualDate: '2023-01-03T00:00:00',
+      DocumentExpiryDate: '2023-01-13T00:00:00',
+      DocumentRateLimit: 2.500,
+      DocumentRate: 2.500,
+      DocumentRegistrationRate: 2.500,
+      DocumentCorrespondentAccountNumber: 'GE00BG0000000000000000USD',
+      DocumentCorrespondentBankCode: 'BANKGE22',
+      DocumentCorrespondentBankName: 'BANK OF GEORGIA',
+      DocumentKey: '00000000000.0',
+      EntryId: '00000000000.0'
+    }, {
+      hold: false,
+      date: new Date('2023-01-03T00:00:00'),
+      movements: [
+        {
+          id: '00000000000.0',
+          account: { id: 'GE00BG0000000000000000GEL' },
+          sum: 100,
+          fee: 0,
+          invoice: null
+        },
+        {
+          id: null,
+          account: { id: 'GE00BG0000000000000000USD' },
+          sum: -40,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: {
+        country: null,
+        city: null,
+        title: 'COMPANY NAME LLC',
+        mcc: null,
+        location: null
+      },
+      comment: 'Curren' +
+        'cy exchange. Rate: 2.500 Counter amount: USD40.00. Conversion'
+    }],
+
+    ['fee', {
+      Currency: 'GEL',
+      AccountID: 'GE00BG0000000000000000GEL',
+      EntryDate: '2023-01-04T00:00:00',
+      EntryDocumentNumber: 'FEE',
+      EntryAccountNumber: '00000000000000000000',
+      EntryAmountDebit: 5.0,
+      EntryAmountDebitBase: 5.0,
+      EntryAmountCredit: 0.0,
+      EntryAmountBase: 5.0,
+      EntryAmount: -5.0,
+      EntryComment: 'Business package service fee',
+      EntryDepartment: 'DEPT00',
+      EntryAccountPoint: 'BRANCH00',
+      DocumentProductGroup: 'FEE',
+      DocumentValueDate: '2023-01-04T00:00:00',
+      SenderDetails: {
+        Name: 'COMPANY NAME LLC',
+        Inn: '000000000',
+        AccountNumber: 'GE00BG0000000000000000GEL',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      BeneficiaryDetails: {
+        Name: '',
+        AccountNumber: '00000000000000000000',
+        BankCode: 'BANKGE22',
+        BankName: 'BANK OF GEORGIA'
+      },
+      DocumentNomination: 'Business package service fee',
+      DocumentInformation: 'Business package service fee',
+      DocumentSourceAmount: 5.0,
+      DocumentSourceCurrency: 'GEL',
+      DocumentDestinationAmount: 5.0,
+      DocumentDestinationCurrency: 'GEL',
+      DocumentReceiveDate: '2023-01-05T00:00:00',
+      DocumentBranch: '000',
+      DocumentDepartment: 'DEPT00',
+      DocumentCorrespondentAccountNumber: '00000000000000000000',
+      DocumentCorrespondentBankCode: 'BANKGE22',
+      DocumentCorrespondentBankName: 'BANK OF GEORGIA',
+      DocumentKey: '00000000000.0',
+      EntryId: '98700000000.0',
+      DocumentPayerName: 'COMPANY NAME LLC',
+      DocumentPayerInn: '000000000'
+    }, {
+      hold: false,
+      date: new Date('2023-01-04T00:00:00'),
+      movements: [
+        {
+          id: '98700000000.0',
+          account: { id: 'GE00BG0000000000000000GEL' },
+          sum: 0,
+          fee: 5,
+          invoice: null
+        }
+      ],
+      merchant: { city: null, country: null, location: null, title: '', mcc: null },
+      comment: 'Business package service fee'
+    }]
+  ])('converts %s', (_, accountRecord, expectedTransaction) => {
+    expect(convertToZenMoneyTransaction(accountRecord as AccountRecord, [accountRecord as AccountRecord])).toEqual(expectedTransaction)
+  })
+})

--- a/src/plugins/bankofgeorgia-business-ge/api.ts
+++ b/src/plugins/bankofgeorgia-business-ge/api.ts
@@ -1,0 +1,69 @@
+import { fetchToken, fetchAccountStatement, fetchAccountBalance } from './fetchApi'
+import { Preferences, StatementResponse, Account, BalanceResponse } from './models'
+
+const CURRENCIES = ['GEL', 'USD', 'EUR']
+
+async function getAccessToken (preferences: Preferences): Promise<string> {
+  let accessToken = ZenMoney.getData('accessToken') as string | undefined
+  let tokenExpiry = ZenMoney.getData('tokenExpiry') as string | undefined
+
+  if ((accessToken == null) || (tokenExpiry == null) || new Date() >= new Date(tokenExpiry)) {
+    const authResponse = await fetchToken(preferences.clientId, preferences.clientSecret)
+    accessToken = authResponse.access_token
+    tokenExpiry = new Date(Date.now() + authResponse.expires_in * 1000).toISOString()
+    ZenMoney.setData('accessToken', accessToken)
+    ZenMoney.setData('tokenExpiry', tokenExpiry)
+    ZenMoney.saveData()
+  }
+
+  return accessToken
+}
+
+export function parseAccounts (preferences: Preferences): Account[] {
+  const accountStrings = preferences.accounts.split(',').map(acc => acc.trim())
+  const accounts: Account[] = []
+
+  for (const accountString of accountStrings) {
+    const accountCurrency = accountString.slice(-3)
+    const includesCurrency = CURRENCIES.includes(accountCurrency)
+    if (includesCurrency) {
+      accounts.push({
+        id: accountString,
+        number: accountString.slice(0, -3),
+        currency: accountCurrency
+      })
+    } else {
+      for (const currency of CURRENCIES) {
+        accounts.push({
+          id: accountString + currency,
+          number: accountString,
+          currency
+        })
+      }
+    }
+  }
+
+  return accounts
+}
+
+function formatDate (date: Date): string {
+  return date.toISOString().split('T')[0]
+}
+
+export async function fetchTransactions (
+  preferences: Preferences,
+  account: Account,
+  fromDate: Date,
+  toDate: Date
+): Promise<StatementResponse> {
+  const accessToken = await getAccessToken(preferences)
+  return await fetchAccountStatement(accessToken, account.number, account.currency, formatDate(fromDate), formatDate(toDate))
+}
+
+export async function fetchBalance (
+  preferences: Preferences,
+  account: Account
+): Promise<BalanceResponse> {
+  const accessToken = await getAccessToken(preferences)
+  return await fetchAccountBalance(accessToken, account.number, account.currency)
+}

--- a/src/plugins/bankofgeorgia-business-ge/converters.ts
+++ b/src/plugins/bankofgeorgia-business-ge/converters.ts
@@ -1,0 +1,136 @@
+import { Account as ZenMoneyAccount, AccountType, Transaction as ZenMoneyTransaction, Movement as TransactionMovement } from '../../types/zenmoney'
+import { Account, AccountRecord, Record } from './models'
+
+export function convertToZenMoneyAccount (account: Account): ZenMoneyAccount {
+  return {
+    id: account.id,
+    type: AccountType.checking,
+    title: `BoG Business ${account.currency}`,
+    instrument: account.currency,
+    syncIds: [account.id],
+    balance: account.balance
+  }
+}
+
+function createMovement (record: AccountRecord, sum: number, fee = 0): TransactionMovement {
+  return {
+    id: record.EntryId.toString(),
+    account: { id: record.AccountID },
+    sum,
+    fee,
+    invoice: null
+  }
+}
+
+function createCounterpartyMovement (record: AccountRecord, sum: number, fee = 0, receiving = false): TransactionMovement {
+  const counterparty = receiving ? record.SenderDetails : record.BeneficiaryDetails
+  return {
+    id: null,
+    account: {
+      type: AccountType.checking,
+      instrument: record.DocumentDestinationCurrency,
+      company: { id: counterparty.Name },
+      syncIds: [counterparty.AccountNumber]
+    },
+    sum,
+    fee,
+    invoice: null
+  }
+}
+
+function addMatchingConversion (record: AccountRecord, transaction: ZenMoneyTransaction, allRecords: AccountRecord[]): void {
+  const matchingRecord = allRecords.find(r =>
+    r.DocumentProductGroup === 'PLC' &&
+    r.AccountID !== record.AccountID &&
+    r.EntryDate === record.EntryDate &&
+    r.DocumentNomination === record.DocumentNomination
+  )
+  if (matchingRecord) {
+    transaction.movements.push(createMovement(matchingRecord, matchingRecord.EntryAmount))
+  }
+}
+export function convertToZenMoneyTransaction (record: AccountRecord, allRecords: AccountRecord[]): ZenMoneyTransaction {
+  const mccMatch = record.EntryComment.match(/MCC:\s*(\d{4})/)
+
+  let mcc: number | null = null
+  if ((mccMatch?.[1]) != null) {
+    mcc = parseInt(mccMatch[1])
+  }
+
+  const transaction: ZenMoneyTransaction = {
+    hold: false,
+    date: new Date(record.EntryDate),
+    movements: [createMovement(record, record.EntryAmount)],
+    merchant: { city: null, country: null, mcc, title: record.BeneficiaryDetails.Name, location: null },
+    comment: record.EntryComment
+  }
+
+  switch (record.DocumentProductGroup) {
+    case 'PMI':
+      if (record.EntryAmount < 0) {
+        // bank transfer outgoing
+        transaction.movements.push(
+          createCounterpartyMovement(record, record.EntryAmountDebit)
+        )
+      } else {
+        // bank transfer incoming
+        const movements = [
+          createCounterpartyMovement(record, -record.EntryAmount, 0, true)
+        ]
+        transaction.movements.push(...movements)
+      }
+      break
+
+    case 'CCO':
+      // currency exchange between accounts
+      transaction.movements.push(
+        {
+          id: null,
+          account: {
+            id: record.BeneficiaryDetails.AccountNumber !== record.AccountID
+              ? record.BeneficiaryDetails.AccountNumber
+              : record.SenderDetails.AccountNumber
+          },
+          sum: record.EntryAmount !== -record.DocumentDestinationAmount
+            ? -record.DocumentDestinationAmount
+            : record.DocumentSourceAmount,
+          fee: 0,
+          invoice: null
+        }
+      )
+      break
+
+    case 'COM':
+    case 'FEE':
+      // commission or fee
+      transaction.movements[0].fee = (transaction.movements[0].sum != null) ? -transaction.movements[0].sum : 0
+      transaction.movements[0].sum = 0
+      break
+
+    case 'PMD': // outgoing transfer (for example to treasury)
+      transaction.movements.push(
+        createCounterpartyMovement(record, record.EntryAmountDebit)
+      )
+      break
+
+    case 'TRN': // card payment
+      break
+
+    case 'PLC': // automatic currency conversion
+      addMatchingConversion(record, transaction, allRecords)
+      break
+
+    default:
+      throw new Error(`Unknown DocumentProductGroup: ${record.DocumentProductGroup}`)
+  }
+
+  return transaction
+}
+
+export function injectAccountInfo (records: Record[], account: Account): AccountRecord[] {
+  return records.map(record => ({
+    ...record,
+    Currency: account.currency,
+    AccountID: account.id
+  }))
+}

--- a/src/plugins/bankofgeorgia-business-ge/fetchApi.ts
+++ b/src/plugins/bankofgeorgia-business-ge/fetchApi.ts
@@ -1,0 +1,70 @@
+import { fetchJson } from '../../common/network'
+import { AuthResponse, BalanceResponse, StatementResponse } from './models'
+import { TemporaryError, InvalidPreferencesError } from '../../errors'
+import { stringify } from 'querystring'
+
+const BASE_URL = 'https://api.businessonline.ge/api'
+const TOKEN_URL = 'https://account.bog.ge/auth/realms/bog/protocol/openid-connect/token'
+
+export async function fetchToken (clientId: string, clientSecret: string): Promise<AuthResponse> {
+  const response = await fetchJson(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: {
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret
+    },
+    stringify,
+    sanitizeRequestLog: { body: { client_id: true, client_secret: true } }
+  })
+
+  if (response.status !== 200) {
+    throw new InvalidPreferencesError('Unable to authorize using provided client credentials')
+  }
+
+  return response.body as AuthResponse
+}
+
+export async function fetchAccountStatement (
+  accessToken: string,
+  accountNumber: string,
+  currency: string,
+  startDate: string,
+  endDate: string
+): Promise<StatementResponse> {
+  const url = `${BASE_URL}/statement/${accountNumber}/${currency}/${startDate}/${endDate}`
+
+  const headers = { Authorization: `Bearer ${accessToken}` }
+
+  const response = await fetchJson(url, {
+    method: 'GET',
+    headers
+  })
+
+  if (response.status !== 200) {
+    throw new TemporaryError(`API responded with unexpected status ${response.status}`)
+  }
+
+  return response.body as StatementResponse
+}
+
+export async function fetchAccountBalance (
+  accessToken: string,
+  accountNumber: string,
+  currency: string
+): Promise<BalanceResponse> {
+  const url = `${BASE_URL}/accounts/${accountNumber}/${currency}`
+  const headers = { Authorization: `Bearer ${accessToken}` }
+
+  const response = await fetchJson(url, {
+    method: 'GET',
+    headers
+  })
+
+  if (response.status !== 200) {
+    throw new TemporaryError(`API responded with unexpected status ${response.status}`)
+  }
+
+  return response.body as BalanceResponse
+}

--- a/src/plugins/bankofgeorgia-business-ge/index.ts
+++ b/src/plugins/bankofgeorgia-business-ge/index.ts
@@ -1,0 +1,37 @@
+import { ScrapeFunc, Account as ZenMoneyAccount, Transaction as ZenMoneyTransaction } from '../../types/zenmoney'
+import { parseAccounts, fetchTransactions, fetchBalance } from './api'
+import { convertToZenMoneyAccount, convertToZenMoneyTransaction, injectAccountInfo } from './converters'
+import { AccountRecord, Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  toDate = toDate ?? new Date()
+
+  const accounts = parseAccounts(preferences)
+  const zenAccounts: ZenMoneyAccount[] = []
+
+  let records: AccountRecord[] = []
+
+  for (const account of accounts) {
+    if (ZenMoney.isAccountSkipped(account.id)) {
+      continue
+    }
+
+    const balanceResponse = await fetchBalance(preferences, account)
+    account.balance = balanceResponse.CurrentBalance
+    zenAccounts.push(convertToZenMoneyAccount(account))
+
+    const statement = await fetchTransactions(preferences, account, fromDate, toDate)
+    const accountRecords = injectAccountInfo(statement.Records, account)
+    records = records.concat(accountRecords)
+  }
+
+  const zenTransactions: ZenMoneyTransaction[] = []
+  for (const record of records) {
+    zenTransactions.push(convertToZenMoneyTransaction(record, records))
+  }
+
+  return {
+    accounts: zenAccounts,
+    transactions: zenTransactions
+  }
+}

--- a/src/plugins/bankofgeorgia-business-ge/models.ts
+++ b/src/plugins/bankofgeorgia-business-ge/models.ts
@@ -1,0 +1,99 @@
+export interface Preferences {
+  clientId: string
+  clientSecret: string
+  accounts: string
+  startDate: string
+}
+
+export interface Account {
+  id: string
+  number: string
+  currency: string
+  balance?: number
+}
+
+export interface AuthResponse {
+  access_token: string
+  expires_in: number
+  refresh_expires_in: number
+  token_type: string
+  not_before_policy?: number
+  scope: string
+}
+
+export interface SenderDetails {
+  Name: string
+  Inn?: string
+  AccountNumber: string
+  BankCode?: string
+  BankName?: string
+}
+
+export interface BeneficiaryDetails {
+  Name: string
+  Inn?: string
+  AccountNumber: string
+  BankCode?: string
+  BankName?: string
+}
+
+export interface Record {
+  EntryDate: string
+  EntryDocumentNumber: string
+  EntryAccountNumber: string
+  EntryAmountDebit: number
+  EntryAmountDebitBase?: number
+  EntryAmountCredit: number
+  EntryAmountCreditBase?: number
+  EntryAmountBase: number
+  EntryAmount: number
+  EntryComment: string
+  EntryDepartment: string
+  EntryAccountPoint: string
+  DocumentProductGroup: string
+  DocumentValueDate?: string
+  SenderDetails: SenderDetails
+  BeneficiaryDetails: BeneficiaryDetails
+  DocumentTreasuryCode?: string
+  DocumentNomination: string
+  DocumentInformation: string
+  DocumentSourceAmount: number
+  DocumentSourceCurrency: string
+  DocumentDestinationAmount: number
+  DocumentDestinationCurrency: string
+  DocumentReceiveDate: string
+  DocumentBranch: string
+  DocumentDepartment: string
+  DocumentActualDate?: string
+  DocumentExpiryDate?: string
+  DocumentRateLimit?: number
+  DocumentRate?: number
+  DocumentRegistrationRate?: number
+  DocumentSenderInstitution?: string
+  DocumentIntermediaryInstitution?: string
+  DocumentBeneficiaryInstitution?: string
+  DocumentPayee?: string
+  DocumentCorrespondentAccountNumber: string
+  DocumentCorrespondentBankCode?: string
+  DocumentCorrespondentBankName?: string
+  DocumentKey: string
+  EntryId: string
+  DocumentPayerName?: string
+  DocumentPayerInn?: string
+  DocComment?: string
+}
+export interface AccountRecord extends Record {
+  Currency: string
+  AccountID: string
+}
+
+export interface StatementResponse {
+  Id: number
+  Count: number
+  Records: Record[]
+}
+
+export interface BalanceResponse {
+  AvailableBalance: number
+  CurrentBalance: number
+}

--- a/src/plugins/bankofgeorgia-business-ge/preferences.xml
+++ b/src/plugins/bankofgeorgia-business-ge/preferences.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="clientId"
+        obligatory="true"
+        title="Client ID"
+        dialogTitle="Client ID"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="||{@s}"
+    />
+    <EditTextPreference
+        key="clientSecret"
+        obligatory="true"
+        inputType="textPassword"
+        title="Client Secret"
+        dialogTitle="Client Secret"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="||***********"
+    />
+    <EditTextPreference
+        key="accounts"
+        obligatory="true"
+        title="Accounts"
+        dialogTitle="Accounts"
+        dialogMessage="Enter your account numbers separated by commas (e.g., GE06BG0000000538407835,GE06BG0000000538407836GEL)"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="||{@s}"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="From what date to load transactions"
+        defaultValue="2018-01-01T00:00:00.000Z"
+        dialogTitle="From what date to load transactions"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
# Add Bank of Georgia Business Plugin
Following up on #756.

During the development, I discovered there's an official API for BoG Business customers.

Hopefully, with these changes transactions from BoG Business will be automatically linked with individual BoG transactions.

## Features
- Auth with Client ID and Client Secret from official API
- Transaction syncing with the following types:
  - Card payments (with MCC parsing)
  - Outgoing transfers
  - Incoming transfers
  - Currency exchanges
  - Automatic conversions
  - Fees
- Balance fetching for accounts

## Testing

The plugin has been tested with data from my BoG Business account.

There are also some test cases with mock data, although they don't cover all cases and plugin functionality.

