### PR TITLE
[tbc-ge] Loan percent should always be numeric value, add default

### DIFF
--- a/src/ZPAPI.js
+++ b/src/ZPAPI.js
@@ -272,7 +272,7 @@ function ZPAPI ({ manifest, preferences, data }) {
         account.payoffInterval = castInterval(account.payoffInterval)
         account.endDateOffsetInterval = castInterval(account.endDateOffsetInterval)
 
-        if ((account.percent !== null && typeof account.percent !== 'number') ||
+        if (typeof account.percent !== 'number' ||
                     typeof account.capitalization !== 'boolean' ||
                     typeof account.endDateOffset !== 'number' ||
                     typeof account.payoffStep !== 'number' ||

--- a/src/plugins/tbc-ge/converters.ts
+++ b/src/plugins/tbc-ge/converters.ts
@@ -130,7 +130,7 @@ export function convertLoansV2 (apiLoans: LoanProductV2[]): PreparedLoanV2[] {
         startDate,
         startBalance: apiLoan.totalLoanAmount,
         capitalization: true,
-        percent: null,
+        percent: 0, // TBC API does not return interest rate for loans but it is required
         endDateOffsetInterval,
         endDateOffset,
         payoffInterval: 'month',


### PR DESCRIPTION
Sync failed because of of loan percent being null. Unfortunately changes from #759 was a little misleading. It looked like now ZPAPI.js allows it to be null, but it's not. It is safe to use just default 0 value in converter.