### PR TITLE
[tbc-ge] currency auto-conversion counts as an income

### DIFF
--- a/src/plugins/tbc-ge/__tests__/convertersV2/transactions/currencyExchange.test.ts
+++ b/src/plugins/tbc-ge/__tests__/convertersV2/transactions/currencyExchange.test.ts
@@ -1,0 +1,62 @@
+import { convertTransactionsV2 } from '../../../converters'
+import { FetchHistoryV2Data, TransactionsByDateV2 } from '../../../models'
+import { Account, ExtendedTransaction } from '../../../../../types/zenmoney'
+import { creditCardEurV2 } from '../../../common-tests/accountsV2'
+import { TransactionRecordV2Class } from '../../../common-tests/classes'
+
+describe('currency convertion transactions', () => {
+  const eurTransfer: [TransactionsByDateV2, ExtendedTransaction, Account] = [
+    {
+      date: new Date('2024-10-11T20:00:00.000Z').getTime(),
+      transactions:
+        [
+          TransactionRecordV2Class.standard(
+            'კონვერტაცია',
+            'internal transfer',
+            -0.95,
+            'EUR',
+            13822643871,
+            818399447,
+            'd_13822643871',
+            'PAYMENTS',
+            'PAYMENTS',
+            5
+          )
+        ]
+    },
+    {
+      comment: 'კონვერტაცია',
+      date: new Date('2024-10-11T20:00:00.000Z'),
+      hold: false,
+      merchant: null,
+      movements: [
+        {
+          account: {
+            id: creditCardEurV2.id
+          },
+          fee: 0,
+          id: 'd_13822643871',
+          invoice: null,
+          sum: -0.95
+        }
+      ],
+      groupKeys: ['13822643871', 'კონვერტაცია']
+    },
+    creditCardEurV2
+  ]
+  const suite: Array<[TransactionsByDateV2, ExtendedTransaction, Account]> = [
+    eurTransfer
+  ]
+
+  it.each(suite)('should have correct groupKeys', (transactions, transaction, account) => {
+    const historyData: FetchHistoryV2Data = {
+      account,
+      currency: account.instrument,
+      iban: account.syncIds[0],
+      id: account.id
+    }
+
+    const date = new Date(transactions.date - 1000 * 60 * 60 * 24)
+    expect(convertTransactionsV2([transactions], date, historyData)).toEqual([transaction])
+  })
+})

--- a/src/plugins/tbc-ge/__tests__/convertersV2/transactions/currencyExchangeAdjust.test.ts
+++ b/src/plugins/tbc-ge/__tests__/convertersV2/transactions/currencyExchangeAdjust.test.ts
@@ -1,0 +1,131 @@
+import { ExtendedTransaction } from '../../../../../types/zenmoney'
+import { creditCardEurV2, creditCardUsdV2 } from '../../../common-tests/accountsV2'
+import { adjustTransactions } from '../../../../../common/transactionGroupHandler'
+
+describe('transactions with currency conversion', () => {
+  const eurTransfer: [ExtendedTransaction[], ExtendedTransaction[]] = [
+    [{
+      comment: 'კონვერტაცია',
+      date: new Date('2024-10-11T20:00:00.000Z'),
+      hold: false,
+      merchant: null,
+      movements: [
+        {
+          account: {
+            id: creditCardUsdV2.id
+          },
+          fee: 0,
+          id: 'c_13822643871',
+          invoice: null,
+          sum: 1.01
+        }
+      ],
+      groupKeys: ['13822643871', 'კონვერტაცია']
+    },
+    {
+      comment: 'კონვერტაცია',
+      date: new Date('2024-10-11T20:00:00.000Z'),
+      hold: false,
+      merchant: null,
+      movements: [
+        {
+          account: {
+            id: creditCardEurV2.id
+          },
+          fee: 0,
+          id: 'd_13822643871',
+          invoice: null,
+          sum: -0.95
+        }
+      ],
+      groupKeys: ['13822643871', 'კონვერტაცია']
+    },
+    {
+      comment: null,
+      date: new Date('2024-10-11T20:00:00.000Z'),
+      hold: false,
+      merchant: {
+        title: '216 - C MARKET 485',
+        mcc: 5331,
+        country: null,
+        city: null,
+        location: null
+      },
+      movements: [
+        {
+          account: {
+            id: creditCardUsdV2.id
+          },
+          fee: 0,
+          id: 'd_13822636279',
+          invoice: {
+            sum: -103.98,
+            instrument: 'RSD'
+          },
+          sum: -1.01
+        }
+      ]
+    }],
+    [{
+      comment: 'კონვერტაცია',
+      date: new Date('2024-10-11T20:00:00.000Z'),
+      hold: false,
+      merchant: null,
+      movements: [
+        {
+          account: {
+            id: creditCardEurV2.id
+          },
+          fee: 0,
+          id: 'd_13822643871',
+          invoice: null,
+          sum: -0.95
+        },
+        {
+          account: {
+            id: creditCardUsdV2.id
+          },
+          fee: 0,
+          id: 'c_13822643871',
+          invoice: null,
+          sum: 1.01
+        }
+      ]
+    },
+    {
+      comment: null,
+      date: new Date('2024-10-11T20:00:00.000Z'),
+      hold: false,
+      merchant: {
+        title: '216 - C MARKET 485',
+        mcc: 5331,
+        country: null,
+        city: null,
+        location: null
+      },
+      movements: [
+        {
+          account: {
+            id: creditCardUsdV2.id
+          },
+          fee: 0,
+          id: 'd_13822636279',
+          invoice: {
+            sum: -103.98,
+            instrument: 'RSD'
+          },
+          sum: -1.01
+        }
+      ]
+    }]
+  ]
+  const suite: Array<[ExtendedTransaction[], ExtendedTransaction[]]> = [
+    eurTransfer // autoconvert EUR->USD and buy in RSD
+  ]
+
+  it.each(suite)('should merge convertion into one operation', (transactionsToAdjust, adjustedTransactionsExpected) => {
+    const adjustedTransactions = adjustTransactions({ transactions: transactionsToAdjust })
+
+    expect(adjustedTransactions).toEqual(adjustedTransactionsExpected)
+  })
+})

--- a/src/plugins/tbc-ge/common-tests/accountsV2.ts
+++ b/src/plugins/tbc-ge/common-tests/accountsV2.ts
@@ -21,3 +21,14 @@ export const creditCardUsdV2: Account = {
   title: 'My Account',
   type: AccountType.ccard
 }
+
+export const creditCardEurV2: Account = {
+  balance: 48.48,
+  id: '10FAKE-EUR36',
+  instrument: 'EUR',
+  syncIds: [
+    'GE00TB0000000001111002'
+  ],
+  title: 'My Account',
+  type: AccountType.ccard
+}

--- a/src/plugins/tbc-ge/converters.ts
+++ b/src/plugins/tbc-ge/converters.ts
@@ -156,6 +156,7 @@ export function convertTransactionsV2 (transactionRecordsByDate: TransactionsByD
       let invoice: Amount | null = null
       let id: string | null = null
       let dateNum: number | null = null
+      let groupKeys: string[] = []
       try {
         if (transactionRecord.entryType === 'BlockedTransaction') {
           const blockedTransaction = new TransactionBlockedV2(transactionRecord, transactionRecords.date)
@@ -180,6 +181,10 @@ export function convertTransactionsV2 (transactionRecordsByDate: TransactionsByD
             const transfer = new TransactionTransferV2(transactionRecord)
             comment = transfer.transaction.title
             merchant = null
+            groupKeys = [
+              transactionRecord.transactionId.toString(),
+              transactionRecord.title
+            ]
           } else if (TransactionUtilPayV2.isUtilPay(transactionRecord)) {
             const utilPayV2 = new TransactionUtilPayV2(transactionRecord)
             id = transactionRecord.movementId!
@@ -271,7 +276,7 @@ export function convertTransactionsV2 (transactionRecordsByDate: TransactionsByD
         movements,
         merchant,
         comment,
-        groupKeys: []
+        groupKeys
       }
       transactions.push(transaction)
     }


### PR DESCRIPTION
This introduces groupKeys usage in transfers, so transactions with the same `transactionId` and `title` are considered a part of one operation.

Closes #773