### PR TITLE
solana: update for non-legacy transactions

### DIFF
--- a/src/plugins/solana/api.ts
+++ b/src/plugins/solana/api.ts
@@ -76,8 +76,13 @@ export async function fetchBalance (address: string): Promise<number> {
 }
 
 const fetchTransaction = rateLimit(2, async function (signature: string): Promise<Transaction> {
-  const response = await fetch<Transaction>('getTransaction', [signature, 'json'])
-
+  const response = await fetch<Transaction>('getTransaction', [
+    signature,
+    {
+      encoding: 'jsonParsed',
+      maxSupportedTransactionVersion: 0
+    }
+  ])
   return response
 })
 

--- a/src/plugins/solana/types.ts
+++ b/src/plugins/solana/types.ts
@@ -2,6 +2,11 @@ export interface GetBalanceResponse {
   value: number
 }
 
+export interface AccountKeys {
+  pubkey: string
+  signer: boolean
+}
+
 export interface Transaction {
   blockTime: number
   meta: {
@@ -11,7 +16,7 @@ export interface Transaction {
   }
   transaction: {
     message: {
-      accountKeys: string[]
+      accountKeys: AccountKeys[]
     }
     signatures: string[]
   }


### PR DESCRIPTION
currently plugin fails if it stumbles on some transactions because API doesn't return fields plugin expects for them, since they're not legacy txns
use jsonParsed encoding with maxSupportedTransactionVersion:0 when calling getTransaction, and update other logic accordingly.
also fix the fee calculation to make it more robust and generic.