### PR TITLE
[yettelbank-rs] Separate accounts by currency sub-account

### DIFF
--- a/src/plugins/yettelbank-rs/__tests__/parsers/accounts.test.ts
+++ b/src/plugins/yettelbank-rs/__tests__/parsers/accounts.test.ts
@@ -10,9 +10,15 @@ describe('parseAccounts', () => {
       [
         {
           id: '4815162342',
-          name: 'Current account',
+          name: '4815162342-RSD',
           currency: 'RSD',
           balance: 39367.79
+        },
+        {
+          id: '4815162342-EUR',
+          name: '4815162342-EUR',
+          currency: 'EUR',
+          balance: 0
         }
       ]
     ]

--- a/src/plugins/yettelbank-rs/__tests__/parsers/transactions-empty.html
+++ b/src/plugins/yettelbank-rs/__tests__/parsers/transactions-empty.html
@@ -1,0 +1,7 @@
+<div class="dashboard-content" data-method="animateDashboard">
+    <section class="head-promo">
+        <p> Some empty page, no transactions and no pagination!</p>
+    </section>
+</div>
+
+

--- a/src/plugins/yettelbank-rs/__tests__/parsers/transactions.test.ts
+++ b/src/plugins/yettelbank-rs/__tests__/parsers/transactions.test.ts
@@ -3,7 +3,7 @@ import { loadHtmlFile } from '../../helpers'
 
 const transactionsBody = loadHtmlFile('__tests__/parsers/transactions.html')
 
-describe('parseTransactions', () => {
+describe('parseRsdTransactions', () => {
   it.each([
     [
       transactionsBody,
@@ -17,13 +17,6 @@ describe('parseTransactions', () => {
         },
         {
           isPending: false,
-          date: new Date(2024, 8, 10),
-          title: 'ApplePay SHIO-RAMEN, TBILISI',
-          amount: -8.08,
-          currency: 'EUR'
-        },
-        {
-          isPending: false,
           date: new Date(2024, 10, 30),
           title: 'FRIENDLY DONATE',
           amount: 15000,
@@ -32,6 +25,38 @@ describe('parseTransactions', () => {
       ]
     ]
   ])('parses transactions', (transactionsBody, transactionsArray) => {
-    expect(parseTransactions(transactionsBody, false)).toEqual(transactionsArray)
+    expect(parseTransactions(transactionsBody, false, 'RSD')).toEqual(transactionsArray)
+  })
+})
+
+describe('parseEurTransactions', () => {
+  it.each([
+    [
+      transactionsBody,
+      [
+        {
+          isPending: false,
+          date: new Date(2024, 8, 10),
+          title: 'ApplePay SHIO-RAMEN, TBILISI',
+          amount: -8.08,
+          currency: 'EUR'
+        }
+      ]
+    ]
+  ])('parses transactions', (transactionsBody, transactionsArray) => {
+    expect(parseTransactions(transactionsBody, false, 'EUR')).toEqual(transactionsArray)
+  })
+})
+
+const noTransactionsBody = loadHtmlFile('__tests__/parsers/transactions-empty.html')
+
+describe('parseNoTransactionsShouldNotThrow', () => {
+  it.each([
+    [
+      noTransactionsBody,
+      []
+    ]
+  ])('parses transactions', (transactionsBody, transactionsArray) => {
+    expect(parseTransactions(transactionsBody, false, 'EUR')).toEqual(transactionsArray)
   })
 })

--- a/src/plugins/yettelbank-rs/api.ts
+++ b/src/plugins/yettelbank-rs/api.ts
@@ -18,9 +18,9 @@ export async function fetchAccounts (session: Session): Promise<AccountInfo[]> {
   return await fetchAllAccounts(session)
 }
 
-export async function fetchTransactions (session: Session, accountId: string, fromDate: Date, toDate: Date): Promise<TransactionInfo[]> {
+export async function fetchTransactions (session: Session, accountId: string, currency: string, fromDate: Date, toDate: Date): Promise<TransactionInfo[]> {
   if (toDate === null) {
     toDate = new Date()
   }
-  return await fetchProductTransactions(accountId, session, fromDate, toDate)
+  return await fetchProductTransactions(accountId, currency, session, fromDate, toDate)
 }

--- a/src/plugins/yettelbank-rs/fetchApi.ts
+++ b/src/plugins/yettelbank-rs/fetchApi.ts
@@ -85,7 +85,7 @@ async function fetchLogin (url: string, workflowId: string, username: string, pa
   }
 }
 
-function* extractAccountInfo (loadedCheerio: cheerio.Root, accountId: string): Generator<AccountInfo | null> {
+function * extractAccountInfo (loadedCheerio: cheerio.Root, accountId: string): Generator<AccountInfo | null> {
   const accountElements = loadedCheerio(`#pie-stats-${accountId}`)
   if (accountElements.length === 0) {
     console.debug(`Account ${accountId} not found`)
@@ -94,18 +94,18 @@ function* extractAccountInfo (loadedCheerio: cheerio.Root, accountId: string): G
 
   for (const el of accountElements.toArray()) {
     const $accountElement = loadedCheerio(el)
-    const balanceDiv = $accountElement.find(`div[id^="total available-balance-stat-${accountId}-"]`).first();
+    const balanceDiv = $accountElement.find(`div[id^="total available-balance-stat-${accountId}-"]`).first()
 
-    if (balanceDiv.length) {
-      const fullId = balanceDiv.attr('id');
-  
-      if (fullId) {
-        const accountName = fullId.replace(`total available-balance-stat-`, '');
-        const accountCurrency = accountName.split('-')[1];
-        const balanceText = balanceDiv.find('.amount-stats.big-nr p').first().text().trim();
+    if (balanceDiv.length !== 0) {
+      const fullId = balanceDiv.attr('id')
+
+      if (fullId !== null && fullId !== undefined) {
+        const accountName = fullId.replace('total available-balance-stat-', '')
+        const accountCurrency = accountName.split('-')[1]
+        const balanceText = balanceDiv.find('.amount-stats.big-nr p').first().text().trim()
         const activeCurrency = balanceDiv.find('option[selected="selected"]').val()
         // for backward compatibility
-        const newAccountId = activeCurrency === accountCurrency ? accountId : `${accountId}-${accountCurrency}`;
+        const newAccountId = activeCurrency === accountCurrency ? accountId : `${accountId}-${accountCurrency}`
 
         yield {
           id: newAccountId,
@@ -225,11 +225,11 @@ async function fetchTransactions (accountId: string, currency: string, status: s
     if (totalPages !== undefined && totalPages !== null && totalPages !== '') {
       return parseInt(totalPages, 10)
     }
-    return 0;
+    return 0
   }
 
   // getting raw accountId for parsing
-  const rawAccountId = accountId.replace(`-${currency}`, '');
+  const rawAccountId = accountId.replace(`-${currency}`, '')
 
   const response = await fetchTransactionsInternal(rawAccountId, status, fromDate, toDate)
   const totalPages = parseTotalPages(response.body)

--- a/src/plugins/yettelbank-rs/fetchApi.ts
+++ b/src/plugins/yettelbank-rs/fetchApi.ts
@@ -85,24 +85,36 @@ async function fetchLogin (url: string, workflowId: string, username: string, pa
   }
 }
 
-function extractAccountInfo (loadedCheerio: cheerio.Root, accountId: string): AccountInfo | null {
-  const accountElement = loadedCheerio(`#pie-stats-${accountId}`)
-  if (accountElement.length === 0) {
+function* extractAccountInfo (loadedCheerio: cheerio.Root, accountId: string): Generator<AccountInfo | null> {
+  const accountElements = loadedCheerio(`#pie-stats-${accountId}`)
+  if (accountElements.length === 0) {
     console.debug(`Account ${accountId} not found`)
     return null
   }
 
-  const accountCurrency = accountElement.find('option[selected="selected"]').val()
-  const availableBalanceAccount = accountElement.find(`#available-balance-stat-${accountId}-${accountCurrency}`)
-  const accountName = availableBalanceAccount.find('.stat-name').text().trim()
-  const balanceText = availableBalanceAccount.find('.amount-stats.big-nr p').first().text().trim()
-  const accountBalance = parseFloat(balanceText.replace(/,/g, ''))
+  for (const el of accountElements.toArray()) {
+    const $accountElement = loadedCheerio(el)
+    const balanceDiv = $accountElement.find(`div[id^="total available-balance-stat-${accountId}-"]`).first();
 
-  return {
-    id: accountId,
-    name: accountName,
-    currency: accountCurrency,
-    balance: accountBalance
+    if (balanceDiv.length) {
+      const fullId = balanceDiv.attr('id');
+  
+      if (fullId) {
+        const accountName = fullId.replace(`total available-balance-stat-`, '');
+        const accountCurrency = accountName.split('-')[1];
+        const balanceText = balanceDiv.find('.amount-stats.big-nr p').first().text().trim();
+        const activeCurrency = balanceDiv.find('option[selected="selected"]').val()
+        // for backward compatibility
+        const newAccountId = activeCurrency === accountCurrency ? accountId : `${accountId}-${accountCurrency}`;
+
+        yield {
+          id: newAccountId,
+          name: `${accountId}-${accountCurrency}`,
+          currency: accountCurrency,
+          balance: parseFloat(balanceText.replace(/,/g, ''))
+        }
+      }
+    }
   }
 }
 
@@ -116,10 +128,11 @@ export function parseAccounts (body: unknown): AccountInfo[] {
       accountIds.push(accountNumber as string)
     }
   })
-  const accounts = accountIds.map(id => extractAccountInfo($, id)).filter(Boolean)
+  const accounts = accountIds.flatMap(id => Array.from(extractAccountInfo($, id))).filter(Boolean)
   if (accounts.length === 0) {
     throw new Error('No accounts have been parsed')
   }
+
   return accounts as AccountInfo[]
 }
 
@@ -140,7 +153,7 @@ async function fetchAccounts (): Promise<AccountInfo[]> {
   return parseAccounts(response.body)
 }
 
-export function parseTransactions (body: unknown, pending: boolean): TransactionInfo[] {
+export function parseTransactions (body: unknown, pending: boolean, currencyFilter: string): TransactionInfo[] {
   function parseDate (dateString: string): Date {
     const [day, month, year] = dateString.split('.').map(Number)
     return new Date(year, month - 1, day)
@@ -162,14 +175,15 @@ export function parseTransactions (body: unknown, pending: boolean): Transaction
       if (transactionArrowClass !== undefined && transactionArrowClass !== '' && transactionArrowClass.includes('expense')) {
         parsedTransactionAmount *= -1
       }
-
-      transactions.push({
-        isPending: pending,
-        date: parseDate(date),
-        title: parsedTitle,
-        amount: parsedTransactionAmount,
-        currency: parsedCurrency
-      })
+      if (parsedCurrency === currencyFilter) {
+        transactions.push({
+          isPending: pending,
+          date: parseDate(date),
+          title: parsedTitle,
+          amount: parsedTransactionAmount,
+          currency: parsedCurrency
+        })
+      }
     })
   })
 
@@ -198,7 +212,7 @@ async function fetchTransactionsInternal (accountId: string, status: string, fro
   return response
 }
 
-async function fetchTransactions (accountId: string, status: string, fromDate: Date, toDate: Date): Promise<TransactionInfo[]> {
+async function fetchTransactions (accountId: string, currency: string, status: string, fromDate: Date, toDate: Date): Promise<TransactionInfo[]> {
   if (mockResponses) {
     return mockedTransactionsResponse
   }
@@ -211,17 +225,20 @@ async function fetchTransactions (accountId: string, status: string, fromDate: D
     if (totalPages !== undefined && totalPages !== null && totalPages !== '') {
       return parseInt(totalPages, 10)
     }
-    return 0
+    return 0;
   }
 
-  const response = await fetchTransactionsInternal(accountId, status, fromDate, toDate)
+  // getting raw accountId for parsing
+  const rawAccountId = accountId.replace(`-${currency}`, '');
+
+  const response = await fetchTransactionsInternal(rawAccountId, status, fromDate, toDate)
   const totalPages = parseTotalPages(response.body)
 
-  const transactions: TransactionInfo[] = parseTransactions(response.body, status === 'Pending')
+  const transactions: TransactionInfo[] = parseTransactions(response.body, status === 'Pending', currency)
 
   for (let page = 1; page < totalPages - 1; page++) {
-    const pageResponse = await fetchTransactionsInternal(accountId, status, fromDate, toDate, page)
-    transactions.push(...parseTransactions(pageResponse.body, status === 'Pending'))
+    const pageResponse = await fetchTransactionsInternal(rawAccountId, status, fromDate, toDate, page)
+    transactions.push(...parseTransactions(pageResponse.body, status === 'Pending', currency))
   }
 
   return transactions
@@ -244,8 +261,8 @@ export async function fetchAllAccounts (session: Session): Promise<AccountInfo[]
   return await fetchAccounts()
 }
 
-export async function fetchProductTransactions (accountId: string, session: Session, fromDate: Date, toDate: Date): Promise<TransactionInfo[]> {
-  const executedTransactions = await fetchTransactions(accountId, 'Executed', fromDate, toDate)
-  const pendingTransactions = await fetchTransactions(accountId, 'Pending', fromDate, toDate)
+export async function fetchProductTransactions (accountId: string, currency: string, session: Session, fromDate: Date, toDate: Date): Promise<TransactionInfo[]> {
+  const executedTransactions = await fetchTransactions(accountId, currency, 'Executed', fromDate, toDate)
+  const pendingTransactions = await fetchTransactions(accountId, currency, 'Pending', fromDate, toDate)
   return [...executedTransactions, ...pendingTransactions]
 }

--- a/src/plugins/yettelbank-rs/index.ts
+++ b/src/plugins/yettelbank-rs/index.ts
@@ -17,7 +17,7 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
       return
     }
     await Promise.all(products.map(async product => {
-      const apiTransactions = await fetchTransactions(session, product.id, fromDate, toDate!)
+      const apiTransactions = await fetchTransactions(session, product.id, account.instrument, fromDate, toDate!)
       for (const apiTransaction of apiTransactions) {
         transactions.push(convertTransaction(apiTransaction, account))
       }


### PR DESCRIPTION
In Yettel, one account can have several currencies, which looks and operated like several sub-accounts.
In this PR, I'm parsing these sub-accounts and separating transactions by currency-sub-acc.
Covered with tests. 