### PR TITLE
[raiffeisen-rs] remove invoice from cash income movement

### DIFF
--- a/src/plugins/raiffeisen-rs/converters.ts
+++ b/src/plugins/raiffeisen-rs/converters.ts
@@ -85,7 +85,7 @@ export function convertCashTransaction (t1: GetAccountTransactionsResponse): Tra
       {
         id: t1.TransactionID ?? null,
         account: { type: AccountType.cash, instrument: t1.CurrencyCode, syncIds: null, company: null },
-        invoice,
+        invoice: null,
         sum: t1.DebitAmount - t1.CreditAmount,
         fee: 0
       }


### PR DESCRIPTION
Зачем: сломан парсинг снятия наличных в валюте отличающейся от валюты счета

`Invalid transaction opIncome and opOutcome must have same sign as income and outcome`

<details><summary>пример ломающей транзакции</summary>

замазал все чувствительное

```json
// ответ от райфа
[
  {
    "e_UserLocality": null,
    "ReceiveDate": null,
    "fwType": "aoFullTransactionDetails",
    "m_PayDeskNumber": null,
    "CurrencyCodeNumeric": null,
    "p2p_Message": null,
    "p2p_Status": null,
    "s_Alias": null,
    "m_UserGroup": null,
    "Alias": null,
    "dev_cred_bank_address_postal": null,
    "e_UserName": null,
    "c_Alias": null,
    "m_ExchangeOfficeLocality": null,
    "dev_Status": null,
    "DebtorName": null,
    "c_TerminalID": "********",
    "m_Basics": null,
    "p2p_CurrencyCodeNumeric": null,
    "ValueDate": null,
    "s_Note_st": "MATBUOTCHILAR 9 UZB TOSHKENT",
    "UserName": null,
    "dev_cred_bank_address_locality": null,
    "m_DebtorCurrencyCode": null,
    "m_CommissionCurrencyCode": null,
    "DebtorAddress": null,
    "m_UserCurrencyCode": null,
    "PaymentPurpose": null,
    "dev_Charge": null,
    "dev_ComissionAccount": null,
    "m_UserCurrencyCodeNumeric": null,
    "e_ID": null,
    "s_AccountPurpose": "A vista računi fizičkih lica u stranoj valuti",
    "p2p_PaymentCode": null,
    "dev_cred_bank_address_country": null,
    "m_TransactionID": null,
    "m_AmountTotal": null,
    "iBankingCreditorTypeFRN": null,
    "dev_cred_bank_address_line": null,
    "m_Course": null,
    "dev_cred_address_locality": null,
    "m_DebtorCurrencyCodeNumeric": null,
    "m_OrderNumber": null,
    "m_CommissionPercentage": null,
    "fwNamespace": "SagaBG.SeP.RetailOutput",
    "p2p_RealizationDate": null,
    "mpay_payment_type": null,
    "e_UserAlias": null,
    "s_StatementID": null,
    "fwStatus": 1,
    "iBankingProcessedDateCoreFRN": null,
    "p2p_ExpiryDate": null,
    "ReceiverReference": null,
    "p2p_CreateDate": null,
    "c_DebtorDetails": "MATBUOTCHILAR 9 UZB TOSHKENT",
    "m_ExchangeNumber": null,
    "s_ValueDate": "2025-03-24T00:00:00",
    "dev_SwiftMessage": null,
    "PaymentStatusName": null,
    "DebtorLocality": null,
    "m_JobType": null,
    "PaymentState": null,
    "dev_SpecAmount": null,
    "c_Date_tx": "2025-03-22T00:00:00",
    "dev_SpecCurrency": null,
    "tn_ValueDate": null,
    "c_DomesticAmount": 2645.918796,
    "Priority": null,
    "dev_SpecInvoiceNumber": null,
    "e_DebtorAccount": null,
    "m_CommissionCurrencyCodeNumeric": null,
    "c_Amount_tx": 304500.0,
    "m_UserID": null,
    "m_UserName": null,
    "dev_CreditorAddressCountry": null,
    "m_UserType": null,
    "s_ProcessedDate": "2025-03-24T00:00:00",
    "m_Operator": null,
    "ID": -1,
    "s_Amount": 22.02,
    "s_ConfirmationDate": "2025-03-25T07:42:17",
    "m_UserAlias": null,
    "dev_SpecPurposeCode": null,
    "dev_SpecInvoiceYear": null,
    "e_Channel": null,
    "s_PaymentBasis": 102,
    "s_CurrencyCode": "EUR",
    "m_BankLocality": null,
    "c_CalculationDate": "2025-03-24T00:00:00",
    "PaymentCode": null,
    "m_CommissionAmount": null,
    "tn_Description": null,
    "CommissionCurrencyCodeNumeric": null,
    "OrderNumber_pp": null,
    "m_DebtorGroup": null,
    "m_DebtorAlias": null,
    "UserAddress": null,
    "DebtorAccount": null,
    "m_JobDescription": null,
    "p2p_Alias": null,
    "dev_creditor_bank": null,
    "UserAccount": null,
    "m_ExchangeName": null,
    "Reference": null,
    "CommissionCurrencyCode": null,
    "p2p_IssueDate": null,
    "End2endID": null,
    "m_DebtorName": null,
    "c_Reference": 123456789000,
    "s_OrderNumber": "00000000000000",
    "dev_CreditorBankSwiftCode": null,
    "PaymentAmount": null,
    "mpay_merchant_code": null,
    "IsInvestOrder": false,
    "dev_PersonalNumber": null,
    "m_DebtorID": null,
    "p2p_CurrencyCode": null,
    "e_UserAccount": null,
    "mpay_sales_point_code": null,
    "Model": null,
    "m_UserAmount": null,
    "c_CardNumber": "123456******7890",
    "CommissionAmount": null,
    "dev_cred_address_postal_code": null,
    "dev_SpecialMark": null,
    "s_Group": "123456789123456789",
    "dev_cred_address_line": null,
    "m_Date": null,
    "CurrencyCode": null,
    "UserLocality": null,
    "p2p_Amount": null,
    "e_DebtorName": null,
    "s_CurrencyCodeNumeric": 978,
    "dev_BulkId": null,
    "p2p_DebtorGroup": null,
    "e_DebtorAlias": null,
    "dev_AuthorizationType": null,
    "c_CurrencyCode_tx": "UZS",
    "dev_SpecPaymentDescription": null,
    "c_AuthorizationID": "123456",
    "m_DebtorAmount": null,
    "e_DebtorLocality": null
  }
]



// output from convertCashTransaction
{
  "fullTitle": "MATBUOTCHILAR 9 UZB TOSHKENT",
  "location": null,
  "mcc": null,
  "movements": [
    {
      "account": {
        "id": "123456789123456789EUR"
      },
      "fee": 0,
      "id": "12345678900000#0#12#123456789000",
      "invoice": {
        "sum": -304500,
        "instrument": "UZS"
      },
      "sum": -22.02,
    },
    {
      "account": {
        "company": null,
        "instrument": "EUR",
        "syncIds": null,
        "type": "cash"
      },
      "fee": 0,
      "id": "12345678900000#0#12#123456789000",
      "invoice": {
        "sum": -304500, // предполагаю что вся проблема из-за этого
        "instrument": "UZS"
      },
      "sum": 22.02,
    }
  ]
}


// addedTransactions
[
// ...
{
  "comment": null,
  "date": "2025-03-20T00:00:00.000Z",
  "hold": false,
  "income": 22.02,
  "incomeAccount": "cash#EUR",
  "incomeBankID": "12345678900000#0#12#123456789000",
  "mcc": null,
  "opIncome": 304500,
  "opIncomeInstrument": "UZS",
  "opOutcome": 304500, // тут какой-то явной проблемы не видно, но кажется это в самой реализации в приложении может отличаться, потому что строки с ошибкой здесь в коде я не нашел
  "opOutcomeInstrument": "UZS",
  "outcome": 22.02,
  "outcomeAccount": "123456789123456789EUR",
  "outcomeBankID": "12345678900000#0#12#123456789000",
  "payee": "MATBUOTCHILAR 9 UZB TOSHKENT"
},
// ...
]

```

</details> 


не нашел ни одного плагина который бы добавлял инвойс в транзакцию снятия наличных, даже в эталонном из common https://github.com/zenmoney/ZenPlugins/blob/master/src/common/converters.js#L121

думаю что стоит просто убрать его