### PR TITLE
[bscscan] Add bscscan plugin for BNB and BEP20 tokens support

### DIFF
--- a/src/plugins/bscscan/ZenmoneyManifest.xml
+++ b/src/plugins/bscscan/ZenmoneyManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>bscscan</id>
+    <company>15936</company>
+    <description>
+        Плагин для синхронизации BNB Smart Chain с помощью bscscan.
+        Для синхронизации укажите ApiKey и адреса кошельков.
+    </description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <api>public</api>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+</provider>

--- a/src/plugins/bscscan/__tests__/converters/accounts/accounts.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/accounts/accounts.test.ts
@@ -19,7 +19,7 @@ describe('convertAccounts', () => {
           id: '0xe61289f5dc092d685e6e918b6624e273b42b6730',
           type: AccountType.checking,
           title: '0xe61289f5dc092d685e6e918b6624e273b42b6730',
-          instrument: 'μETH',
+          instrument: 'bnb',
           balance: 2000000,
           syncIds: ['0xe61289f5dc092d685e6e918b6624e273b42b6730']
         },
@@ -27,7 +27,7 @@ describe('convertAccounts', () => {
           id: '0xe61289f5dc092d685e6e918b6624e273b42b6740',
           type: AccountType.checking,
           title: '0xe61289f5dc092d685e6e918b6624e273b42b6740',
-          instrument: 'μETH',
+          instrument: 'bnb',
           balance: 0,
           syncIds: ['0xe61289f5dc092d685e6e918b6624e273b42b6740']
         }

--- a/src/plugins/bscscan/__tests__/converters/accounts/accounts.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/accounts/accounts.test.ts
@@ -1,0 +1,39 @@
+import { AccountType } from '../../../../../types/zenmoney'
+import { convertAccounts } from '../../../bnb/converters'
+
+describe('convertAccounts', () => {
+  it.each([
+    [
+      [
+        {
+          account: '0xe61289f5dc092d685e6e918b6624e273b42b6730',
+          balance: '2000000000000000000'
+        },
+        {
+          account: '0xe61289f5dc092d685e6e918b6624e273b42b6740',
+          balance: '0'
+        }
+      ],
+      [
+        {
+          id: '0xe61289f5dc092d685e6e918b6624e273b42b6730',
+          type: AccountType.checking,
+          title: '0xe61289f5dc092d685e6e918b6624e273b42b6730',
+          instrument: 'μETH',
+          balance: 2000000,
+          syncIds: ['0xe61289f5dc092d685e6e918b6624e273b42b6730']
+        },
+        {
+          id: '0xe61289f5dc092d685e6e918b6624e273b42b6740',
+          type: AccountType.checking,
+          title: '0xe61289f5dc092d685e6e918b6624e273b42b6740',
+          instrument: 'μETH',
+          balance: 0,
+          syncIds: ['0xe61289f5dc092d685e6e918b6624e273b42b6740']
+        }
+      ]
+    ]
+  ])('converts current account', (apiAccounts, accounts) => {
+    expect(convertAccounts(apiAccounts)).toEqual(accounts)
+  })
+})

--- a/src/plugins/bscscan/__tests__/converters/bnb-scrape.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/bnb-scrape.test.ts
@@ -21,7 +21,7 @@ describe('scrape', () => {
         id: '1',
         type: AccountType.checking,
         title: '1',
-        instrument: 'μETH',
+        instrument: 'bnb',
         balance: 2000000,
         syncIds: ['1']
       },
@@ -29,7 +29,7 @@ describe('scrape', () => {
         id: '2',
         type: AccountType.checking,
         title: '2',
-        instrument: 'μETH',
+        instrument: 'bnb',
         balance: 10000000,
         syncIds: ['2']
       }

--- a/src/plugins/bscscan/__tests__/converters/bnb-scrape.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/bnb-scrape.test.ts
@@ -1,0 +1,96 @@
+import { AccountType } from '../../../../types/zenmoney'
+import { scrape } from '../../bnb'
+import { mockEndPoints, preferencesMock } from '../../mocks'
+
+describe('scrape', () => {
+  it('should hit the mocks and return results', async () => {
+    mockEndPoints()
+
+    const result = await scrape(
+      {
+        preferences: preferencesMock,
+        startBlock: 1,
+        endBlock: 99999999,
+        isFirstRun: false,
+        isInBackground: false
+      }
+    )
+
+    expect(result.accounts).toEqual([
+      {
+        id: '1',
+        type: AccountType.checking,
+        title: '1',
+        instrument: 'μETH',
+        balance: 2000000,
+        syncIds: ['1']
+      },
+      {
+        id: '2',
+        type: AccountType.checking,
+        title: '2',
+        instrument: 'μETH',
+        balance: 10000000,
+        syncIds: ['2']
+      }
+    ])
+
+    expect(result.transactions).toEqual([
+      {
+        hold: null,
+        date: new Date('2015-07-30T15:26:28.000Z'),
+        movements: [{
+          id: '1',
+          account: { id: '1' },
+          invoice: null,
+          sum: -1000000,
+          fee: -323
+        }],
+        merchant: {
+          fullTitle: 'OTHER_ACCOUNT',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      },
+      {
+        hold: null,
+        date: new Date('2015-07-30T15:26:28.000Z'),
+        movements: [{
+          id: '2',
+          account: { id: '1' },
+          invoice: null,
+          sum: 2000000,
+          fee: 0
+        }],
+        merchant: {
+          fullTitle: 'OTHER_ACCOUNT',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      },
+      {
+        hold: null,
+        date: new Date('2015-07-30T15:26:28.000Z'),
+        movements: [
+          {
+            id: '3',
+            account: { id: '1' },
+            invoice: null,
+            sum: -1000000,
+            fee: -323
+          }, {
+            id: '3',
+            account: { id: '2' },
+            invoice: null,
+            sum: 1000000,
+            fee: 0
+          }
+        ],
+        merchant: null,
+        comment: null
+      }
+    ])
+  })
+})

--- a/src/plugins/bscscan/__tests__/converters/transaction/transaction.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/transaction/transaction.test.ts
@@ -1,0 +1,63 @@
+import { convertTransaction } from '../../../bnb/converters'
+import { BNBTransaction } from '../../../bnb/types'
+
+const OWN_ACCOUNT = 'ACCOUNT_ID'
+const baseMock: BNBTransaction = {
+  timeStamp: '1658608646',
+  hash: '0x90bb0dcbe8fa38387145aa17d6ad99f57da91d4c6d4b65b5f7cf56454f73234b',
+  from: '1',
+  to: '2',
+  value: '870728990000000000',
+  gasPrice: '15402961964',
+  isError: '0',
+  gasUsed: '21000'
+}
+
+describe('convertTransaction', () => {
+  it('should handle payment operation', () => {
+    const result = convertTransaction(OWN_ACCOUNT, {
+      ...baseMock,
+      from: OWN_ACCOUNT
+    })
+
+    expect(result?.movements[0].sum).toBeLessThanOrEqual(0)
+    expect(result?.movements[0].fee).toBeLessThan(0)
+  })
+
+  it('should handle deposit operation', () => {
+    const result = convertTransaction(OWN_ACCOUNT, {
+      ...baseMock,
+      to: OWN_ACCOUNT
+    })
+
+    expect(result?.movements[0].sum).toBeGreaterThan(0)
+    expect(result?.movements[0].fee).toBe(0)
+  })
+
+  it('should ignore errored operations', () => {
+    const result = convertTransaction(OWN_ACCOUNT, {
+      ...baseMock,
+      isError: '1'
+    })
+
+    expect(result).toBe(null)
+  })
+
+  it('should ignore value = 0 operations', () => {
+    const result = convertTransaction(OWN_ACCOUNT, {
+      ...baseMock,
+      value: '0'
+    })
+
+    expect(result).toBe(null)
+  })
+
+  it('should convert operation amount', () => {
+    const result = convertTransaction(OWN_ACCOUNT, {
+      ...baseMock,
+      value: '1000000000000000000'
+    })
+
+    expect(result?.movements[0].sum).toBe(1000000)
+  })
+})

--- a/src/plugins/bscscan/bnb/api.ts
+++ b/src/plugins/bscscan/bnb/api.ts
@@ -1,0 +1,67 @@
+import { fetch } from '../common'
+import { Preferences } from '../types'
+import { AccountResponse, BNBAccount, BNBTransaction, TransactionResponse } from './types'
+
+export async function fetchAccounts (
+  preferences: Preferences
+): Promise<BNBAccount[]> {
+  const response = await fetch<AccountResponse>({
+    module: 'account',
+    action: 'balancemulti',
+    address: preferences.account,
+    tag: 'latest',
+    apiKey: preferences.apiKey
+  })
+
+  return response.result
+}
+
+interface AccountTransactionsOptions {
+  account: string
+  startBlock: number
+  endBlock: number
+  page?: number
+}
+
+const PAGE_SIZE = 100
+
+export async function fetchAccountTransactions (
+  preferences: Preferences,
+  options: AccountTransactionsOptions
+): Promise<BNBTransaction[]> {
+  const { account, startBlock, endBlock, page = 1 } = options
+
+  try {
+    const response = await fetch<TransactionResponse>({
+      module: 'account',
+      action: 'txlist',
+      address: account,
+      startblock: startBlock,
+      endblock: endBlock,
+      page,
+      offset: PAGE_SIZE,
+      sort: 'desc',
+      apikey: preferences.apiKey
+    })
+
+    const transactions = response.result
+
+    if (response.result.length === PAGE_SIZE) {
+      return [
+        ...transactions,
+        ...await fetchAccountTransactions(preferences, {
+          ...options,
+          page: page + 1
+        })
+      ]
+    }
+
+    return transactions
+  } catch (error: any) { // eslint-disable-line
+    if (error?.body?.message === 'No transactions found') {
+      return []
+    }
+
+    throw error
+  }
+}

--- a/src/plugins/bscscan/bnb/converters.ts
+++ b/src/plugins/bscscan/bnb/converters.ts
@@ -17,7 +17,7 @@ function convertAccount ({ account, balance }: BNBAccount): Account {
     id: account,
     type: AccountType.checking,
     title: account,
-    instrument: 'μETH',
+    instrument: 'bnb',
     balance: convertWeiToUETH(Number(balance)),
     syncIds: [account]
   }

--- a/src/plugins/bscscan/bnb/converters.ts
+++ b/src/plugins/bscscan/bnb/converters.ts
@@ -1,0 +1,72 @@
+import { Account, AccountType, Transaction } from '../../../types/zenmoney'
+
+import { BNBAccount, BNBTransaction } from './types'
+
+function convertWeiToUETH (value: number): number {
+  return Math.round(value / 10 ** 12)
+}
+
+function getTransactionFee (transaction: BNBTransaction): number {
+  const { gasPrice, gasUsed } = transaction
+
+  return convertWeiToUETH(Number(gasPrice) * Number(gasUsed))
+}
+
+function convertAccount ({ account, balance }: BNBAccount): Account {
+  return {
+    id: account,
+    type: AccountType.checking,
+    title: account,
+    instrument: 'μETH',
+    balance: convertWeiToUETH(Number(balance)),
+    syncIds: [account]
+  }
+}
+
+export function convertAccounts (accounts: BNBAccount[]): Account[] {
+  return accounts.map(convertAccount)
+}
+
+export function convertTransaction (account: string, transaction: BNBTransaction): Transaction | null {
+  const direction = transaction.from === account ? 'PAYMENT' : 'DEPOSIT'
+  const targetAccount = direction === 'PAYMENT' ? transaction.to : transaction.from
+  const sign = direction === 'PAYMENT' ? -1 : 1
+  const operationValue = convertWeiToUETH(Number(transaction.value))
+
+  if (transaction.isError === '1') {
+    return null
+  }
+  if (operationValue === 0) {
+    return null
+  }
+
+  return {
+    hold: null,
+    date: new Date(Number(transaction.timeStamp) * 1000),
+    movements: [
+      {
+        id: transaction.hash,
+        account: {
+          id: account
+        },
+        invoice: null,
+        sum: sign * operationValue,
+        fee: direction === 'PAYMENT' ? sign * getTransactionFee(transaction) : 0
+      }
+    ],
+    merchant: {
+      fullTitle: targetAccount,
+      mcc: null,
+      location: null
+    },
+    comment: null
+  }
+}
+
+export function convertTransactions (account: string, transactions: BNBTransaction[]): Transaction[] {
+  const list = transactions
+    .map((transaction) => convertTransaction(account, transaction))
+    .filter((transaction): transaction is Transaction => !!transaction)
+
+  return list
+}

--- a/src/plugins/bscscan/bnb/index.ts
+++ b/src/plugins/bscscan/bnb/index.ts
@@ -1,0 +1,32 @@
+import { Account, Transaction } from '../../../types/zenmoney'
+import { Scrape } from '../types'
+import { fetchAccounts, fetchAccountTransactions } from './api'
+import { mergeTransferTransactions } from '../common/converters'
+import { convertAccounts, convertTransactions } from './converters'
+
+export const scrape: Scrape = async ({
+  preferences,
+  startBlock,
+  endBlock
+}) => {
+  const transactions: Transaction[] = []
+
+  const accountsResponse = await fetchAccounts(preferences)
+
+  const accounts: Account[] = convertAccounts(accountsResponse)
+
+  for (const account of accounts) {
+    const accountTransactions = await fetchAccountTransactions(preferences, {
+      account: account.id,
+      startBlock,
+      endBlock
+    })
+
+    transactions.push(...convertTransactions(account.id, accountTransactions))
+  }
+
+  return {
+    accounts,
+    transactions: mergeTransferTransactions(transactions)
+  }
+}

--- a/src/plugins/bscscan/bnb/types.ts
+++ b/src/plugins/bscscan/bnb/types.ts
@@ -1,0 +1,43 @@
+import { Response } from '../common/types'
+
+export interface AccountResponse extends Response {
+  result: BNBAccount[]
+}
+
+export interface BlockNoResponse extends Response {
+  result: string
+}
+
+export interface TransactionResponse extends Response {
+  result: BNBTransaction[]
+}
+
+export interface BNBAccount {
+  account: string
+  balance: string
+}
+
+export interface BNBTransaction {
+  gasUsed: string
+  hash: string
+  from: string
+  to: string
+  value: string
+  gasPrice: string
+  isError: string
+  timeStamp: string
+
+  // Exists in API, but not used now. Keep for possible future updates
+  // blockNumber: string
+  // nonce: string
+  // blockHash: string
+  // transactionIndex: string
+  // gas: string
+  // txreceipt_status: string
+  // input: string
+  // contractAddress: string
+  // cumulativeGasUsed: string
+  // confirmations: string
+  // methodId: string
+  // functionName: string
+}

--- a/src/plugins/bscscan/common/converters.ts
+++ b/src/plugins/bscscan/common/converters.ts
@@ -1,0 +1,25 @@
+import { Transaction } from '../../../types/zenmoney'
+
+export function mergeTransferTransactions (transactions: Transaction[]): Transaction[] {
+  const list = transactions.reduce<{[key in string]?: Transaction}>((acc, item) => {
+    const movementId = item.movements[0].id!
+    const existingItem = acc[movementId]
+
+    if (!existingItem) {
+      acc[movementId] = item
+    } else {
+      acc[movementId] = {
+        ...existingItem,
+        movements: [
+          existingItem.movements[0],
+          item.movements[0]
+        ],
+        merchant: null
+      }
+    }
+
+    return acc
+  }, {})
+
+  return Object.values(list) as Transaction[]
+}

--- a/src/plugins/bscscan/common/index.ts
+++ b/src/plugins/bscscan/common/index.ts
@@ -1,0 +1,63 @@
+import { stringify } from 'querystring'
+import { fetchJson } from '../../../common/network'
+import { delay } from '../../../common/utils'
+import { Preferences } from '../types'
+
+import type { Response, BlockNoResponse } from './types'
+
+const baseUrl = 'https://api.bscscan.com/api'
+
+const MAX_RPS = 5
+let activeList: Array<Promise<unknown>> = []
+
+async function fetchInner<T extends Response> (params: Record<string, string | number>): Promise<T> {
+  const query = stringify(params)
+
+  const response = await fetchJson(`${baseUrl}?${query}`)
+
+  const data = response.body as T
+
+  if (data.message === 'OK') {
+    return data
+  }
+
+  throw response
+}
+
+export async function fetch<T extends Response> (params: Record<string, string | number>): Promise<T> {
+  if (activeList.length < MAX_RPS) {
+    const request = fetchInner<T>(params)
+
+    const waiter = request
+      .then(async () => await delay(1000))
+      .catch(async () => await delay(1000))
+      .then(() => { // eslint-disable-line @typescript-eslint/no-floating-promises
+        activeList = activeList.filter(item => item !== waiter)
+      })
+    activeList.push(waiter)
+
+    const result = await request
+
+    return result
+  }
+
+  await Promise.race(activeList)
+  return await fetch<T>(params)
+}
+
+export async function fetchBlockNoByTime (
+  preferences: Preferences,
+  { timestamp }: { timestamp: number }
+): Promise<number> {
+  const response = await fetch<BlockNoResponse>({
+    module: 'block',
+    action: 'getblocknobytime',
+    closest: 'before',
+    timestamp,
+    apiKey: preferences.apiKey
+  })
+
+  return Number(response.result)
+}
+
+export { Response }

--- a/src/plugins/bscscan/common/types.ts
+++ b/src/plugins/bscscan/common/types.ts
@@ -1,0 +1,8 @@
+export interface Response {
+  status: string
+  message: string
+}
+
+export interface BlockNoResponse extends Response {
+  result: string
+}

--- a/src/plugins/bscscan/index.ts
+++ b/src/plugins/bscscan/index.ts
@@ -2,7 +2,7 @@ import { ScrapeFunc } from '../../types/zenmoney'
 import { fetchBlockNoByTime } from './common'
 import { Preferences } from './types'
 
-import { scrape as scrapeEther } from './bnb'
+import { scrape as scrapeBnb } from './bnb'
 import { scrape as scrapeTokens } from './tokens'
 
 export const scrape: ScrapeFunc<Preferences> = async ({
@@ -21,8 +21,8 @@ export const scrape: ScrapeFunc<Preferences> = async ({
     })
   ])
 
-  const [ether, tokens] = await Promise.all([
-    scrapeEther({
+  const [bnb, tokens] = await Promise.all([
+    scrapeBnb({
       preferences,
       startBlock,
       endBlock,
@@ -39,7 +39,7 @@ export const scrape: ScrapeFunc<Preferences> = async ({
   ])
 
   return {
-    accounts: [...ether.accounts, ...tokens.accounts],
-    transactions: [...ether.transactions, ...tokens.transactions]
+    accounts: [...bnb.accounts, ...tokens.accounts],
+    transactions: [...bnb.transactions, ...tokens.transactions]
   }
 }

--- a/src/plugins/bscscan/index.ts
+++ b/src/plugins/bscscan/index.ts
@@ -1,0 +1,45 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { fetchBlockNoByTime } from './common'
+import { Preferences } from './types'
+
+import { scrape as scrapeEther } from './bnb'
+import { scrape as scrapeTokens } from './tokens'
+
+export const scrape: ScrapeFunc<Preferences> = async ({
+  fromDate,
+  toDate,
+  preferences,
+  isFirstRun,
+  isInBackground
+}) => {
+  const [startBlock, endBlock] = await Promise.all([
+    fetchBlockNoByTime(preferences, {
+      timestamp: Math.floor(fromDate.valueOf() / 1000)
+    }),
+    fetchBlockNoByTime(preferences, {
+      timestamp: Math.floor((toDate ?? new Date()).valueOf() / 1000)
+    })
+  ])
+
+  const [ether, tokens] = await Promise.all([
+    scrapeEther({
+      preferences,
+      startBlock,
+      endBlock,
+      isFirstRun,
+      isInBackground
+    }),
+    scrapeTokens({
+      preferences,
+      startBlock,
+      endBlock,
+      isFirstRun,
+      isInBackground
+    })
+  ])
+
+  return {
+    accounts: [...ether.accounts, ...tokens.accounts],
+    transactions: [...ether.transactions, ...tokens.transactions]
+  }
+}

--- a/src/plugins/bscscan/mocks/index.ts
+++ b/src/plugins/bscscan/mocks/index.ts
@@ -1,0 +1,112 @@
+import fetchMock from 'fetch-mock'
+import { AccountResponse, BlockNoResponse, TransactionResponse } from '../bnb/types'
+import { Preferences } from '../types'
+
+export const preferencesMock: Preferences = {
+  apiKey: 'API_KEY',
+  account: '1,2'
+}
+
+export const accountResponseMock: AccountResponse = {
+  status: '1',
+  message: 'OK',
+  result: [
+    {
+      account: '1',
+      balance: '2000000000000000000'
+    },
+    {
+      account: '2',
+      balance: '10000000000000000000'
+    }
+  ]
+}
+
+export const startBlockResponseMock: BlockNoResponse = {
+  status: '1',
+  message: 'OK',
+  result: '1'
+}
+
+export const endBlockResponseMock: BlockNoResponse = {
+  status: '1',
+  message: 'OK',
+  result: '99999999'
+}
+
+export const transactionsResponseMock1: TransactionResponse = {
+  status: '1',
+  message: 'OK',
+  result: [
+    {
+      hash: '1',
+      from: '1',
+      to: 'OTHER_ACCOUNT',
+      value: '1000000000000000000',
+      timeStamp: '1438269988',
+      isError: '0',
+      gasPrice: '15402961964',
+      gasUsed: '21000'
+    },
+    {
+      hash: '2',
+      from: 'OTHER_ACCOUNT',
+      to: '1',
+      value: '2000000000000000000',
+      timeStamp: '1438269988',
+      isError: '0',
+      gasPrice: '15402961964',
+      gasUsed: '21000'
+    },
+    {
+      hash: '3',
+      from: '1',
+      to: '2',
+      value: '1000000000000000000',
+      timeStamp: '1438269988',
+      isError: '0',
+      gasPrice: '15402961964',
+      gasUsed: '21000'
+    }
+  ]
+}
+
+export const transactionsResponseMock2: TransactionResponse = {
+  status: '1',
+  message: 'OK',
+  result: [
+    {
+      hash: '3',
+      from: '1',
+      to: '2',
+      value: '1000000000000000000',
+      timeStamp: '1438269988',
+      isError: '0',
+      gasPrice: '15402961964',
+      gasUsed: '21000'
+    }
+  ]
+}
+
+export function mockEndPoints (): void {
+  fetchMock.once('https://api.bscscan.com/api?module=account&action=balancemulti&address=1%2C2&tag=latest&apiKey=API_KEY', {
+    status: 200,
+    body: accountResponseMock
+  })
+  fetchMock.once('https://api.bscscan.com/api?module=block&action=getblocknobytime&closest=before&timestamp=1640552400&apiKey=API_KEY', {
+    status: 200,
+    body: startBlockResponseMock
+  })
+  fetchMock.once('https://api.bscscan.com/api?module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY', {
+    status: 200,
+    body: endBlockResponseMock
+  })
+  fetchMock.once('https://api.bscscan.com/api?module=account&action=txlist&address=1&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY', {
+    status: 200,
+    body: transactionsResponseMock1
+  })
+  fetchMock.once('https://api.bscscan.com/api?module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY', {
+    status: 200,
+    body: transactionsResponseMock2
+  })
+}

--- a/src/plugins/bscscan/preferences.xml
+++ b/src/plugins/bscscan/preferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="apiKey"
+        obligatory="true"
+        title="ApiKey"
+        dialogTitle="ApiKey"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Ключ от API|***********"
+    />
+    <EditTextPreference
+        key="account"
+        obligatory="true"
+        inputType="textPassword"
+        title="Адрес кошелька"
+        dialogTitle="Адрес кошелька"
+        dialogMessage="В случае нескольких адресов укажите их через запятую"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Адрес кошелька|{@s}"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2018-01-01T00:00:00.000Z"
+        dialogTitle="Дата начала загрузки"
+        dialogMessage="Введите дату, с которой загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>

--- a/src/plugins/bscscan/tokens/bep20.ts
+++ b/src/plugins/bscscan/tokens/bep20.ts
@@ -1,0 +1,98 @@
+import flatten from 'lodash/flatten'
+import { fetch } from '../common'
+import { Preferences } from '../types'
+
+import { AccountResponse, TokenAccount, TokenTransaction, TokenTransactionResponse } from './types'
+import { SUPPORTED_TOKENS } from './config'
+
+export async function fetchAddressTokens (preferences: Preferences, address: string): Promise<TokenAccount[]> {
+  const result = await Promise.all(SUPPORTED_TOKENS.map(async token => {
+    const response = await fetch<AccountResponse>({
+      module: 'account',
+      action: 'tokenbalance',
+      contractaddress: token.contractAddress,
+      address,
+      tag: 'latest',
+      apiKey: preferences.apiKey
+    })
+
+    const balance = Number(response.result)
+
+    const account: TokenAccount = {
+      id: address,
+      balance,
+      contractAddress: token.contractAddress
+    }
+
+    return account
+  }))
+
+  return result
+}
+
+/* Эндпоинт bscscan для получения инфы про все токены — платный.
+   Поэтому обходим тут все поддерживаемые токены по каждому адресу отдельно */
+export async function fetchAccounts (
+  preferences: Preferences
+): Promise<TokenAccount[]> {
+  const accounts = preferences.account.split(',')
+
+  const result = await Promise.all(accounts.map(async (address: string) => {
+    const tokensAccounts = await fetchAddressTokens(preferences, address)
+
+    return tokensAccounts
+  }))
+
+  return flatten(result)
+}
+
+const PAGE_SIZE = 100
+
+interface AccountTransactionsOptions {
+  startBlock: number
+  endBlock: number
+  page?: number
+}
+
+export async function fetchAccountTransactions (
+  preferences: Preferences,
+  account: TokenAccount,
+  options: AccountTransactionsOptions
+): Promise<TokenTransaction[]> {
+  const { startBlock, endBlock, page = 1 } = options
+
+  try {
+    const response = await fetch<TokenTransactionResponse>({
+      module: 'account',
+      action: 'tokentx',
+      contractaddress: account.contractAddress,
+      address: account.id,
+      startblock: startBlock,
+      endblock: endBlock,
+      page,
+      offset: PAGE_SIZE,
+      sort: 'desc',
+      apikey: preferences.apiKey
+    })
+
+    const transactions = response.result
+
+    if (response.result.length === PAGE_SIZE) {
+      return [
+        ...transactions,
+        ...await fetchAccountTransactions(preferences, account, {
+          ...options,
+          page: page + 1
+        })
+      ]
+    }
+
+    return transactions
+  } catch (error: any) { // eslint-disable-line
+    if (error?.body?.message === 'No transactions found') {
+      return []
+    }
+
+    throw error
+  }
+}

--- a/src/plugins/bscscan/tokens/config.ts
+++ b/src/plugins/bscscan/tokens/config.ts
@@ -1,0 +1,25 @@
+export interface TokenConfig {
+  title: string
+  contractAddress: string
+  instrument: string
+  convertBalance: (value: number) => number
+}
+
+export const generateTokenAddress = (address: string, token: TokenConfig): string => {
+  return `${address}-${token.contractAddress}`
+}
+
+export const SUPPORTED_TOKENS: TokenConfig[] = [
+  {
+    title: 'USDT',
+    contractAddress: '0x55d398326f99059ff775485246999027b3197955',
+    instrument: 'USDT',
+    convertBalance: (value) => value / 1000000
+  },
+  {
+    title: 'USDC',
+    contractAddress: '0x8965349fb649a33a30cbfda057d8ec2c48abe2a2',
+    instrument: 'USDT',
+    convertBalance: (value) => value / 1000000
+  }
+]

--- a/src/plugins/bscscan/tokens/converters.ts
+++ b/src/plugins/bscscan/tokens/converters.ts
@@ -1,0 +1,71 @@
+import { Account, AccountType, Transaction } from '../../../types/zenmoney'
+import { generateTokenAddress, SUPPORTED_TOKENS } from './config'
+import { TokenAccount, TokenTransaction } from './types'
+
+function convertAccount (account: TokenAccount): Account | null {
+  const token = SUPPORTED_TOKENS.find(token => token.contractAddress === account.contractAddress)
+
+  if (!token) {
+    return null
+  }
+
+  const id = generateTokenAddress(account.id, token)
+
+  return {
+    id,
+    type: AccountType.checking,
+    title: `${token.title} ${account.id}`,
+    instrument: token.instrument,
+    balance: token.convertBalance(account.balance),
+    syncIds: [id]
+  }
+}
+
+export function convertAccounts (accounts: TokenAccount[]): Account[] {
+  return accounts.map(convertAccount).filter((account): account is Account => account !== null)
+}
+
+export function convertTransaction (account: TokenAccount, transaction: TokenTransaction): Transaction | null {
+  const token = SUPPORTED_TOKENS.find(token => token.contractAddress === account.contractAddress)
+
+  if (!token) {
+    return null
+  }
+
+  const direction = transaction.from === account.id ? 'PAYMENT' : 'DEPOSIT'
+  const targetAccount = direction === 'PAYMENT' ? transaction.to : transaction.from
+  const sign = direction === 'PAYMENT' ? -1 : 1
+  const operationValue = token.convertBalance(Number(transaction.value))
+
+  return {
+    hold: null,
+    date: new Date(Number(transaction.timeStamp) * 1000),
+    movements: [
+      {
+        id: transaction.hash,
+        account: {
+          id: generateTokenAddress(account.id, token)
+        },
+        invoice: null,
+        sum: sign * operationValue,
+        fee: 0
+      }
+    ],
+    merchant: {
+      fullTitle: targetAccount,
+      mcc: null,
+      location: null
+    },
+    comment: null
+  }
+}
+
+export function convertTransactions (account: TokenAccount, transactions: TokenTransaction[]): Transaction[] {
+  const list = transactions
+    .map((transaction) => convertTransaction(account, transaction))
+    .filter((transaction): transaction is Transaction => transaction !== null)
+
+  console.log('LST', list)
+
+  return list
+}

--- a/src/plugins/bscscan/tokens/index.ts
+++ b/src/plugins/bscscan/tokens/index.ts
@@ -1,0 +1,31 @@
+import { Transaction } from '../../../types/zenmoney'
+import { mergeTransferTransactions } from '../common/converters'
+import { Scrape } from '../types'
+
+import { convertAccounts, convertTransactions } from './converters'
+import { fetchAccounts, fetchAccountTransactions } from './bep20'
+
+export const scrape: Scrape = async ({
+  preferences,
+  startBlock,
+  endBlock
+}) => {
+  const transactions: Transaction[] = []
+  const [accounts] = await Promise.all([
+    fetchAccounts(preferences)
+  ])
+
+  for (const account of accounts) {
+    const accountTransactions = await fetchAccountTransactions(preferences, account, {
+      startBlock,
+      endBlock
+    })
+
+    transactions.push(...convertTransactions(account, accountTransactions))
+  }
+
+  return {
+    accounts: convertAccounts(accounts),
+    transactions: mergeTransferTransactions(transactions)
+  }
+}

--- a/src/plugins/bscscan/tokens/types.ts
+++ b/src/plugins/bscscan/tokens/types.ts
@@ -1,0 +1,37 @@
+import { Response } from '../common'
+
+export interface AccountResponse extends Response {
+  result: string
+}
+
+export interface TokenTransaction {
+  blockNumber: string
+  timeStamp: string
+  hash: string
+  nonce: string
+  blockHash: string
+  from: string
+  contractAddress: string
+  to: string
+  value: string
+  tokenName: string
+  tokenSymbol: string
+  tokenDecimal: string
+  transactionIndex: string
+  gas: string
+  gasPrice: string
+  gasUsed: string
+  cumulativeGasUsed: string
+  input: string
+  confirmations: string
+}
+
+export interface TokenTransactionResponse extends Response {
+  result: TokenTransaction[]
+}
+
+export interface TokenAccount {
+  id: string
+  balance: number
+  contractAddress: string
+}

--- a/src/plugins/bscscan/types.ts
+++ b/src/plugins/bscscan/types.ts
@@ -1,0 +1,14 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+
+export interface Preferences {
+  apiKey: string
+  account: string
+}
+
+export type Scrape = (args: {
+  startBlock: number
+  endBlock: number
+  preferences: Preferences
+  isFirstRun: boolean
+  isInBackground: boolean
+}) => ReturnType<ScrapeFunc<Preferences>>


### PR DESCRIPTION
This plugin based on `etherscan` plugin because API interfaces of bscscan and etherscan are similar.