### PR TITLE
[bnbank] Improve(fix) last transactions (add processing ones)

### DIFF
--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -267,9 +267,45 @@ function mockDepositAccountStatement () {
 }
 
 function mockCardLastTransactions () {
-  fetchMock.once('https://mb.bnb.by/services/v2/products/getBlockedAmountStatement', {
+  fetchMock.once('https://mb.bnb.by/services/v2/products/getCardTransactions', {
     status: 200,
-    body: '{"errorInfo":{"error":"0","errorText":"Успешно"}}',
+    body: JSON.stringify({
+      errorInfo:
+    {
+      error: '0',
+      errorText: 'Успешно'
+    },
+      transactions:
+    [
+      {
+        identifier: '_aabb',
+        operations:
+            [
+              {
+                operationSign: '1',
+                operationId: '-',
+                transactionAmount: 0.0,
+                transactionCurrency: '840',
+                operationAmount: 0.0,
+                operationCurrency: '840',
+                operationName: 'Капитализация',
+                transType: '-',
+                operationDetail:
+                    {
+                      source: '5*** **** **** 1111',
+                      authCode: '-',
+                      mccCode: '-',
+                      paymentDate: 1547051340000,
+                      operationDescription: '-',
+                      status: 'DONE',
+                      terminalLocation: '-',
+                      operationName: '-'
+                    }
+              }
+            ]
+      }
+    ]
+    }),
     statusText: 'OK',
     headers: { session_token: '6af71bdf-69f8-4f62-8e59-4c26ce68add1' },
     sendAsJson: false

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -244,17 +244,22 @@ export async function fetchTransactions (token, accounts, fromDate, toDate = new
 export async function fetchLastCardTransactions (token, account) {
   console.log('>>> Загрузка списка последних транзакций для карты ' + account.title)
 
-  const response = await fetchApiJson('products/getBlockedAmountStatement', {
+  const response = await fetchApiJson('products/getCardTransactions', {
     method: 'POST',
     headers: { session_token: token },
     body: {
       cards: [
         account.cardHash
       ],
+      reportData: {
+        from: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).getTime(),
+        till: new Date().getTime()
+      },
       internalAccountId: account.id
     }
   }, response => response.body)
-  const operations = response.body.operations ? response.body.operations : []
+  const transactions = response.body.transactions || []
+  const operations = flatMap(transactions, t => t.operations || [])
   for (let i = 0; i < operations.length; i++) {
     operations[i].accountNumber = account.syncID[0]
   }

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -98,7 +98,7 @@ export function convertTransaction (apiTransaction, accounts, hold = false) {
     instrument: codeToCurrencyLookup[transactionCurrency]
   }
   const transaction = {
-    date: new Date(apiTransaction.operationDate),
+    date: new Date(apiTransaction.operationDate ?? apiTransaction.operationDetail.paymentDate),
     movements: [
       {
         id: apiTransaction.transactionAuthCode ? apiTransaction.transactionAuthCode : null,


### PR DESCRIPTION
AR:
Since around mid 2024, when BNB Bank changed their API, it has become impossible to retrieve unconfirmed transactions — the `getBlockedAmountStatement` request always returns 0 transactions.

ER:
There is another request, `getCardTransactions`, which resolves this issue.

NOTE:
The current implementation is not complete — it could potentially be improved by filtering only transactions with the “processing” status and verifying that all fields are parsed correctly (as the structure differs slightly).
However, since the API is closed, debugging the app would take significantly more time. Zenmoney already merges transactions correctly, so there’s no urgent need for further adjustments. The structure is consistent for all main fields, so in case a bug arises, fixing it should be straightforward.

Screens:
Before:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/96be2e38-dd07-4ae8-82bd-ca5e9d5d7313" />

After:
+6 transactions (that were completed today)
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/0e70420d-9ef0-4a25-93da-8110aeeb3c6d" />
