### PR TITLE
[etherscan]: handle No transactions found gracefully

### DIFF
--- a/src/plugins/etherscan/__tests__/converters/ether-scrape.test.ts
+++ b/src/plugins/etherscan/__tests__/converters/ether-scrape.test.ts
@@ -32,6 +32,14 @@ describe('scrape', () => {
         instrument: 'μETH',
         balance: 10000000,
         syncIds: ['2']
+      },
+      {
+        id: '3',
+        type: AccountType.checking,
+        title: '3',
+        instrument: 'μETH',
+        balance: 0,
+        syncIds: ['3']
       }
     ])
 

--- a/src/plugins/etherscan/common/index.ts
+++ b/src/plugins/etherscan/common/index.ts
@@ -24,6 +24,11 @@ async function fetchInner<T extends Response> (params: Record<string, string | n
     return data
   }
 
+  // No transactions found is also a valid response
+  if (data.status === '0' && data.message === 'No transactions found') {
+    return data
+  }
+
   throw new Error(`fetch error: ${JSON.stringify(response)}`)
 }
 

--- a/src/plugins/etherscan/mocks/index.ts
+++ b/src/plugins/etherscan/mocks/index.ts
@@ -18,6 +18,10 @@ export const accountResponseMock: AccountResponse = {
     {
       account: '2',
       balance: '10000000000000000000'
+    },
+    {
+      account: '3',
+      balance: '0'
     }
   ]
 }
@@ -88,6 +92,12 @@ export const transactionsResponseMock2: TransactionResponse = {
   ]
 }
 
+export const transactionsResponseMock3: TransactionResponse = {
+  status: '0',
+  message: 'No transactions found',
+  result: []
+}
+
 export function mockEndPoints (): void {
   fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=balancemulti&address=1%2C2&tag=latest&apiKey=API_KEY&chainid=1', {
     status: 200,
@@ -108,5 +118,9 @@ export function mockEndPoints (): void {
   fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY&chainid=1', {
     status: 200,
     body: transactionsResponseMock2
+  })
+  fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=txlist&address=3&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY&chainid=1', {
+    status: 200,
+    body: transactionsResponseMock3
   })
 }


### PR DESCRIPTION
txlist can return `No trascations found` which is a valid response and should be handled gracefully, but currently it just aborts and crashes syncronization