### PR TITLE
[bankofgeorgia-ge] Use /rest/operations API (fixes #888)

### DIFF
--- a/src/plugins/bankofgeorgia-ge/converters.ts
+++ b/src/plugins/bankofgeorgia-ge/converters.ts
@@ -1,7 +1,20 @@
 import { Account, AccountType, ExtendedTransaction, Merchant, Movement, Amount } from '../../types/zenmoney'
 import { ConvertedAccount, ConvertedProduct, FetchedAccount, ConvertedLoan } from './models'
-import { getArray, getNumber, getOptNumber, getOptString, getString } from '../../types/get'
+import get, { getArray, getNumber, getOptNumber, getOptString, getString } from '../../types/get'
 import { getIntervalBetweenDates } from '../../common/momentDateUtils'
+
+function parseAmount (data: unknown, path: string): number {
+  const value = get(data, path)
+  if (typeof value === 'number') {
+    return value
+  }
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value)
+    assert(!isNaN(parsed), `cant parse amount as number at "${path}" from `, data)
+    return parsed
+  }
+  assert(false, `cant get number at "${path}" from `, data)
+}
 
 export function getAmountFromDescription (description: string | undefined): Amount | null {
   if (description == null || description === undefined) {
@@ -146,25 +159,50 @@ function convertLoan (apiAccount: FetchedAccount): ConvertedLoan {
 export function convertTransaction (apiTransaction: unknown, product: ConvertedProduct): ExtendedTransaction | null {
   const printFormType = getString(apiTransaction, 'printFormType')
   const entryType = getString(apiTransaction, 'entryType')
-  const entryGroupDKey = getString(apiTransaction, 'entryGroupDKey')
+  // Handle both old API (entryGroupDKey) and new API (entryGroupDValue) field names
+  const entryGroupDKey = getOptString(apiTransaction, 'entryGroupDKey') ?? getOptString(apiTransaction, 'entryGroupDValue')
   const instrument = getString(apiTransaction, 'ccy')
-  let date = new Date(getNumber(apiTransaction, 'inpSysdate'))
-  if (getOptString(apiTransaction, 'authDateStr') !== undefined) {
-    const authDateStr = parseTransactionDate(getString(apiTransaction, 'authDateStr'))
+
+  // Handle date parsing for both old and new API formats
+  let date: Date
+  if (getOptString(apiTransaction, 'postDate') !== undefined) {
+    // New API format: uses ISO date string in postDate
+    date = new Date(getString(apiTransaction, 'postDate'))
+  } else {
+    // Old API format: uses timestamp in inpSysdate
+    date = new Date(getNumber(apiTransaction, 'inpSysdate'))
+  }
+
+  // Handle auth date for both formats
+  const authDateField = getOptString(apiTransaction, 'authDate') ?? getOptString(apiTransaction, 'authDateStr')
+  if (authDateField !== undefined) {
+    const authDateStr = parseTransactionDate(authDateField)
     if (authDateStr !== null) {
       date = new Date(authDateStr)
     }
   }
+
   assert(instrument === product.account.instrument, 'invoice tx found', apiTransaction)
+
+  // Handle transaction ID for both old and new API formats
+  let transactionId: string
+  if (getOptString(apiTransaction, 'entryId') !== undefined) {
+    // New API format: uses entryId
+    transactionId = getString(apiTransaction, 'entryId')
+  } else {
+    // Old API format: uses statmentId
+    transactionId = getNumber(apiTransaction, 'statmentId').toString()
+  }
+
   const transaction: ExtendedTransaction = {
     hold: getString(apiTransaction, 'status') === 'F',
     date,
     movements: [
       {
-        id: getNumber(apiTransaction, 'statmentId').toString(), // also there are entryId, docKey
+        id: transactionId,
         account: { id: product.account.id },
         invoice: null,
-        sum: -getNumber(apiTransaction, 'amount'),
+        sum: -parseAmount(apiTransaction, 'amount'),
         fee: 0
       }
     ],
@@ -210,8 +248,23 @@ export function convertTransaction (apiTransaction: unknown, product: ConvertedP
           transaction.movements.push(
             invertMovement(transaction.movements[0], product.account, { type: AccountType.ccard })
           )
-          if (getNumber(apiTransaction, 'statmentId') !== getNumber(apiTransaction, 'docKey')) {
-            transaction.groupKeys = [getNumber(apiTransaction, 'docKey').toString()]
+
+          // Handle groupKeys for both old and new API formats
+          let statementId: number | string
+          let docKeyId: number | string
+
+          if (getOptString(apiTransaction, 'entryId') !== undefined) {
+            // New API format
+            statementId = getString(apiTransaction, 'entryId')
+            docKeyId = getNumber(apiTransaction, 'docKey')
+          } else {
+            // Old API format
+            statementId = getNumber(apiTransaction, 'statmentId')
+            docKeyId = getNumber(apiTransaction, 'docKey')
+          }
+
+          if (statementId.toString() !== docKeyId.toString()) {
+            transaction.groupKeys = [docKeyId.toString()]
           }
         }
       }
@@ -240,7 +293,7 @@ export function convertTransaction (apiTransaction: unknown, product: ConvertedP
         transaction.comment = 'Cash withdrawal comission / ' + getString(apiTransaction, 'nominationOriginal')
       } else {
         transaction.comment = 'Cash withdrawal'
-        const txAmount = getNumber(apiTransaction, 'amount')
+        const txAmount = parseAmount(apiTransaction, 'amount')
         if (cashAmount != null) {
           if (cashAmount.instrument !== product.account.instrument) {
             transaction.movements[0].invoice = { sum: -cashAmount.sum, instrument: cashAmount.instrument }
@@ -264,7 +317,7 @@ export function convertTransaction (apiTransaction: unknown, product: ConvertedP
             transaction.comment = 'cash withdrawal fee'
             break
           }
-          const txAmount = getNumber(apiTransaction, 'amount')
+          const txAmount = parseAmount(apiTransaction, 'amount')
           if (cashAmount != null) {
             if (cashAmount.instrument !== product.account.instrument) {
               transaction.movements[0].invoice = { sum: -cashAmount.sum, instrument: cashAmount.instrument }


### PR DESCRIPTION
Having 0 (none, zero) JS experience, I managed to implement /rest/operations for bankofgeorgia-ge plugin. It works better than before (fixes #888 )

I would like someone more experienced with ZenPlugins code to take over this PR. Maybe @lucomsky or @strawberrystr1 can help?