### PR TITLE
[etherscan] Support BSC in etherscan plugin

### DIFF
--- a/src/plugins/etherscan/ZenmoneyManifest.xml
+++ b/src/plugins/etherscan/ZenmoneyManifest.xml
@@ -3,8 +3,8 @@
     <id>etherscan</id>
     <company>15936</company>
     <description>
-        Плагин для синхронизации ETH с помощью etherscan.
-        Для синхронизации укажите ApiKey и адреса кошельков.
+        Плагин для синхронизации ETH и BSC с помощью etherscan V2.
+        Для синхронизации выберите блокчейн, укажите ApiKey etherscan V2 и адреса кошельков.
     </description>
     <version>1.0</version>
     <build>4</build>

--- a/src/plugins/etherscan/common/config.ts
+++ b/src/plugins/etherscan/common/config.ts
@@ -1,0 +1,7 @@
+export const ETHER_MAINNET = 1
+export const BNB_MAINNET = 56
+
+export const Instruments = {
+  [ETHER_MAINNET]: 'μETH',
+  [BNB_MAINNET]: 'bnb'
+} as const

--- a/src/plugins/etherscan/common/index.ts
+++ b/src/plugins/etherscan/common/index.ts
@@ -10,10 +10,11 @@ const baseUrl = 'https://api.etherscan.io/v2/api'
 const MAX_RPS = 5
 let activeList: Array<Promise<unknown>> = []
 
-async function fetchInner<T extends Response> (params: Record<string, string | number>): Promise<T> {
+async function fetchInner<T extends Response> (
+  params: Record<string, string | number>
+): Promise<T> {
   const query = stringify({
-    ...params,
-    chainid: 1
+    ...params
   })
 
   const response = await fetchJson(`${baseUrl}?${query}`)
@@ -32,15 +33,18 @@ async function fetchInner<T extends Response> (params: Record<string, string | n
   throw new Error(`fetch error: ${JSON.stringify(response)}`)
 }
 
-export async function fetch<T extends Response> (params: Record<string, string | number>): Promise<T> {
+export async function fetch<T extends Response> (
+  params: Record<string, string | number>
+): Promise<T> {
   if (activeList.length < MAX_RPS) {
     const request = fetchInner<T>(params)
 
     const waiter = request
       .then(async () => await delay(1000))
       .catch(async () => await delay(1000))
-      .then(() => { // eslint-disable-line @typescript-eslint/no-floating-promises
-        activeList = activeList.filter(item => item !== waiter)
+      .then(() => {
+        // eslint-disable-line @typescript-eslint/no-floating-promises
+        activeList = activeList.filter((item) => item !== waiter)
       })
     activeList.push(waiter)
 
@@ -58,6 +62,7 @@ export async function fetchBlockNoByTime (
   { timestamp }: { timestamp: number }
 ): Promise<number> {
   const response = await fetch<BlockNoResponse>({
+    chainid: preferences.chain,
     module: 'block',
     action: 'getblocknobytime',
     closest: 'before',

--- a/src/plugins/etherscan/common/types.ts
+++ b/src/plugins/etherscan/common/types.ts
@@ -1,3 +1,5 @@
+import { ETHER_MAINNET, BNB_MAINNET } from './config'
+
 export interface Response {
   status: string
   message: string
@@ -6,3 +8,5 @@ export interface Response {
 export interface BlockNoResponse extends Response {
   result: string
 }
+
+export type Chain = typeof ETHER_MAINNET | typeof BNB_MAINNET

--- a/src/plugins/etherscan/ether/api.ts
+++ b/src/plugins/etherscan/ether/api.ts
@@ -1,11 +1,17 @@
 import { fetch } from '../common'
 import { Preferences } from '../types'
-import { AccountResponse, EthereumAccount, EthereumTransaction, TransactionResponse } from './types'
+import {
+  AccountResponse,
+  EthereumAccount,
+  EthereumTransaction,
+  TransactionResponse
+} from './types'
 
 export async function fetchAccounts (
   preferences: Preferences
 ): Promise<EthereumAccount[]> {
   const response = await fetch<AccountResponse>({
+    chainid: preferences.chain,
     module: 'account',
     action: 'balancemulti',
     address: preferences.account,
@@ -33,6 +39,7 @@ export async function fetchAccountTransactions (
 
   try {
     const response = await fetch<TransactionResponse>({
+      chainid: preferences.chain,
       module: 'account',
       action: 'txlist',
       address: account,
@@ -49,15 +56,16 @@ export async function fetchAccountTransactions (
     if (response.result.length === PAGE_SIZE) {
       return [
         ...transactions,
-        ...await fetchAccountTransactions(preferences, {
+        ...(await fetchAccountTransactions(preferences, {
           ...options,
           page: page + 1
-        })
+        }))
       ]
     }
 
     return transactions
-  } catch (error: any) { // eslint-disable-line
+  } catch (error: any) {
+    // eslint-disable-line
     if (error?.body?.message === 'No transactions found') {
       return []
     }

--- a/src/plugins/etherscan/ether/index.ts
+++ b/src/plugins/etherscan/ether/index.ts
@@ -3,17 +3,15 @@ import { Scrape } from '../types'
 import { fetchAccounts, fetchAccountTransactions } from './api'
 import { mergeTransferTransactions } from '../common/converters'
 import { convertAccounts, convertTransactions } from './converters'
+import { Instruments } from '../common/config'
 
-export const scrape: Scrape = async ({
-  preferences,
-  startBlock,
-  endBlock
-}) => {
+export const scrape: Scrape = async ({ preferences, startBlock, endBlock }) => {
   const transactions: Transaction[] = []
 
   const accountsResponse = await fetchAccounts(preferences)
 
-  const accounts: Account[] = convertAccounts(accountsResponse)
+  const instrument = Instruments[preferences.chain]
+  const accounts: Account[] = convertAccounts(accountsResponse, instrument)
 
   for (const account of accounts) {
     const accountTransactions = await fetchAccountTransactions(preferences, {

--- a/src/plugins/etherscan/index.ts
+++ b/src/plugins/etherscan/index.ts
@@ -1,9 +1,10 @@
-import { ScrapeFunc } from '../../types/zenmoney'
+import type { ScrapeFunc } from '../../types/zenmoney'
 import { fetchBlockNoByTime } from './common'
-import { Preferences } from './types'
+import type { Preferences } from './types'
 
 import { scrape as scrapeEther } from './ether'
 import { scrape as scrapeTokens } from './tokens'
+import { ETHER_MAINNET } from './common/config'
 
 export const scrape: ScrapeFunc<Preferences> = async ({
   fromDate,
@@ -12,6 +13,10 @@ export const scrape: ScrapeFunc<Preferences> = async ({
   isFirstRun,
   isInBackground
 }) => {
+  if (preferences.chain === undefined) {
+    preferences.chain = ETHER_MAINNET
+  }
+
   const [startBlock, endBlock] = await Promise.all([
     fetchBlockNoByTime(preferences, {
       timestamp: Math.floor(fromDate.valueOf() / 1000)

--- a/src/plugins/etherscan/mocks/index.ts
+++ b/src/plugins/etherscan/mocks/index.ts
@@ -1,8 +1,13 @@
 import fetchMock from 'fetch-mock'
-import { AccountResponse, BlockNoResponse, TransactionResponse } from '../ether/types'
+import {
+  AccountResponse,
+  BlockNoResponse,
+  TransactionResponse
+} from '../ether/types'
 import { Preferences } from '../types'
 
 export const preferencesMock: Preferences = {
+  chain: 1,
   apiKey: 'API_KEY',
   account: '1,2'
 }
@@ -99,28 +104,144 @@ export const transactionsResponseMock3: TransactionResponse = {
 }
 
 export function mockEndPoints (): void {
-  fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=balancemulti&address=1%2C2&tag=latest&apiKey=API_KEY&chainid=1', {
-    status: 200,
-    body: accountResponseMock
-  })
-  fetchMock.once('https://api.etherscan.io/v2/api?module=block&action=getblocknobytime&closest=before&timestamp=1640552400&apiKey=API_KEY&chainid=1', {
-    status: 200,
-    body: startBlockResponseMock
-  })
-  fetchMock.once('https://api.etherscan.io/v2/api?module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY&chainid=1', {
-    status: 200,
-    body: endBlockResponseMock
-  })
-  fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=txlist&address=1&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY&chainid=1', {
-    status: 200,
-    body: transactionsResponseMock1
-  })
-  fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY&chainid=1', {
-    status: 200,
-    body: transactionsResponseMock2
-  })
-  fetchMock.once('https://api.etherscan.io/v2/api?module=account&action=txlist&address=3&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY&chainid=1', {
-    status: 200,
-    body: transactionsResponseMock3
-  })
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=balancemulti&address=1%2C2&tag=latest&apiKey=API_KEY',
+    {
+      status: 200,
+      body: accountResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1640552400&apiKey=API_KEY',
+    {
+      status: 200,
+      body: startBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY',
+    {
+      status: 200,
+      body: endBlockResponseMock
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=1&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY',
+    {
+      status: 200,
+      body: transactionsResponseMock1
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY',
+    {
+      status: 200,
+      body: transactionsResponseMock2
+    }
+  )
+  fetchMock.once(
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=3&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY',
+    {
+      status: 200,
+      body: transactionsResponseMock3
+    }
+  )
 }

--- a/src/plugins/etherscan/preferences.xml
+++ b/src/plugins/etherscan/preferences.xml
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen>
+    <ListPreference
+        positiveButtonText="ОК"
+        key="chain"
+        dialogTitle="Блокчейн"
+        negativeButtonText="Отмена"
+        title="Блокчейн"
+        entries="Etherium|BSC" entryValues="1|56"
+        defaultValue="1"
+        summary="|Блокчейн|{@s}"
+        obligatory="true"
+    />
     <EditTextPreference
         key="apiKey"
         obligatory="true"
         title="ApiKey"
-        dialogTitle="ApiKey"
+        dialogTitle="Etherscan V2 API Key"
         positiveButtonText="ОК"
         negativeButtonText="Отмена"
         summary="|Ключ от API|***********"

--- a/src/plugins/etherscan/tokens/config.ts
+++ b/src/plugins/etherscan/tokens/config.ts
@@ -1,31 +1,54 @@
-export interface TokenConfig {
+import { ETHER_MAINNET, BNB_MAINNET } from '../common/config'
+
+export type TokenConfig = Record<number, TokenConfigItem[]>
+
+export interface TokenConfigItem {
   title: string
   contractAddress: string
   instrument: string
   convertBalance: (value: number) => number
 }
 
-export const generateTokenAddress = (address: string, token: TokenConfig): string => {
+export const generateTokenAddress = (
+  address: string,
+  token: TokenConfigItem
+): string => {
   return `${address}-${token.contractAddress}`
 }
 
-export const SUPPORTED_TOKENS: TokenConfig[] = [
-  {
-    title: 'USDT',
-    contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
-    instrument: 'USDT',
-    convertBalance: (value) => value / 1000000
-  },
-  {
-    title: 'USDC',
-    contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-    instrument: 'USDT',
-    convertBalance: (value) => value / 1000000
-  },
-  {
-    title: 'BUSD',
-    contractAddress: '0x4fabb145d64652a948d72533023f6e7a623c7c53',
-    instrument: 'USDT',
-    convertBalance: (value) => value / 1000000
-  }
-]
+export const SUPPORTED_TOKENS: TokenConfig = {
+  [ETHER_MAINNET]: [
+    {
+      title: 'USDT',
+      contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      instrument: 'USDT',
+      convertBalance: (value: number) => value / 1000000
+    },
+    {
+      title: 'USDC',
+      contractAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      instrument: 'USDT',
+      convertBalance: (value: number) => value / 1000000
+    },
+    {
+      title: 'BUSD',
+      contractAddress: '0x4fabb145d64652a948d72533023f6e7a623c7c53',
+      instrument: 'USDT',
+      convertBalance: (value: number) => value / 1000000
+    }
+  ],
+  [BNB_MAINNET]: [
+    {
+      title: 'USDT',
+      contractAddress: '0x55d398326f99059fF775485246999027B3197955',
+      instrument: 'USDT',
+      convertBalance: (value: number) => value / 1000000000 / 1000000000
+    },
+    {
+      title: 'USDC',
+      contractAddress: '0x8965349fb649a33a30cbfda057d8ec2c48abe2a2',
+      instrument: 'USDT',
+      convertBalance: (value: number) => value / 1000000000 / 1000000000
+    }
+  ]
+}

--- a/src/plugins/etherscan/tokens/index.ts
+++ b/src/plugins/etherscan/tokens/index.ts
@@ -5,27 +5,27 @@ import { Scrape } from '../types'
 import { convertAccounts, convertTransactions } from './converters'
 import { fetchAccounts, fetchAccountTransactions } from './erc20'
 
-export const scrape: Scrape = async ({
-  preferences,
-  startBlock,
-  endBlock
-}) => {
+export const scrape: Scrape = async ({ preferences, startBlock, endBlock }) => {
   const transactions: Transaction[] = []
-  const [accounts] = await Promise.all([
-    fetchAccounts(preferences)
-  ])
+  const [accounts] = await Promise.all([fetchAccounts(preferences)])
 
   for (const account of accounts) {
-    const accountTransactions = await fetchAccountTransactions(preferences, account, {
-      startBlock,
-      endBlock
-    })
+    const accountTransactions = await fetchAccountTransactions(
+      preferences,
+      account,
+      {
+        startBlock,
+        endBlock
+      }
+    )
 
-    transactions.push(...convertTransactions(account, accountTransactions))
+    transactions.push(
+      ...convertTransactions(account, accountTransactions, preferences.chain)
+    )
   }
 
   return {
-    accounts: convertAccounts(accounts),
+    accounts: convertAccounts(accounts, preferences.chain),
     transactions: mergeTransferTransactions(transactions)
   }
 }

--- a/src/plugins/etherscan/types.ts
+++ b/src/plugins/etherscan/types.ts
@@ -1,6 +1,8 @@
-import { ScrapeFunc } from '../../types/zenmoney'
+import type { ScrapeFunc } from '../../types/zenmoney'
+import type { Chain } from './common/types'
 
 export interface Preferences {
+  chain: Chain
   apiKey: string
   account: string
 }


### PR DESCRIPTION
bscscan stopped issuing new API keys and forces developers to use etherscan v2 multichain scanner. 
Due to that reason, the `bscscan` plugin doesn't work anymore, as you can't get an API key for it. 

This PR adds the Binance Smart Chain support to the etherscan plugin by providing the chain selection in the plugin preferences. 

I'm a bit unsure about the balance amount conversion. The current implementation for the etherium shows the balance x 12 to the real one. I set the divider to 10^18, and with that I can see the correct balance for USDT in the development environment. 

Probably, the divider for the Etherium balances should be changed, or maybe I missed something. 