### PR TITLE
[apelsin-uz] Adding uzum visa cards support

### DIFF
--- a/src/plugins/apelsin-uz/__tests__/accounts/card.test.js
+++ b/src/plugins/apelsin-uz/__tests__/accounts/card.test.js
@@ -111,4 +111,24 @@ describe('convertAccount', () => {
       balance: 21141190.51
     })
   })
+  it('converts account UZUM VISA', () => {
+    expect(convertCard({
+      id: 48798631,
+      account: '22618000613592339001',
+      state: 'ACTIVE',
+      pan: '491699******0167',
+      currency: { name: 'UZS', scale: 2 },
+      type: 'UZUM_DEBIT_VISA',
+      balance: 998100
+    })).toEqual({
+      id: '48798631',
+      type: 'ccard',
+      title: 'UZUM_DEBIT_VISA *0167',
+      instrument: 'UZS',
+      syncIds: [
+        '491699******0167'
+      ],
+      balance: 9981
+    })
+  })
 })

--- a/src/plugins/apelsin-uz/__tests__/transactions/outcome.test.js
+++ b/src/plugins/apelsin-uz/__tests__/transactions/outcome.test.js
@@ -2,6 +2,7 @@ import {
   convertUzcardCardTransaction,
   convertHumoCardTransaction,
   convertVisaCardTransaction,
+  convertUzumVisaCardTransaction,
   convertWalletTransaction,
   convertAccountTransaction
 } from '../../converters'
@@ -95,6 +96,56 @@ describe('convertTransaction', () => {
   ])('converts outcome VISA', (rawTransaction, transaction) => {
     const card = { id: 'card', instrument: 'USD' }
     expect(convertVisaCardTransaction(card, rawTransaction)).toEqual(transaction)
+  })
+
+  it.each([
+    [
+      {
+        transactionId: '6f358aef-c368-4044-80a0-2e5d97b123f4',
+        holdId: 'b53c79df-37e2-425c-a416-bd119b2476aa',
+        description: 'ELECTRONIC_PURCHASE',
+        transactionStatus: 'SUCCESS',
+        transAmount: '1700.00',
+        transCurrency: 'UZS',
+        conversionRate: '1.0000000',
+        transDate: 1758091645083,
+        amount: '1700.00',
+        merchantName: 'ATTO>uzumbank.uz/                     UZ',
+        transType: 'DEBIT',
+        fee: '0.00',
+        currency: {
+          uzscurrency: true,
+          name: 'UZS',
+          scale: 2
+        },
+        transCode: '680',
+        reversed: false
+      },
+      {
+        date: new Date('2025-09-17T06:47:25.083Z'),
+        hold: false,
+        comment: null,
+        merchant: {
+          country: null,
+          city: null,
+          title: 'ATTO>uzumbank.uz/                     UZ',
+          mcc: null,
+          location: null
+        },
+        movements: [
+          {
+            id: '6f358aef-c368-4044-80a0-2e5d97b123f4',
+            account: { id: 'card' },
+            invoice: null,
+            sum: -1700,
+            fee: 0
+          }
+        ]
+      }
+    ]
+  ])('converts outcome VISA', (rawTransaction, transaction) => {
+    const card = { id: 'card', instrument: 'UZS' }
+    expect(convertUzumVisaCardTransaction(card, rawTransaction)).toEqual(transaction)
   })
 
   it.each([

--- a/src/plugins/apelsin-uz/api.js
+++ b/src/plugins/apelsin-uz/api.js
@@ -6,6 +6,7 @@ import {
   convertHumoCardTransaction,
   convertUzcardCardTransaction,
   convertVisaCardTransaction,
+  convertUzumVisaCardTransaction,
   convertWallet,
   convertWalletTransaction,
   convertMasterCardTransaction
@@ -105,6 +106,32 @@ export async function getVisaCards () {
   console.assert(response.ok, 'unexpected visa response', response)
 
   return response.body.data.map(convertCard).filter(card => card !== null)
+}
+
+/**
+ * Получить список карт платежной системы Visa от Uzum
+ *
+ * @returns массив карт платежной системы Visa от Uzum в формате Дзенмани
+ */
+export async function getUzumVisaCards () {
+  const endpoint = '/dbs/debit'
+  const requestHeaders = {
+    authorization: 'Bearer ' + ZenMoney.getData('apiAccessToken'),
+    'device-id': ZenMoney.getData('deviceId')
+  }
+
+  const response = await fetchJson(baseUrl + endpoint, {
+    method: 'GET',
+    headers: {
+      ...defaultHeaders,
+      ...requestHeaders
+    },
+    sanitizeRequestLog: { headers: { 'device-id': true, authorization: true } }
+  })
+
+  console.assert(response.ok, 'unexpected dbs/debit response', response)
+
+  return response.body.data.map(convertCard).filter((card) => card !== null)
 }
 
 /**
@@ -302,6 +329,47 @@ export async function getVisaCardsTransactions (cards, fromDate, toDate) {
 
       transactions = transactions.concat(response.body.data.map(transaction =>
         convertVisaCardTransaction(card, transaction)).filter(transaction => transaction !== null))
+    }
+  }
+
+  return transactions
+}
+
+/**
+ * Получить список транзакций по картам платежной системы Visa от Uzum
+ *
+ * @param cards массив карт платежной системы Visa от Uzum
+ * @param fromDate дата в формате ISO8601, с которой нужно выгружать транзакции
+ * @param toDate дата в формате ISO8601, по которую нужно выгружать транзакции
+ * @returns массив транзакций в формате Дзенмани
+ */
+export async function getUzumVisaCardsTransactions (cards, fromDate, toDate) {
+  let transactions = []
+  const requestHeaders = {
+    authorization: 'Bearer ' + ZenMoney.getData('apiAccessToken'),
+    'device-id': ZenMoney.getData('deviceId')
+  }
+
+  for (const card of cards) {
+    if (!ZenMoney.isAccountSkipped(card.id)) {
+      const endpoint = '/dbs/debit/history?' +
+        'cardId=' + card.id + '&' +
+        'dateFrom=' + fromDate + '&' +
+        'dateTo=' + toDate
+
+      const response = await fetchJson(baseUrl + endpoint, {
+        method: 'GET',
+        headers: {
+          ...defaultHeaders,
+          ...requestHeaders
+        },
+        sanitizeRequestLog: { headers: { 'device-id': true, authorization: true } }
+      })
+
+      console.assert(response.ok, 'unexpected dbs/debit/history response', response)
+
+      transactions = transactions.concat(response.body.data.map(transaction =>
+        convertUzumVisaCardTransaction(card, transaction)).filter(transaction => transaction !== null))
     }
   }
 

--- a/src/plugins/apelsin-uz/index.js
+++ b/src/plugins/apelsin-uz/index.js
@@ -8,6 +8,8 @@ import {
   getUzcardCardsTransactions,
   getVisaCards,
   getVisaCardsTransactions,
+  getUzumVisaCards,
+  getUzumVisaCardsTransactions,
   getWallets,
   getWalletsTransactions,
   getMastercardCards,
@@ -50,6 +52,7 @@ export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
   }
   const humoCards = await getHumoCards()
   const visaCards = await getVisaCards()
+  const uzumVisaCards = await getUzumVisaCards()
   const mastercardCards = await getMastercardCards()
   const wallets = await getWallets()
   const accounts = await getAccounts()
@@ -63,6 +66,7 @@ export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
   const uzcardCardsTransactions = await getUzcardCardsTransactions(uzcardCards, from, to)
   const humoCardsTransactions = await getHumoCardsTransactions(humoCards, from, to)
   const visaCardsTransactions = await getVisaCardsTransactions(visaCards, from, to)
+  const uzumVisaCardsTransactions = await getUzumVisaCardsTransactions(uzumVisaCards, from, to)
   const mastercardCardsTransactions = await getMastercardCardsTransactions(mastercardCards, from, to)
   const walletTransactions = await getWalletsTransactions(wallets, from, to)
   const accountTransactions = await getAccountsTransactions(accounts, from, to)
@@ -75,6 +79,7 @@ export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
       ...uzcardCards,
       ...humoCards,
       ...visaCards,
+      ...uzumVisaCards,
       ...mastercardCards,
       ...wallets,
       ...accounts
@@ -83,6 +88,7 @@ export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
       ...uzcardCardsTransactions,
       ...humoCardsTransactions,
       ...visaCardsTransactions,
+      ...uzumVisaCardsTransactions,
       ...mastercardCardsTransactions,
       ...walletTransactions,
       ...accountTransactions


### PR DESCRIPTION
This PR adds support for Uzum Bank Visa cards. These cards are retrieved from a new endpoint and feature a different transaction history schema.