### PR TITLE
add new transaction group type VE - fee for bank statement

### DIFF
--- a/src/plugins/bankofgeorgia-business-ge/converters.ts
+++ b/src/plugins/bankofgeorgia-business-ge/converters.ts
@@ -102,6 +102,7 @@ export function convertToZenMoneyTransaction (record: AccountRecord, allRecords:
 
     case 'COM':
     case 'FEE':
+    case 'VE': // Verification Entry - bank fee for document/certificate
       // commission or fee
       transaction.movements[0].fee = (transaction.movements[0].sum != null) ? -transaction.movements[0].sum : 0
       transaction.movements[0].sum = 0


### PR DESCRIPTION
Failing on reveiving and parsing transactions with group type = VE, it's just a fee for banks statement