### PR TITLE
[bankofgeorgia-business-ge] add adjust transactions

### DIFF
--- a/src/plugins/bankofgeorgia-business-ge/index.ts
+++ b/src/plugins/bankofgeorgia-business-ge/index.ts
@@ -2,6 +2,7 @@ import { ScrapeFunc, Account as ZenMoneyAccount, Transaction as ZenMoneyTransact
 import { parseAccounts, fetchTransactions, fetchBalance } from './api'
 import { convertToZenMoneyAccount, convertToZenMoneyTransaction, injectAccountInfo } from './converters'
 import { AccountRecord, Preferences } from './models'
+import { adjustTransactions } from '../../common/transactionGroupHandler'
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
   toDate = toDate ?? new Date()
@@ -32,6 +33,6 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
 
   return {
     accounts: zenAccounts,
-    transactions: zenTransactions
+    transactions: adjustTransactions({ transactions: zenTransactions })
   }
 }


### PR DESCRIPTION
For bankofgeorgia-business-ge plugin I add adjust transactions, because after receiving in applications no new transactions were saved. I have only updated sum on my account, but if I reopen the application my sum will be updated for old values and no new transactions will be saved. 