### PR TITLE
[timo-vn] Web client's version update

### DIFF
--- a/src/plugins/timo-vn/index.ts
+++ b/src/plugins/timo-vn/index.ts
@@ -7,7 +7,7 @@ import { generateRandomString } from '../../common/utils'
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate, isFirstRun }) => {
   toDate = toDate ?? new Date()
 
-  const appVersion = '291'
+  const appVersion = '293'
 
   if (isFirstRun) {
     const auth: Auth = {


### PR DESCRIPTION
-Web client's version updated 291->293
-Added ability to set up web client's version manually in case of "NEED_UPGRADE_APP_VERSION" error due to the bank updating versions very frequently. With this option skilled users can get properly working plugin without long waiting of merge.