### PR TITLE
[raiffeisen-business-rs]: resolving an auth error №96022

### DIFF
--- a/src/plugins/raiffeisen-business-rs/fetchApi.ts
+++ b/src/plugins/raiffeisen-business-rs/fetchApi.ts
@@ -109,7 +109,7 @@ export async function setLegalEntity (legalEntityId: string, lastSuccessfulLogon
       authenticationType: 'UsernamePassword',
       gridName: 'LegalEntityPreviewFlat',
       loginCertificateID: '',
-      multipleUser: true,
+      multipleUser: false,
       lastSuccessfulLogon,
       legalEntityId,
       ticket


### PR DESCRIPTION
сравнил с тем как осуществляется авторизация на сайте райфайзен банка, у них в пейлоад у эндпойнта SetLegalEntityWeb, значение multipleUser теперь false:  

```
authenticationType: 'UsernamePassword',
gridName: 'LegalEntityPreviewFlat',
loginCertificateID: '',
multipleUser: false, // ‼️ у нас сейчас true
```

если у нас поправить на multipleUser: **false** то синхронизация снова работает. 

**Я не знаю на что влияет это значение и не сломает ли это авторизацию у других пользователей?**