### PR TITLE
etherscan: decrease RPS limit

### DIFF
--- a/src/plugins/etherscan/common/index.ts
+++ b/src/plugins/etherscan/common/index.ts
@@ -7,7 +7,7 @@ import type { BlockNoResponse, Response } from './types'
 
 const baseUrl = 'https://api.etherscan.io/v2/api'
 
-const MAX_RPS = 5
+const MAX_RPS = 3
 let activeList: Array<Promise<unknown>> = []
 
 async function fetchInner<T extends Response> (


### PR DESCRIPTION
etherscan now has 3rps limit for free api keys instead of older 5 rps, see https://etherscan.io/apis