### PR TITLE
[etherscan] Filter tiny movements to avoid TSN validation errors

### DIFF
--- a/src/plugins/etherscan/__tests__/converters/token-transactions.test.ts
+++ b/src/plugins/etherscan/__tests__/converters/token-transactions.test.ts
@@ -1,0 +1,54 @@
+import { convertTransactions } from '../../tokens/converters'
+import { ETHER_MAINNET } from '../../common/config'
+import type { TokenAccount, TokenTransaction } from '../../tokens/types'
+
+const account: TokenAccount = {
+  id: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  balance: 0,
+  contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7'
+}
+
+const baseTransaction: TokenTransaction = {
+  blockNumber: '1',
+  timeStamp: '1658608646',
+  hash: '0x90bb0dcbe8fa38387145aa17d6ad99f57da91d4c6d4b65b5f7cf56454f73234b',
+  nonce: '1',
+  blockHash: '0x1',
+  from: '0x1111111111111111111111111111111111111111',
+  contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+  to: account.id,
+  value: '1000000',
+  tokenName: 'Tether USD',
+  tokenSymbol: 'USDT',
+  tokenDecimal: '6',
+  transactionIndex: '1',
+  gas: '21000',
+  gasPrice: '1000000000',
+  gasUsed: '21000',
+  cumulativeGasUsed: '21000',
+  input: 'deprecated',
+  confirmations: '1'
+}
+
+describe('token convertTransactions', () => {
+  it('filters out movements with absolute value below 0.01', () => {
+    const list = convertTransactions(
+      account,
+      [{ ...baseTransaction, value: '1' }],
+      ETHER_MAINNET
+    )
+
+    expect(list).toHaveLength(0)
+  })
+
+  it('keeps movements with absolute value at least 0.01', () => {
+    const list = convertTransactions(
+      account,
+      [{ ...baseTransaction, value: '10000' }],
+      ETHER_MAINNET
+    )
+
+    expect(list).toHaveLength(1)
+    expect(list[0].movements[0].sum).toBe(0.01)
+  })
+})

--- a/src/plugins/etherscan/__tests__/converters/token-transactions.test.ts
+++ b/src/plugins/etherscan/__tests__/converters/token-transactions.test.ts
@@ -41,6 +41,21 @@ describe('token convertTransactions', () => {
     expect(list).toHaveLength(0)
   })
 
+  it('does not leave fee-only transaction when payment amount is below 0.01', () => {
+    const list = convertTransactions(
+      account,
+      [{
+        ...baseTransaction,
+        from: account.id,
+        to: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        value: '1'
+      }],
+      ETHER_MAINNET
+    )
+
+    expect(list).toHaveLength(0)
+  })
+
   it('keeps movements with absolute value at least 0.01', () => {
     const list = convertTransactions(
       account,

--- a/src/plugins/etherscan/ether/converters.ts
+++ b/src/plugins/etherscan/ether/converters.ts
@@ -6,6 +6,8 @@ import {
 import { ETHER_MAINNET, Instruments } from '../common/config'
 import type { EthereumAccount, EthereumTransaction } from './types'
 
+const MIN_MOVEMENT_SUM = 0.01
+
 function convertWeiToUETH (value: number): number {
   return Math.round(value / 10 ** 12)
 }
@@ -85,7 +87,11 @@ export function convertTransactions (
   const list = transactions
     .map((transaction) => convertTransaction(account, transaction))
     .filter((transaction): transaction is Transaction =>
-      Boolean(transaction?.movements.some((movement) => movement.sum !== 0))
+      Boolean(
+        transaction?.movements.some((movement) =>
+          movement.sum !== null && Math.abs(movement.sum) >= MIN_MOVEMENT_SUM
+        )
+      )
     )
 
   return list

--- a/src/plugins/etherscan/tokens/converters.ts
+++ b/src/plugins/etherscan/tokens/converters.ts
@@ -10,6 +10,8 @@ import { ETHER_MAINNET } from '../common/config'
 import { getTransactionFee } from '../ether/converters'
 import type { EthereumTransaction } from '../ether/types'
 
+const MIN_MOVEMENT_SUM = 0.01
+
 function convertAccount (account: TokenAccount, chain: Chain): Account | null {
   const token = SUPPORTED_TOKENS[chain].find(
     (token) => token.contractAddress === account.contractAddress
@@ -128,7 +130,11 @@ export function convertTransactions (
   const list = transactions
     .flatMap((transaction) => convertTransaction(account, transaction, chain))
     .filter((transaction): transaction is Transaction =>
-      Boolean(transaction?.movements.some((movement) => movement.sum !== 0))
+      Boolean(
+        transaction?.movements.some((movement) =>
+          movement.sum !== null && Math.abs(movement.sum) >= MIN_MOVEMENT_SUM
+        )
+      )
     )
 
   return list

--- a/src/plugins/etherscan/tokens/converters.ts
+++ b/src/plugins/etherscan/tokens/converters.ts
@@ -66,6 +66,10 @@ export function convertTransaction (
   const operationValue = token.convertBalance(Number(transaction.value))
   const { gas, hash, timeStamp } = transaction
 
+  if (Math.abs(operationValue) < MIN_MOVEMENT_SUM) {
+    return null
+  }
+
   const transactions = []
   const TokenTransaction: Transaction = {
     hold: null,


### PR DESCRIPTION
## Summary
- filter out tiny movements below `0.01` in etherscan ETH converter
- filter out tiny movements below `0.01` in etherscan token converter
- add regression tests for token conversion threshold behavior

## Problem
After merging the previous etherscan fix, sync could still fail with:
`[TSN] Invalid transaction ... Income and outcome must be non-negative number >= 0.01`.

The root cause was tiny movement amounts passing through conversion and then failing transaction validation.

## Validation
- `XDG_CACHE_HOME=/tmp HOME=/tmp yarn test etherscan`
- live Etherscan check on provided wallet list and API key: `scrape -> patch -> ZPAPI.addTransaction` completed without TSN/TTS validation errors
