### PR TITLE
[belagroprombank] fix: correctly handle operationSign value as '0'

### DIFF
--- a/src/plugins/belagroprombank/__tests__/converters/transactions/outcome.test.js
+++ b/src/plugins/belagroprombank/__tests__/converters/transactions/outcome.test.js
@@ -397,6 +397,38 @@ describe('convertTransactions', () => {
           comment: 'Абонентская плата (Ежемесячная абонентская плата по БПК)'
         }
       ]
+    ],
+    // Transaction with `operationSign` is 0
+    [
+      [
+        {
+          operationName: 'Списание подоходного налога',
+          transactionDate: 1767230152000,
+          transactionSum: 0.0,
+          transactionCurrency: '933',
+          operationSign: '0',
+          operationDate: 1767575752000,
+          operationSum: 0.5
+        }
+      ],
+      [
+        {
+          hold: false,
+          date: new Date(1767230152000),
+          movements:
+            [
+              {
+                id: '1767230152000_-0.5',
+                account: { id: 'account' },
+                invoice: null,
+                sum: -0.5,
+                fee: 0
+              }
+            ],
+          merchant: null,
+          comment: 'Списание подоходного налога'
+        }
+      ]
     ]
   ])('converts outcome transfers', (apiTransaction, transaction) => {
     expect(convertTransactions(apiTransaction, account1)).toEqual(transaction)

--- a/src/plugins/belagroprombank/converters.js
+++ b/src/plugins/belagroprombank/converters.js
@@ -241,7 +241,8 @@ function convertTransaction (apiTransaction, account) {
   }
 
   const sign = apiTransaction.operationSign
-    ? Number(apiTransaction.operationSign)
+    // Convert to number or consider as expense (-1) if operationSign value is '0'
+    ? (Number(apiTransaction.operationSign) || -1)
     : [
         /^.*OPLATA USLUG.*$/i,
         /^.*Списание.*$/i,


### PR DESCRIPTION
Банк может возвращать транзакции, в которых `operationSign: '0'`. В таких случаях нужно расценивать операцию как расход и устанавливать знак как `-1`