### PR TITLE
[hapoalim] recover sync after LOGONOTP

### DIFF
--- a/src/plugins/hapoalim/api.js
+++ b/src/plugins/hapoalim/api.js
@@ -2,8 +2,22 @@ import { flatten } from 'lodash'
 import qs from 'querystring'
 import { InvalidPreferencesError, TemporaryError } from '../../errors'
 import { toISODateString } from '../../common/dateUtils'
-import { fetchJson, ParseError } from '../../common/network'
+import { fetchJson, ParseError, openWebViewAndInterceptRequest } from '../../common/network'
 import { generateRandomString } from '../../common/utils'
+
+const WEB_PORTAL_URL = 'https://login.bankhapoalim.co.il/'
+const WEB_SUCCESS_PATTERNS = [
+  /\/ng--portals\/rb\/he\//i,
+  /\/ng-portals\/rb\/he\//i,
+  /\/current-account\/transactions/i,
+  /\/ServerServices\/general\/accounts/i
+]
+const API_BASE_URLS = {
+  mobile: 'https://iphone.bankhapoalim.co.il',
+  official: 'https://login.bankhapoalim.co.il'
+}
+
+let apiHostMode = 'mobile'
 
 function summarizeResponse (response) {
   return response
@@ -58,33 +72,87 @@ export function isLikelyAuthGateError (error) {
     /text\/html/i.test(contentType)
 }
 
+function isUsingOfficialApiHost () {
+  return apiHostMode === 'official'
+}
+
+function resetApiHostMode () {
+  apiHostMode = 'mobile'
+}
+
 async function fetchApi (url, options) {
+  const usingOfficialApiHost = isUsingOfficialApiHost()
   const params = {
-    appId: 'bankApp3Generation',
     ...options?.accountId && { accountId: options.accountId }
   }
-  const fullUrl = url + ((url.indexOf('?') === -1) ? '?' : '&') + qs.stringify(params)
+  if (!usingOfficialApiHost) {
+    params.appId = 'bankApp3Generation'
+  }
+  const query = qs.stringify(params)
+  const fullUrl = query
+    ? url + ((url.indexOf('?') === -1) ? '?' : '&') + query
+    : url
+  const defaultHeaders = usingOfficialApiHost
+    ? {
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=UTF-8'
+      }
+    : {
+        mobile: 'ca',
+        'x-dynatrace': 'MT_3_1_1842511945_1_BankApp-Android-Gen3_0_1001_130',
+        Accept: 'application/json',
+        'Content-Type': 'application/json;charset=UTF-8',
+        'User-Agent': 'okhttp/3.12.1'
+      }
 
-  return fetchJson('https://iphone.bankhapoalim.co.il' + fullUrl, {
+  return fetchJson(API_BASE_URLS[apiHostMode] + fullUrl, {
     method: 'GET',
     ...options,
     sanitizeResponseLog: {
+      ...options?.sanitizeResponseLog,
       headers: {
-        'set-cookie': true
+        'set-cookie': true,
+        ...options?.sanitizeResponseLog?.headers
       }
     },
     headers: {
-      mobile: 'ca',
-      'x-dynatrace': 'MT_3_1_1842511945_1_BankApp-Android-Gen3_0_1001_130',
-      Accept: 'application/json',
-      'Content-Type': 'application/json;charset=UTF-8',
-      'User-Agent': 'okhttp/3.12.1',
+      ...defaultHeaders,
       ...options && options.headers
     }
   })
 }
 
+export async function tryInteractiveWebBootstrap () {
+  if (!ZenMoney?.openWebView) {
+    return false
+  }
+
+  try {
+    const result = await openWebViewAndInterceptRequest({
+      url: WEB_PORTAL_URL,
+      log: false,
+      intercept (request) {
+        return WEB_SUCCESS_PATTERNS.some(pattern => pattern.test(request.url))
+          ? { verified: true, url: request.url }
+          : null
+      }
+    })
+
+    const verified = Boolean(result?.verified)
+    if (verified) {
+      apiHostMode = 'official'
+    }
+
+    return verified
+  } catch (error) {
+    console.warn('interactive web bootstrap failed', error?.message || error)
+    return false
+  }
+}
+
 export async function login ({ login, password }, device) {
+  resetApiHostMode()
+
   const response = await fetchApi('/authenticate/verify', {
     method: 'POST',
     headers: {
@@ -176,7 +244,14 @@ export async function login ({ login, password }, device) {
       deviceId: '10010110210310410510610710810910a10b10c10d10e10f'
     },
     stringify: qs.stringify,
-    sanitizeRequestLog: { body: { identifier: true, credentials: true } }
+    sanitizeRequestLog: {
+      body: {
+        identifier: true,
+        credentials: true,
+        mfp: true,
+        deviceId: true
+      }
+    }
   })
 
   if (response.body.error?.errCode === '1.6' && response.body.error?.errDesc === 'Login Failure') {
@@ -200,8 +275,16 @@ export async function login ({ login, password }, device) {
 }
 
 async function fetchMainAccountDetails (mainAccount, accountId) {
-  const response = await fetchApi('/ServerServices/general/accounts/selectedAccount/totalBalances', { accountId })
-  mainAccount.details = response.body
+  const response = isUsingOfficialApiHost()
+    ? await fetchApi('/ServerServices/current-account/composite/balanceAndCreditLimit?view=details&lang=he', { accountId })
+    : await fetchApi('/ServerServices/general/accounts/selectedAccount/totalBalances', { accountId })
+
+  mainAccount.details = isUsingOfficialApiHost()
+    ? {
+        ...response.body,
+        currentAccountCreditFrame: response.body?.creditLimitAmount ?? response.body?.currentAccountCreditFrame ?? 0
+      }
+    : response.body
   mainAccount.structType = 'checking'
   return [mainAccount]
 }

--- a/src/plugins/hapoalim/index.js
+++ b/src/plugins/hapoalim/index.js
@@ -1,6 +1,6 @@
 import { adjustTransactions } from '../../common/transactionGroupHandler'
 import { ZPAPIError } from '../../errors'
-import { fetchAccounts, fetchTransactions, generateDevice, login, isLikelyAuthGateError } from './api'
+import { fetchAccounts, fetchTransactions, generateDevice, login, isLikelyAuthGateError, tryInteractiveWebBootstrap } from './api'
 import { convertAccounts, convertTransaction } from './converters'
 
 function getFallbackFromDate (preferences, toDate) {
@@ -29,6 +29,25 @@ function rethrowAuthGate (error, authState, isInBackground) {
   throw error
 }
 
+async function withInteractiveBootstrapRetry (fn, authState, isInBackground) {
+  try {
+    return await fn()
+  } catch (error) {
+    if (!isInBackground &&
+      authState?.state === 'LOGONOTP' &&
+      isLikelyAuthGateError(error) &&
+      await tryInteractiveWebBootstrap()) {
+      try {
+        return await fn()
+      } catch (retryError) {
+        rethrowAuthGate(retryError, authState, isInBackground)
+      }
+    }
+
+    rethrowAuthGate(error, authState, isInBackground)
+  }
+}
+
 export async function scrape ({ preferences, fromDate, toDate, isInBackground, isFirstRun }) {
   ZenMoney.locale = 'he'
 
@@ -47,12 +66,7 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground, i
   const seenAccountIds = new Set()
   const transactions = []
 
-  let apiAccounts
-  try {
-    apiAccounts = await fetchAccounts()
-  } catch (error) {
-    rethrowAuthGate(error, authState, isInBackground)
-  }
+  const apiAccounts = await withInteractiveBootstrapRetry(async () => await fetchAccounts(), authState, isInBackground)
 
   for (const { mainProduct, account } of convertAccounts(apiAccounts)) {
     if (seenAccountIds.has(account.id)) {
@@ -65,12 +79,11 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground, i
       continue
     }
 
-    let apiTransactions
-    try {
-      apiTransactions = await fetchTransactions(mainProduct, fromDate, toDate)
-    } catch (error) {
-      rethrowAuthGate(error, authState, isInBackground)
-    }
+    const apiTransactions = await withInteractiveBootstrapRetry(
+      async () => await fetchTransactions(mainProduct, fromDate, toDate),
+      authState,
+      isInBackground
+    )
 
     for (const apiTransaction of apiTransactions) {
       const transaction = convertTransaction(apiTransaction, account)


### PR DESCRIPTION
## Summary

Hapoalim now returns `LOGONOTP` on the legacy mobile login flow. After that step, the old `iphone.bankhapoalim.co.il/ServerServices` host no longer provides a usable JSON data session, so account loading falls into an HTML error page instead of returning `general/accounts`.

This patch adds a small recovery path for that case:

- keep the current mobile login flow as-is
- if login ended in `LOGONOTP` and the next data request hits the auth gate
- open the official Hapoalim web flow in WebView once
- after a verified official navigation, retry the failed data request against the official `login.bankhapoalim.co.il/ServerServices` host

For current accounts on the official host, the old
`/ServerServices/general/accounts/selectedAccount/totalBalances`
endpoint is blocked, so this patch uses
`/ServerServices/current-account/composite/balanceAndCreditLimit?view=details&lang=he`
instead and maps its response back to the existing converter contract.

## What changed

- one-shot interactive retry in foreground only
- no change for the healthy `LANDPAGE` path
- no WebView in background sync
- switch to the official `login.bankhapoalim.co.il` data host only after a verified WebView bootstrap
- map `balanceAndCreditLimit` back to:
  - `details.currentBalance`
  - `details.currentAccountCreditFrame`

## Compatibility

- current account ids are unchanged: `bank-branch-account`
- account iteration still comes from `general/accounts`
- transactions are still fetched per explicit `accountId`
- converters were not changed
- common runtime helpers were not changed

## Validation

Local checks:

- `node --check` on the changed plugin files
- local emulation scenarios `L-S0..L-S8` are green
- compatibility compare against the upstream base remains green on the non-WebView paths

Live evidence gathered outside Android runtime:

- after a real OTP-completed official web session,
  `https://login.bankhapoalim.co.il/ServerServices/general/accounts?lang=he`
  returns JSON
- `current-account/transactions` returns JSON on the official host
- `balanceAndCreditLimit` returns JSON for both current accounts
- the legacy `iphone` host still does not recover after OTP

## Notes

This is intentionally a small plugin-only change. It does not try to submit OTP programmatically, guess device fingerprints, or refactor shared runtime code.

The remaining runtime-specific risk is WebView-to-network session sharing inside the real ZenMoney Android runtime. That part cannot be fully proven in local emulation or desktop browser probes and still needs Android verification.
