### PR TITLE
hapoalim: switch sync to the official web session login flow

### DIFF
--- a/src/plugins/hapoalim/ZenmoneyManifest.xml
+++ b/src/plugins/hapoalim/ZenmoneyManifest.xml
@@ -10,5 +10,5 @@
         <js>index.js</js>
         <preferences>preferences.xml</preferences>
     </files>
-    <description>Softens LOGONOTP handling, fixes continuation integrity header and hardens optional endpoints.</description>
+    <description>Uses the official Bank Hapoalim web login flow and reuses the authenticated bank session for sync.</description>
 </provider>

--- a/src/plugins/hapoalim/__tests__/api.login.test.js
+++ b/src/plugins/hapoalim/__tests__/api.login.test.js
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+describe('hapoalim api login', () => {
+  let login
+  let openWebViewAndInterceptRequestMock
+  let fetchMock
+  let fetchJsonMock
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    openWebViewAndInterceptRequestMock = jest.fn(async ({ url, intercept }) => {
+      expect(url).toBe('https://login.bankhapoalim.co.il/cgi-bin/poalwwwc?reqName=getLogonPage')
+
+      const apiRequestResult = intercept({
+        url: 'https://login.bankhapoalim.co.il/ServerServices/general/accounts?lang=he',
+        headers: {
+          cookie: 'TS=api-cookie; XSRF-TOKEN=api-xsrf'
+        }
+      })
+      expect(apiRequestResult).toBeNull()
+
+      const portalRequestResult = intercept({
+        url: 'https://login.bankhapoalim.co.il/portalserver/HomePage',
+        headers: {
+          cookie: 'TS=portal-cookie; XSRF-TOKEN=portal-xsrf'
+        }
+      })
+
+      expect(portalRequestResult.auth.cookieHeader).toContain('TS=portal-cookie')
+      expect(portalRequestResult.auth.cookieHeader).toContain('XSRF-TOKEN=portal-xsrf')
+      expect(portalRequestResult.auth.xsrfToken).toBe('portal-xsrf')
+
+      return portalRequestResult
+    })
+
+    fetchMock = jest.fn().mockResolvedValue({
+      status: 200,
+      url: 'https://login.bankhapoalim.co.il/portalserver/HomePage',
+      headers: {},
+      body: 'window.bnhpApp = { restContext: "/pib" }'
+    })
+    fetchJsonMock = jest.fn()
+
+    global.ZenMoney = {
+      openWebView: jest.fn()
+    }
+
+    jest.doMock('../../../common/network', () => ({
+      __esModule: true,
+      fetch: fetchMock,
+      fetchJson: fetchJsonMock,
+      openWebViewAndInterceptRequest: openWebViewAndInterceptRequestMock,
+      ParseError: class ParseError extends Error {}
+    }))
+
+    login = require('../api').login
+  })
+
+  it('waits for an authenticated portal request, restores rest context and refreshes cookies from response headers', async () => {
+    fetchMock.mockResolvedValue({
+      status: 200,
+      url: 'https://login.bankhapoalim.co.il/portalserver/HomePage',
+      headers: {
+        'set-cookie': 'TS=rotated-cookie; Path=/, XSRF-TOKEN=rotated-xsrf; Path=/'
+      },
+      body: 'window.bnhpApp = { restContext: "/pib" }'
+    })
+
+    const auth = await login()
+
+    expect(openWebViewAndInterceptRequestMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://login.bankhapoalim.co.il/portalserver/HomePage',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Cookie: expect.stringContaining('TS=portal-cookie')
+        })
+      })
+    )
+    expect(auth).toMatchObject({
+      xsrfToken: 'rotated-xsrf',
+      restContext: 'pib'
+    })
+    expect(auth.cookieHeader).toContain('TS=rotated-cookie')
+    expect(auth.cookieHeader).toContain('XSRF-TOKEN=rotated-xsrf')
+  })
+})

--- a/src/plugins/hapoalim/__tests__/index.authFlow.test.js
+++ b/src/plugins/hapoalim/__tests__/index.authFlow.test.js
@@ -1,0 +1,233 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { makePluginDataApi } from '../../../ZPAPI.pluginData'
+
+describe('hapoalim auth flow', () => {
+  const apiAccounts = [{ id: 'api-account' }]
+  const convertedProduct = { id: '12-702-277819', type: 'account' }
+  const convertedAccount = { id: '12-702-277819', type: 'checking', instrument: 'ILS' }
+  const fromDate = new Date('2026-04-01T00:00:00.000Z')
+  const toDate = new Date('2026-04-14T00:00:00.000Z')
+
+  let scrape
+  let dataApi
+  let fetchAccountsMock
+  let fetchTransactionsMock
+  let loginMock
+  let normalizeStoredAuthMock
+  let isLikelyAuthGateErrorMock
+  let convertAccountsMock
+  let convertTransactionMock
+  let adjustTransactionsMock
+
+  function loadScrape (initialData = {}) {
+    dataApi = makePluginDataApi(initialData)
+    global.ZenMoney = {
+      locale: null,
+      isAccountSkipped: jest.fn().mockReturnValue(false),
+      alert: jest.fn(),
+      ...dataApi.methods
+    }
+
+    jest.doMock('../api', () => ({
+      __esModule: true,
+      fetchAccounts: fetchAccountsMock,
+      fetchTransactions: fetchTransactionsMock,
+      isLikelyAuthGateError: isLikelyAuthGateErrorMock,
+      login: loginMock,
+      normalizeStoredAuth: normalizeStoredAuthMock
+    }))
+
+    jest.doMock('../converters', () => ({
+      __esModule: true,
+      convertAccounts: convertAccountsMock,
+      convertTransaction: convertTransactionMock
+    }))
+
+    jest.doMock('../../../common/transactionGroupHandler', () => ({
+      __esModule: true,
+      adjustTransactions: adjustTransactionsMock
+    }))
+
+    scrape = require('../index').scrape
+  }
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.clearAllMocks()
+
+    fetchAccountsMock = jest.fn()
+    fetchTransactionsMock = jest.fn()
+    loginMock = jest.fn()
+    normalizeStoredAuthMock = jest.fn(auth => auth)
+    isLikelyAuthGateErrorMock = jest.fn(error => error?.isAuthGate === true)
+    convertAccountsMock = jest.fn(() => [{ mainProduct: convertedProduct, account: convertedAccount }])
+    convertTransactionMock = jest.fn(transaction => transaction)
+    adjustTransactionsMock = jest.fn(({ transactions }) => transactions)
+  })
+
+  it('reuses stored auth without re-login', async () => {
+    const savedAuth = {
+      cookieHeader: 'TS=1; XSRF-TOKEN=saved-xsrf',
+      xsrfToken: 'saved-xsrf',
+      restContext: 'pib',
+      acquiredAt: 1
+    }
+
+    loadScrape({ auth: savedAuth })
+    fetchAccountsMock.mockResolvedValue(apiAccounts)
+    fetchTransactionsMock.mockResolvedValue([])
+
+    const result = await scrape({
+      preferences: {},
+      fromDate,
+      toDate,
+      isInBackground: false,
+      isFirstRun: false
+    })
+
+    expect(loginMock).not.toHaveBeenCalled()
+    expect(fetchAccountsMock).toHaveBeenCalledTimes(1)
+    expect(fetchAccountsMock).toHaveBeenCalledWith(savedAuth)
+    expect(fetchTransactionsMock).toHaveBeenCalledWith(savedAuth, convertedProduct, fromDate, toDate)
+    expect(result).toEqual({
+      accounts: [convertedAccount],
+      transactions: []
+    })
+    expect(dataApi.currentData.auth).toEqual(savedAuth)
+  })
+
+  it('clears stale auth and logs in again in foreground', async () => {
+    const staleAuth = {
+      cookieHeader: 'TS=stale',
+      xsrfToken: 'stale-xsrf',
+      restContext: 'old',
+      acquiredAt: 1
+    }
+    const freshAuth = {
+      cookieHeader: 'TS=fresh; XSRF-TOKEN=fresh-xsrf',
+      xsrfToken: 'fresh-xsrf',
+      restContext: 'pib',
+      acquiredAt: 2
+    }
+    const authGateError = Object.assign(new Error('expired session'), { isAuthGate: true })
+
+    loadScrape({ auth: staleAuth })
+    fetchAccountsMock
+      .mockRejectedValueOnce(authGateError)
+      .mockResolvedValueOnce(apiAccounts)
+    fetchTransactionsMock.mockResolvedValue([])
+    loginMock.mockResolvedValue(freshAuth)
+
+    await scrape({
+      preferences: {},
+      fromDate,
+      toDate,
+      isInBackground: false,
+      isFirstRun: false
+    })
+
+    expect(loginMock).toHaveBeenCalledTimes(1)
+    expect(fetchAccountsMock).toHaveBeenCalledTimes(2)
+    expect(fetchAccountsMock).toHaveBeenNthCalledWith(1, staleAuth)
+    expect(fetchAccountsMock).toHaveBeenNthCalledWith(2, freshAuth)
+    expect(dataApi.currentData.auth).toEqual(freshAuth)
+  })
+
+  it('requires foreground login when background sync has no stored auth', async () => {
+    loadScrape({})
+
+    await expect(scrape({
+      preferences: {},
+      fromDate,
+      toDate,
+      isInBackground: true,
+      isFirstRun: false
+    })).rejects.toMatchObject({
+      message: expect.stringContaining('foreground')
+    })
+
+    expect(loginMock).not.toHaveBeenCalled()
+    expect(fetchAccountsMock).not.toHaveBeenCalled()
+  })
+
+  it('retries transaction fetch once after foreground re-login', async () => {
+    const savedAuth = {
+      cookieHeader: 'TS=1; XSRF-TOKEN=saved-xsrf',
+      xsrfToken: 'saved-xsrf',
+      restContext: 'old',
+      acquiredAt: 1
+    }
+    const freshAuth = {
+      cookieHeader: 'TS=2; XSRF-TOKEN=fresh-xsrf',
+      xsrfToken: 'fresh-xsrf',
+      restContext: 'pib',
+      acquiredAt: 2
+    }
+    const authGateError = Object.assign(new Error('step-up required'), { isAuthGate: true })
+    const apiTransaction = { id: 'tx-1' }
+    const convertedTransaction = { id: 'tx-1', hold: false }
+
+    loadScrape({ auth: savedAuth })
+    fetchAccountsMock.mockResolvedValue(apiAccounts)
+    fetchTransactionsMock
+      .mockRejectedValueOnce(authGateError)
+      .mockResolvedValueOnce([apiTransaction])
+    loginMock.mockResolvedValue(freshAuth)
+    convertTransactionMock.mockReturnValue(convertedTransaction)
+
+    const result = await scrape({
+      preferences: {},
+      fromDate,
+      toDate,
+      isInBackground: false,
+      isFirstRun: false
+    })
+
+    expect(loginMock).toHaveBeenCalledTimes(1)
+    expect(fetchTransactionsMock).toHaveBeenCalledTimes(2)
+    expect(fetchTransactionsMock).toHaveBeenNthCalledWith(1, savedAuth, convertedProduct, fromDate, toDate)
+    expect(fetchTransactionsMock).toHaveBeenNthCalledWith(2, freshAuth, convertedProduct, fromDate, toDate)
+    expect(result).toEqual({
+      accounts: [convertedAccount],
+      transactions: [convertedTransaction]
+    })
+    expect(dataApi.currentData.auth).toEqual(freshAuth)
+  })
+
+  it('normalizes repeated auth-gate failure after retry into re-login error', async () => {
+    const savedAuth = {
+      cookieHeader: 'TS=1; XSRF-TOKEN=saved-xsrf',
+      xsrfToken: 'saved-xsrf',
+      restContext: 'old',
+      acquiredAt: 1
+    }
+    const freshAuth = {
+      cookieHeader: 'TS=2; XSRF-TOKEN=fresh-xsrf',
+      xsrfToken: 'fresh-xsrf',
+      restContext: 'pib',
+      acquiredAt: 2
+    }
+    const firstAuthGateError = Object.assign(new Error('step-up required'), { isAuthGate: true })
+    const secondAuthGateError = Object.assign(new Error('still blocked'), { isAuthGate: true })
+
+    loadScrape({ auth: savedAuth })
+    fetchAccountsMock.mockResolvedValue(apiAccounts)
+    fetchTransactionsMock
+      .mockRejectedValueOnce(firstAuthGateError)
+      .mockRejectedValueOnce(secondAuthGateError)
+    loginMock.mockResolvedValue(freshAuth)
+
+    await expect(scrape({
+      preferences: {},
+      fromDate,
+      toDate,
+      isInBackground: false,
+      isFirstRun: false
+    })).rejects.toMatchObject({
+      message: expect.stringContaining('official bank page')
+    })
+
+    expect(loginMock).toHaveBeenCalledTimes(1)
+    expect(dataApi.currentData.auth).toBeNull()
+  })
+})

--- a/src/plugins/hapoalim/api.js
+++ b/src/plugins/hapoalim/api.js
@@ -1,23 +1,50 @@
 import { flatten } from 'lodash'
 import qs from 'querystring'
-import { InvalidPreferencesError, TemporaryError } from '../../errors'
+import * as setCookie from 'set-cookie-parser'
+import { TemporaryError } from '../../errors'
 import { toISODateString } from '../../common/dateUtils'
-import { fetchJson, ParseError, openWebViewAndInterceptRequest } from '../../common/network'
+import { fetch, fetchJson, ParseError, openWebViewAndInterceptRequest } from '../../common/network'
 import { generateRandomString } from '../../common/utils'
 
-const WEB_PORTAL_URL = 'https://login.bankhapoalim.co.il/'
+const OFFICIAL_BASE_URL = 'https://login.bankhapoalim.co.il'
+const WEB_LOGIN_URL = `${OFFICIAL_BASE_URL}/cgi-bin/poalwwwc?reqName=getLogonPage`
 const WEB_SUCCESS_PATTERNS = [
+  /\/portalserver\/HomePage/i,
+  /\/ng-portals-bt\/rb\/he\//i,
   /\/ng--portals\/rb\/he\//i,
-  /\/ng-portals\/rb\/he\//i,
-  /\/current-account\/transactions/i,
-  /\/ServerServices\/general\/accounts/i
+  /\/ng-portals\/rb\/he\//i
 ]
-const API_BASE_URLS = {
-  mobile: 'https://iphone.bankhapoalim.co.il',
-  official: 'https://login.bankhapoalim.co.il'
-}
-
-let apiHostMode = 'mobile'
+const PORTAL_PAGE_PATHS = [
+  '/portalserver/HomePage',
+  '/ng-portals-bt/rb/he/homepage',
+  '/ng--portals/rb/he/homepage',
+  '/ng-portals/rb/he/homepage'
+]
+const REST_CONTEXT_URL_PATTERNS = [
+  /https:\/\/login\.bankhapoalim\.co\.il\/([^/?#]+)\/current-account\//i,
+  /https:\/\/login\.bankhapoalim\.co\.il\/([^/?#]+)\/credit-and-mortgage\//i,
+  /https:\/\/login\.bankhapoalim\.co\.il\/([^/?#]+)\/foreign-currency\//i,
+  /https:\/\/login\.bankhapoalim\.co\.il\/([^/?#]+)\/deposits-and-savings\//i
+]
+const REST_CONTEXT_TEXT_PATTERNS = [
+  /restContext["']?\s*[:=]\s*["']\/([^/"'?]+)["']/i,
+  /https:\/\/login\.bankhapoalim\.co\.il\/([^/"'?]+)\/current-account\//i,
+  /https:\/\/login\.bankhapoalim\.co\.il\/([^/"'?]+)\/credit-and-mortgage\//i,
+  /["'/]([^/"'?]+)\/current-account\/(?:composite|transactions)/i,
+  /["'/]([^/"'?]+)\/credit-and-mortgage\//i
+]
+const EXCLUDED_REST_CONTEXTS = new Set([
+  'AUTHENTICATE',
+  'MCP',
+  'ServerServices',
+  'cgi-bin',
+  'ng-portals',
+  'ng-portals-bt',
+  'ng--portals',
+  'portalserver'
+])
+const OFFICIAL_TRANSACTION_PAGE_UUID = '/current-account/transactions'
+const OFFICIAL_TRANSACTION_LIMIT = 1000
 
 function summarizeResponse (response) {
   return response
@@ -55,11 +82,182 @@ async function safeFetch (label, fn) {
   }
 }
 
-export function generateDevice () {
+function createEmptyAuth () {
   return {
-    id: 'PSR1.180720.061',
-    androidId: generateRandomString(16, '0123456789abcdef')
+    cookieHeader: '',
+    xsrfToken: null,
+    restContext: null,
+    acquiredAt: Date.now()
   }
+}
+
+function getHeaderValue (headers, name) {
+  if (!headers) {
+    return null
+  }
+
+  if (typeof headers.get === 'function') {
+    return headers.get(name) || headers.get(name.toLowerCase()) || null
+  }
+
+  const lowerCaseName = name.toLowerCase()
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lowerCaseName) {
+      return value
+    }
+  }
+
+  return null
+}
+
+function parseCookieHeader (cookieHeader) {
+  if (typeof cookieHeader !== 'string' || cookieHeader.trim() === '') {
+    return {}
+  }
+
+  return cookieHeader
+    .split(';')
+    .map(part => part.trim())
+    .filter(part => part.includes('='))
+    .reduce((result, part) => {
+      const separatorIndex = part.indexOf('=')
+      const name = part.slice(0, separatorIndex).trim()
+      const value = part.slice(separatorIndex + 1).trim()
+      if (name !== '') {
+        result[name] = value
+      }
+      return result
+    }, {})
+}
+
+function mergeCookieHeaders (currentCookieHeader, nextCookieHeader) {
+  const currentCookies = parseCookieHeader(currentCookieHeader)
+  const nextCookies = parseCookieHeader(nextCookieHeader)
+  const mergedCookies = { ...currentCookies, ...nextCookies }
+
+  return Object.entries(mergedCookies)
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ')
+}
+
+function mergeSetCookieHeaders (currentCookieHeader, setCookieHeader) {
+  if (typeof setCookieHeader !== 'string' || setCookieHeader.trim() === '') {
+    return currentCookieHeader
+  }
+
+  const nextCookies = setCookie.parse(setCookie.splitCookiesString(setCookieHeader))
+    .reduce((result, cookie) => {
+      if (cookie?.name) {
+        result[cookie.name] = cookie.value
+      }
+      return result
+    }, {})
+
+  const mergedCookies = { ...parseCookieHeader(currentCookieHeader), ...nextCookies }
+  return Object.entries(mergedCookies)
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ')
+}
+
+function getCookieValue (cookieHeader, cookieName) {
+  const cookies = parseCookieHeader(cookieHeader)
+  return cookies[cookieName] || null
+}
+
+function normalizeRestContext (value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalizedValue = value.replace(/^\/+|\/+$/g, '')
+  if (normalizedValue === '' || EXCLUDED_REST_CONTEXTS.has(normalizedValue)) {
+    return null
+  }
+
+  return normalizedValue
+}
+
+function extractRestContextFromUrl (url) {
+  if (typeof url !== 'string') {
+    return null
+  }
+
+  for (const pattern of REST_CONTEXT_URL_PATTERNS) {
+    const match = url.match(pattern)
+    const restContext = normalizeRestContext(match?.[1])
+    if (restContext) {
+      return restContext
+    }
+  }
+
+  return null
+}
+
+function extractRestContextFromText (text) {
+  if (typeof text !== 'string' || text === '') {
+    return null
+  }
+
+  for (const pattern of REST_CONTEXT_TEXT_PATTERNS) {
+    const match = text.match(pattern)
+    const restContext = normalizeRestContext(match?.[1])
+    if (restContext) {
+      return restContext
+    }
+  }
+
+  return null
+}
+
+function updateAuthFromRequest (auth, request) {
+  const nextAuth = { ...auth }
+  const cookieHeader = getHeaderValue(request?.headers, 'cookie') || getHeaderValue(request?.headers, 'Cookie')
+  if (cookieHeader) {
+    nextAuth.cookieHeader = mergeCookieHeaders(nextAuth.cookieHeader, cookieHeader)
+    nextAuth.xsrfToken = getCookieValue(nextAuth.cookieHeader, 'XSRF-TOKEN') || nextAuth.xsrfToken
+  }
+
+  nextAuth.restContext = nextAuth.restContext || extractRestContextFromUrl(request?.url)
+  return nextAuth
+}
+
+function updateAuthFromResponse (auth, response) {
+  const nextAuth = { ...auth }
+  const setCookieHeader = getHeaderValue(response?.headers, 'set-cookie') || getHeaderValue(response?.headers, 'Set-Cookie')
+  if (setCookieHeader) {
+    nextAuth.cookieHeader = mergeSetCookieHeaders(nextAuth.cookieHeader, setCookieHeader)
+    nextAuth.xsrfToken = getCookieValue(nextAuth.cookieHeader, 'XSRF-TOKEN') || nextAuth.xsrfToken
+  }
+
+  nextAuth.restContext = nextAuth.restContext || extractRestContextFromUrl(response?.url)
+  return nextAuth
+}
+
+function applyAuthUpdate (targetAuth, nextAuth) {
+  targetAuth.cookieHeader = nextAuth.cookieHeader
+  targetAuth.xsrfToken = nextAuth.xsrfToken
+  targetAuth.restContext = nextAuth.restContext
+  targetAuth.acquiredAt = nextAuth.acquiredAt
+}
+
+function restoreAuth (rawAuth) {
+  if (!rawAuth || typeof rawAuth !== 'object') {
+    return null
+  }
+
+  const auth = createEmptyAuth()
+  auth.cookieHeader = typeof rawAuth.cookieHeader === 'string' ? rawAuth.cookieHeader : ''
+  auth.xsrfToken = typeof rawAuth.xsrfToken === 'string' && rawAuth.xsrfToken !== ''
+    ? rawAuth.xsrfToken
+    : getCookieValue(auth.cookieHeader, 'XSRF-TOKEN')
+  auth.restContext = normalizeRestContext(rawAuth.restContext)
+  auth.acquiredAt = typeof rawAuth.acquiredAt === 'number' ? rawAuth.acquiredAt : Date.now()
+
+  return auth.cookieHeader !== '' ? auth : null
+}
+
+export function normalizeStoredAuth (rawAuth) {
+  return restoreAuth(rawAuth)
 }
 
 export function isLikelyAuthGateError (error) {
@@ -72,225 +270,183 @@ export function isLikelyAuthGateError (error) {
     /text\/html/i.test(contentType)
 }
 
-function isUsingOfficialApiHost () {
-  return apiHostMode === 'official'
+function createRequestUuid () {
+  const a = generateRandomString(8, '0123456789abcdef')
+  const b = generateRandomString(4, '0123456789abcdef')
+  const c = generateRandomString(3, '0123456789abcdef')
+  const d = generateRandomString(3, '89ab')
+  const e = generateRandomString(3, '0123456789abcdef')
+  const f = generateRandomString(12, '0123456789abcdef')
+  return `${a}-${b}-4${c}-${d}${e}-${f}`
 }
 
-function resetApiHostMode () {
-  apiHostMode = 'mobile'
+function buildOfficialHeaders (auth, headers, { includeXsrf = false } = {}) {
+  return {
+    Accept: 'application/json',
+    'Content-Type': 'application/json;charset=UTF-8',
+    Cookie: auth.cookieHeader,
+    ...includeXsrf && auth.xsrfToken ? { 'X-XSRF-TOKEN': auth.xsrfToken } : {},
+    ...headers
+  }
 }
 
-async function fetchApi (url, options) {
-  const usingOfficialApiHost = isUsingOfficialApiHost()
-  const params = {
-    ...options?.accountId && { accountId: options.accountId }
-  }
-  if (!usingOfficialApiHost) {
-    params.appId = 'bankApp3Generation'
-  }
-  const query = qs.stringify(params)
-  const fullUrl = query
-    ? url + ((url.indexOf('?') === -1) ? '?' : '&') + query
-    : url
-  const defaultHeaders = usingOfficialApiHost
-    ? {
-        Accept: 'application/json',
-        'Content-Type': 'application/json;charset=UTF-8'
-      }
-    : {
-        mobile: 'ca',
-        'x-dynatrace': 'MT_3_1_1842511945_1_BankApp-Android-Gen3_0_1001_130',
-        Accept: 'application/json',
-        'Content-Type': 'application/json;charset=UTF-8',
-        'User-Agent': 'okhttp/3.12.1'
-      }
+async function fetchOfficialJson (path, auth, options = {}) {
+  const {
+    headers,
+    includeXsrf = false,
+    sanitizeRequestLog,
+    sanitizeResponseLog,
+    ...rest
+  } = options
 
-  return fetchJson(API_BASE_URLS[apiHostMode] + fullUrl, {
+  const response = await fetchJson(OFFICIAL_BASE_URL + path, {
     method: 'GET',
-    ...options,
-    sanitizeResponseLog: {
-      ...options?.sanitizeResponseLog,
+    ...rest,
+    headers: buildOfficialHeaders(auth, headers, { includeXsrf }),
+    sanitizeRequestLog: {
+      ...sanitizeRequestLog,
       headers: {
-        'set-cookie': true,
-        ...options?.sanitizeResponseLog?.headers
+        Cookie: true,
+        cookie: true,
+        'X-XSRF-TOKEN': true,
+        ...sanitizeRequestLog?.headers
       }
     },
-    headers: {
-      ...defaultHeaders,
-      ...options && options.headers
+    sanitizeResponseLog: {
+      ...sanitizeResponseLog,
+      headers: {
+        'set-cookie': true,
+        ...sanitizeResponseLog?.headers
+      }
     }
   })
+
+  applyAuthUpdate(auth, updateAuthFromResponse(auth, response))
+  return response
 }
 
-export async function tryInteractiveWebBootstrap () {
-  if (!ZenMoney?.openWebView) {
-    return false
+async function fetchOfficialText (path, auth) {
+  const response = await fetch(OFFICIAL_BASE_URL + path, {
+    method: 'GET',
+    headers: {
+      Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      Cookie: auth.cookieHeader
+    },
+    sanitizeRequestLog: {
+      headers: {
+        Cookie: true,
+        cookie: true
+      }
+    },
+    sanitizeResponseLog: {
+      headers: {
+        'set-cookie': true
+      }
+    }
+  })
+
+  applyAuthUpdate(auth, updateAuthFromResponse(auth, response))
+  return response
+}
+
+async function ensureRestContext (auth) {
+  if (auth.restContext) {
+    return auth.restContext
   }
+
+  for (const path of PORTAL_PAGE_PATHS) {
+    try {
+      const response = await fetchOfficialText(path, auth)
+      const restContext = extractRestContextFromText(response.body)
+      if (restContext) {
+        auth.restContext = restContext
+        return restContext
+      }
+    } catch (error) {
+      console.warn('failed to probe portal page for rest context', path, error?.responseSummary || error?.message || error)
+    }
+  }
+
+  return null
+}
+
+function getCurrentAccountBasePath (auth) {
+  return auth.restContext
+    ? `/${auth.restContext}/current-account`
+    : '/ServerServices/current-account'
+}
+
+async function captureOfficialSessionFromWebView () {
+  if (!ZenMoney?.openWebView) {
+    throw new TemporaryError('Bank Hapoalim login requires WebView support in the ZenMoney app.')
+  }
+
+  let auth = createEmptyAuth()
 
   try {
     const result = await openWebViewAndInterceptRequest({
-      url: WEB_PORTAL_URL,
+      url: WEB_LOGIN_URL,
       log: false,
+      sanitizeRequestLog: {
+        headers: {
+          Cookie: true,
+          cookie: true,
+          'X-XSRF-TOKEN': true
+        }
+      },
       intercept (request) {
-        return WEB_SUCCESS_PATTERNS.some(pattern => pattern.test(request.url))
-          ? { verified: true, url: request.url }
-          : null
+        if (typeof request?.url === 'string' && request.url.indexOf(OFFICIAL_BASE_URL) === 0) {
+          auth = updateAuthFromRequest(auth, request)
+        }
+
+        const isAuthenticatedPortalRequest = WEB_SUCCESS_PATTERNS.some(pattern => pattern.test(request?.url || ''))
+        if (auth.cookieHeader !== '' && isAuthenticatedPortalRequest) {
+          return { auth }
+        }
+
+        return null
       }
     })
 
-    const verified = Boolean(result?.verified)
-    if (verified) {
-      apiHostMode = 'official'
-    }
-
-    return verified
+    auth = restoreAuth(result?.auth) || auth
+    ensure(auth.cookieHeader !== '', 'web login did not produce an authenticated session')
+    await ensureRestContext(auth)
+    return auth
   } catch (error) {
-    console.warn('interactive web bootstrap failed', error?.message || error)
-    return false
-  }
-}
-
-export async function login ({ login, password }, device) {
-  resetApiHostMode()
-
-  const response = await fetchApi('/authenticate/verify', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body: {
-      organization: '106402333',
-      identifier: login,
-      credentials: password,
-      authType: '0',
-      flow: 'authenticate',
-      state: 'logon',
-      mfp: JSON.stringify({
-        deviceSignature: {
-          collector: 'Android',
-          collectorVersion: '8.1.2',
-          system: {
-            platform: 'Android28',
-            androidId: device.androidId,
-            osVersion: '9',
-            deviceName: 'generic_x86_64',
-            model: ZenMoney.device.model,
-            board: 'goldfish_x86_64',
-            brand: 'google',
-            host: 'abfarm719',
-            id: device.id,
-            type: 'userdebug',
-            user: 'android-build',
-            cpuAbi: 'x86_64',
-            cpuAbi2: null,
-            hardware: 'ranchu',
-            manufacturer: ZenMoney.device.manufacturer,
-            serial: 'unknown',
-            tags: 'dev-keys',
-            locale: 'English (United States)',
-            radio: '1.0.0.0',
-            processName: 'בנק הפועלים',
-            systemName: 'AndroidOS',
-            jailBroken: false,
-            timeZone: 'Europe/Moscow',
-            debuggerAttached: true,
-            totalDiskSpace: '1937',
-            totalMemory: 1494,
-            numberOfProcessors: 4
-          },
-          screen: { displayId: `sdk_gphone_x86_64-userdebug 9${device.id} 5075414 dev-keys`, width: '768', height: '1184', orientation: '1' },
-          browser: { userAgent: `Dalvik 2.1.0 (Linux; U; Android 9; ${ZenMoney.device.model} Build ${device.id})` },
-          wifi: {
-            connected: true,
-            macAddress: '02:00:00:00:00:00',
-            ipAddress: '192.168.232.2',
-            netmaskAddress: '0.0.0.0',
-            gatewayAddress: '192.168.232.1',
-            broadcastAddress: '255.255.255.255',
-            userEnabled: true
-          },
-          telephony: {
-            imeiNumber: null,
-            carrierIsoCountryCode: 'us',
-            carrierName: 'Android',
-            carrierMobileCountryCode: null,
-            simOperatorName: 'T-Mobile',
-            carrierMobileNetworkCode: '260',
-            networkType: 'GPRS',
-            phoneType: 'GSM',
-            simIsoCountryCode: 'us',
-            isRoamingNetwork: false,
-            cellIpAddress: null,
-            simSerialNumber: null,
-            subscriberId: null
-          },
-          camera: {
-            numberOfCameras: null,
-            rearCamera: null,
-            frontCamera: '__SDK_DISABLED__',
-            autoFocus: null,
-            flash: null,
-            rearCameraSupportedSizes: null,
-            rearCameraSupportedFormats: null,
-            frontCameraSupportedSizes: '__SDK_DISABLED__',
-            frontCameraSupportedFormats: '__SDK_DISABLED__'
-          },
-          bluetooth: { macAddress: null, supported: null },
-          extra: { account: null, securityPolicy: true },
-          location: { latitude: null, longitude: null }
-        },
-        ipAddress: '192.168.232.2'
-      }),
-      deviceId: '10010110210310410510610710810910a10b10c10d10e10f'
-    },
-    stringify: qs.stringify,
-    sanitizeRequestLog: {
-      body: {
-        identifier: true,
-        credentials: true,
-        mfp: true,
-        deviceId: true
-      }
+    if (error instanceof TemporaryError) {
+      throw error
     }
-  })
-
-  if (response.body.error?.errCode === '1.6' && response.body.error?.errDesc === 'Login Failure') {
-    throw new InvalidPreferencesError()
+    console.warn('interactive web login failed', error?.message || error)
+    throw new TemporaryError('Could not complete Bank Hapoalim web login. Finish the bank login in the opened page and retry sync.')
   }
-
-  if (!response.body.error &&
-    response.body.flow === 'AUTHENTICATE' &&
-    response.body.state === 'LANDPAGE') {
-    return { state: 'LANDPAGE' }
-  }
-
-  if (!response.body.error &&
-    response.body.flow === 'AUTHENTICATE' &&
-    response.body.state === 'LOGONOTP') {
-    console.warn('login returned LOGONOTP', summarizeResponse(response))
-    return { state: 'LOGONOTP' }
-  }
-
-  throwTemporary('unexpected login response', response)
 }
 
-async function fetchMainAccountDetails (mainAccount, accountId) {
-  const response = isUsingOfficialApiHost()
-    ? await fetchApi('/ServerServices/current-account/composite/balanceAndCreditLimit?view=details&lang=he', { accountId })
-    : await fetchApi('/ServerServices/general/accounts/selectedAccount/totalBalances', { accountId })
+export async function login () {
+  return await captureOfficialSessionFromWebView()
+}
 
-  mainAccount.details = isUsingOfficialApiHost()
-    ? {
-        ...response.body,
-        currentAccountCreditFrame: response.body?.creditLimitAmount ?? response.body?.currentAccountCreditFrame ?? 0
-      }
-    : response.body
+async function fetchMainAccountDetails (auth, mainAccount, accountId) {
+  await ensureRestContext(auth)
+  const currentAccountBasePath = getCurrentAccountBasePath(auth)
+  const response = await fetchOfficialJson(
+    `${currentAccountBasePath}/composite/balanceAndCreditLimit?${qs.stringify({ accountId, view: 'details', lang: 'he' })}`,
+    auth
+  )
+
+  mainAccount.details = {
+    ...response.body,
+    currentAccountCreditFrame: response.body?.creditLimitAmount ?? response.body?.currentAccountCreditFrame ?? 0
+  }
   mainAccount.structType = 'checking'
   return [mainAccount]
 }
 
-async function fetchForeignCurrencyAccount (accountId) {
-  const response = await fetchApi('/ServerServices/foreign-currency/transactions?type=business', { accountId })
+async function fetchForeignCurrencyAccount (auth, accountId) {
+  const response = await fetchOfficialJson(`/ServerServices/foreign-currency/transactions?${qs.stringify({
+    type: 'business',
+    accountId
+  })}`, auth)
+
   const account = response.body
   if (!account) {
     return []
@@ -300,8 +456,9 @@ async function fetchForeignCurrencyAccount (accountId) {
   return [account]
 }
 
-async function fetchDeposits (url, structType, accountId) {
-  const response = await fetchApi(url, { accountId })
+async function fetchDeposits (auth, url, structType, accountId) {
+  const separator = url.includes('?') ? '&' : '?'
+  const response = await fetchOfficialJson(`${url}${separator}${qs.stringify({ accountId })}`, auth)
   return (response.body?.list || []).map(account => {
     const result = account.data?.[0]
     if (!result) {
@@ -312,11 +469,11 @@ async function fetchDeposits (url, structType, accountId) {
   }).filter(Boolean)
 }
 
-async function fetchLoans (accountId) {
-  const response = await fetchApi('/ServerServices/credit-and-mortgage/v3/loans', { accountId })
+async function fetchLoans (auth, accountId) {
+  const response = await fetchOfficialJson(`/ServerServices/credit-and-mortgage/v3/loans?${qs.stringify({ accountId })}`, auth)
   return await Promise.all((response.body?.data || []).map(async account => {
-    const query = qs.stringify({ unitedCreditTypeCode: account.unitedCreditTypeCode })
-    const detailsResponse = await fetchApi(`/ServerServices/credit-and-mortgage/v3/loans/${account.creditSerialNumber}?${query}`, { accountId })
+    const query = qs.stringify({ unitedCreditTypeCode: account.unitedCreditTypeCode, accountId })
+    const detailsResponse = await fetchOfficialJson(`/ServerServices/credit-and-mortgage/v3/loans/${account.creditSerialNumber}?${query}`, auth)
 
     account.details = detailsResponse.body
     account.structType = 'loan'
@@ -324,16 +481,16 @@ async function fetchLoans (accountId) {
   }))
 }
 
-async function fetchMortgages (accountId) {
-  const response = await fetchApi('/ServerServices/credit-and-mortgage/mortgages', { accountId })
+async function fetchMortgages (auth, accountId) {
+  const response = await fetchOfficialJson(`/ServerServices/credit-and-mortgage/mortgages?${qs.stringify({ accountId })}`, auth)
   return (response.body?.data || []).map(account => {
     account.structType = 'mortgage'
     return account
   })
 }
 
-export async function fetchAccounts () {
-  const response = await fetchApi('/ServerServices/general/accounts?lang=he')
+export async function fetchAccounts (auth) {
+  const response = await fetchOfficialJson('/ServerServices/general/accounts?lang=he', auth)
   ensure(Array.isArray(response.body), 'unexpected accounts response', response)
 
   const accounts = []
@@ -341,62 +498,125 @@ export async function fetchAccounts () {
     ensure(mainAccount.accountNumber && mainAccount.branchNumber && mainAccount.bankNumber, 'unexpected account', { body: mainAccount })
     const accountId = `${mainAccount.bankNumber}-${mainAccount.branchNumber}-${mainAccount.accountNumber}`
     accounts.push(...flatten(await Promise.all([
-      async () => await fetchMainAccountDetails(mainAccount, accountId),
-      async () => await safeFetch('foreign currency', async () => fetchForeignCurrencyAccount(accountId)),
-      async () => await safeFetch('deposits', async () => fetchDeposits('/ServerServices/deposits-and-savings/deposits?view=details&lang=he', 'deposit', accountId)),
-      async () => await safeFetch('savings', async () => fetchDeposits('/ServerServices/deposits-and-savings/savingsDeposits?view=details&lang=he', 'saving', accountId)),
-      async () => await safeFetch('loans', async () => fetchLoans(accountId)),
-      async () => await safeFetch('mortgages', async () => fetchMortgages(accountId))
+      async () => await fetchMainAccountDetails(auth, mainAccount, accountId),
+      async () => await safeFetch('foreign currency', async () => fetchForeignCurrencyAccount(auth, accountId)),
+      async () => await safeFetch('deposits', async () => fetchDeposits(auth, '/ServerServices/deposits-and-savings/deposits?view=details&lang=he', 'deposit', accountId)),
+      async () => await safeFetch('savings', async () => fetchDeposits(auth, '/ServerServices/deposits-and-savings/savingsDeposits?view=details&lang=he', 'saving', accountId)),
+      async () => await safeFetch('loans', async () => fetchLoans(auth, accountId)),
+      async () => await safeFetch('mortgages', async () => fetchMortgages(auth, accountId))
     ].map(fn => fn()))))
   }))
   return accounts
 }
 
-export async function fetchTransactions (product, fromDate, toDate) {
+function areSameCalendarDay (leftDate, rightDate) {
+  return leftDate.getFullYear() === rightDate.getFullYear() &&
+    leftDate.getMonth() === rightDate.getMonth() &&
+    leftDate.getDate() === rightDate.getDate()
+}
+
+function startOfDay (date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate())
+}
+
+function addDays (date, days) {
+  const result = new Date(date)
+  result.setDate(result.getDate() + days)
+  return result
+}
+
+function getMidpointDay (fromDate, toDate) {
+  return startOfDay(new Date(Math.floor((startOfDay(fromDate).getTime() + startOfDay(toDate).getTime()) / 2)))
+}
+
+function deduplicateTransactions (transactions) {
+  const seenKeys = new Set()
+  return transactions.filter(transaction => {
+    const key = [
+      transaction.serialNumber,
+      transaction.referenceNumber,
+      transaction.eventDate,
+      transaction.valueDate,
+      transaction.eventAmount,
+      transaction.activityDescription
+    ].join('|')
+
+    if (seenKeys.has(key)) {
+      return false
+    }
+
+    seenKeys.add(key)
+    return true
+  })
+}
+
+async function fetchOfficialCurrentAccountTransactionsWindow (auth, product, fromDate, toDate) {
+  await ensureRestContext(auth)
+
+  const fromDateStr = toISODateString(fromDate).replace(/-/g, '')
+  const toDateStr = toISODateString(toDate).replace(/-/g, '')
+  const currentAccountBasePath = getCurrentAccountBasePath(auth)
+  const query = qs.stringify({
+    accountId: product.id,
+    numItemsPerPage: OFFICIAL_TRANSACTION_LIMIT,
+    sortCode: '1',
+    retrievalStartDate: fromDateStr,
+    retrievalEndDate: toDateStr
+  })
+
+  const response = await fetchOfficialJson(
+    `${currentAccountBasePath}/transactions?${query}`,
+    auth,
+    {
+      method: 'POST',
+      body: [],
+      includeXsrf: true,
+      headers: {
+        pageUuid: OFFICIAL_TRANSACTION_PAGE_UUID,
+        uuid: createRequestUuid()
+      }
+    }
+  )
+
+  const batch = response.body?.transactions || (response.status === 204 ? [] : null)
+  ensure(Array.isArray(batch), 'unexpected transactions response', response)
+  return batch
+}
+
+async function fetchOfficialCurrentAccountTransactions (auth, product, fromDate, toDate) {
+  const batch = await fetchOfficialCurrentAccountTransactionsWindow(auth, product, fromDate, toDate)
+
+  if (batch.length < OFFICIAL_TRANSACTION_LIMIT || areSameCalendarDay(fromDate, toDate)) {
+    return batch
+  }
+
+  const midpointDay = getMidpointDay(fromDate, toDate)
+  if (midpointDay.getTime() <= startOfDay(fromDate).getTime() || midpointDay.getTime() >= startOfDay(toDate).getTime()) {
+    return batch
+  }
+
+  const leftTransactions = await fetchOfficialCurrentAccountTransactions(auth, product, fromDate, midpointDay)
+  const rightFromDate = addDays(midpointDay, 1)
+  const rightTransactions = rightFromDate.getTime() <= startOfDay(toDate).getTime()
+    ? await fetchOfficialCurrentAccountTransactions(auth, product, rightFromDate, toDate)
+    : []
+
+  return deduplicateTransactions([...leftTransactions, ...rightTransactions])
+}
+
+export async function fetchTransactions (auth, product, fromDate, toDate) {
   const fromDateStr = toISODateString(fromDate).replace(/-/g, '')
   const toDateStr = toISODateString(toDate).replace(/-/g, '')
 
   if (product.type === 'foreignCurrencyAccount') {
-    const response = await fetchApi('/ServerServices/foreign-currency/transactions?type=business&view=details&' +
+    const response = await fetchOfficialJson('/ServerServices/foreign-currency/transactions?type=business&view=details&' +
       `retrievalStartDate=${fromDateStr}&` +
       `retrievalEndDate=${toDateStr}&` +
       `currencyCodeList=${product.currencyCode}&` +
-      `detailedAccountTypeCodeList=${product.detailedAccountTypeCode}`, { accountId: product.id })
+      `detailedAccountTypeCodeList=${product.detailedAccountTypeCode}&` +
+      `accountId=${product.id}`, auth)
     return response.body.balancesAndLimitsDataList?.transactions || []
   }
 
-  const transactions = []
-  const limit = 50
-  const query = qs.stringify({
-    numItemsPerPage: limit,
-    sortCode: '1',
-    retrievalStartDate: fromDateStr,
-    retrievalEndDate: toDateStr,
-    dataGroupCatenatedKey: ''
-  })
-
-  let response = await fetchApi(`/ServerServices/current-account/transactions?${query}`, {
-    accountId: product.id
-  })
-  while (true) {
-    const batch = response.body?.transactions || (response.status === 204 ? [] : null)
-    ensure(Array.isArray(batch), 'unexpected transactions response', response)
-    transactions.push(...batch)
-
-    const dataHeader = response.headers['data-header']
-    if (batch.length < limit || !dataHeader) {
-      break
-    }
-    const integrityHeader = response.headers['integrity-header']
-    ensure(dataHeader && integrityHeader, 'unexpected transactions continuation response', response)
-    response = await fetchApi(`/ServerServices/current-account/transactions/${dataHeader}?${query}`, {
-      accountId: product.id,
-      headers: {
-        add_integrity_header: 'true',
-        'integrity-header': integrityHeader
-      }
-    })
-  }
-
-  return transactions
+  return await fetchOfficialCurrentAccountTransactions(auth, product, fromDate, toDate)
 }

--- a/src/plugins/hapoalim/index.js
+++ b/src/plugins/hapoalim/index.js
@@ -1,6 +1,6 @@
 import { adjustTransactions } from '../../common/transactionGroupHandler'
 import { ZPAPIError } from '../../errors'
-import { fetchAccounts, fetchTransactions, generateDevice, login, isLikelyAuthGateError, tryInteractiveWebBootstrap } from './api'
+import { fetchAccounts, fetchTransactions, isLikelyAuthGateError, login, normalizeStoredAuth } from './api'
 import { convertAccounts, convertTransaction } from './converters'
 
 function getFallbackFromDate (preferences, toDate) {
@@ -16,35 +16,88 @@ function getFallbackFromDate (preferences, toDate) {
   return fallbackDate
 }
 
-function rethrowAuthGate (error, authState, isInBackground) {
-  if (authState?.state === 'LOGONOTP' && isLikelyAuthGateError(error)) {
-    throw new ZPAPIError(
-      isInBackground
-        ? 'Bank Hapoalim requested an additional verification step. Open the bank app/site, confirm the device and run sync manually in foreground.'
-        : 'Bank Hapoalim requested an additional verification step. Confirm the device in the official bank app/site and retry sync.',
-      false,
-      false
-    )
+function createForegroundReauthError (isInBackground) {
+  return new ZPAPIError(
+    isInBackground
+      ? 'Bank Hapoalim session expired. Run sync manually in foreground and complete login in the official bank page.'
+      : 'Bank Hapoalim requires login in the official bank page. Complete the opened bank login flow and retry sync.',
+    false,
+    false
+  )
+}
+
+function resetStoredAuth () {
+  ZenMoney.setData('auth', null)
+  ZenMoney.saveData()
+}
+
+function rethrowForegroundReauthIfNeeded (error, isInBackground) {
+  if (isLikelyAuthGateError(error)) {
+    throw createForegroundReauthError(isInBackground)
   }
   throw error
 }
 
-async function withInteractiveBootstrapRetry (fn, authState, isInBackground) {
+async function withForegroundReauthRetry (fn, state) {
   try {
-    return await fn()
+    return await fn(state.auth)
   } catch (error) {
-    if (!isInBackground &&
-      authState?.state === 'LOGONOTP' &&
-      isLikelyAuthGateError(error) &&
-      await tryInteractiveWebBootstrap()) {
-      try {
-        return await fn()
-      } catch (retryError) {
-        rethrowAuthGate(retryError, authState, isInBackground)
-      }
+    if (!isLikelyAuthGateError(error)) {
+      throw error
     }
 
-    rethrowAuthGate(error, authState, isInBackground)
+    resetStoredAuth()
+    if (state.isInBackground) {
+      throw createForegroundReauthError(true)
+    }
+
+    state.auth = await login()
+    ZenMoney.setData('auth', state.auth)
+    ZenMoney.saveData()
+
+    try {
+      return await fn(state.auth)
+    } catch (retryError) {
+      resetStoredAuth()
+      rethrowForegroundReauthIfNeeded(retryError, state.isInBackground)
+    }
+  }
+}
+
+async function getAuthorizedAccounts (isInBackground) {
+  const state = {
+    auth: normalizeStoredAuth(ZenMoney.getData('auth')),
+    isInBackground
+  }
+
+  if (state.auth) {
+    try {
+      const apiAccounts = await fetchAccounts(state.auth)
+      ZenMoney.setData('auth', state.auth)
+      ZenMoney.saveData()
+      return { state, apiAccounts }
+    } catch (error) {
+      if (!isLikelyAuthGateError(error)) {
+        throw error
+      }
+      resetStoredAuth()
+    }
+  }
+
+  if (isInBackground) {
+    throw createForegroundReauthError(true)
+  }
+
+  state.auth = await login()
+  ZenMoney.setData('auth', state.auth)
+  ZenMoney.saveData()
+
+  try {
+    const apiAccounts = await fetchAccounts(state.auth)
+    return { state, apiAccounts }
+  } catch (error) {
+    resetStoredAuth()
+    rethrowForegroundReauthIfNeeded(error, isInBackground)
   }
 }
 
@@ -54,19 +107,10 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground, i
   toDate = toDate || new Date()
   fromDate = fromDate || getFallbackFromDate(preferences, toDate)
 
-  let device = ZenMoney.getData('device')
-  if (!device) {
-    device = generateDevice()
-    ZenMoney.setData('device', device)
-    ZenMoney.saveData()
-  }
-
-  const authState = await login(preferences, device)
+  const { state, apiAccounts } = await getAuthorizedAccounts(isInBackground)
   const accounts = []
   const seenAccountIds = new Set()
   const transactions = []
-
-  const apiAccounts = await withInteractiveBootstrapRetry(async () => await fetchAccounts(), authState, isInBackground)
 
   for (const { mainProduct, account } of convertAccounts(apiAccounts)) {
     if (seenAccountIds.has(account.id)) {
@@ -79,10 +123,9 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground, i
       continue
     }
 
-    const apiTransactions = await withInteractiveBootstrapRetry(
-      async () => await fetchTransactions(mainProduct, fromDate, toDate),
-      authState,
-      isInBackground
+    const apiTransactions = await withForegroundReauthRetry(
+      async auth => await fetchTransactions(auth, mainProduct, fromDate, toDate),
+      state
     )
 
     for (const apiTransaction of apiTransactions) {
@@ -92,6 +135,9 @@ export async function scrape ({ preferences, fromDate, toDate, isInBackground, i
       }
     }
   }
+
+  ZenMoney.setData('auth', state.auth)
+  ZenMoney.saveData()
 
   if (isFirstRun && ZenMoney.alert) {
     await ZenMoney.alert('לקבלת תוצאות מיטביות, אנו ממליצים לא לסנכרן כרטיסי כאל, ישראקרט ומקס דרך הבנק אלא ישירות דרך חברות האשראי.')

--- a/src/plugins/hapoalim/preferences.xml
+++ b/src/plugins/hapoalim/preferences.xml
@@ -1,25 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen>
     <EditTextPreference
-        key="login"
-        obligatory="true"
-        title="קוד משתמש"
-        dialogTitle="קוד משתמש"
-        positiveButtonText="בסדר"
-        negativeButtonText="בטל"
-        summary="||{@s}">
-    </EditTextPreference>
-    <EditTextPreference
-        key="password"
-        obligatory="true"
-        inputType="textPassword"
-        title="סיסמה"
-        dialogTitle="סיסמה"
-        positiveButtonText="בסדר"
-        negativeButtonText="בטל"
-        summary="||***********"
-    />
-    <EditTextPreference
         key="startDate"
         obligatory="true"
         inputType="date"


### PR DESCRIPTION
## What changed

- switched the Hapoalim plugin to the official bank web login flow
- removed login and password from plugin preferences to avoid entering credentials twice
- capture and reuse the authenticated web session for account and transaction sync
- refresh stored auth cookies from `set-cookie` response headers
- added regression tests for the auth/session bootstrap and foreground re-login flow

## Why

The current merged flow still starts with plugin credentials, falls back to the bank WebView on OTP, and then loses the authenticated bank web session before the data requests continue. That causes duplicate credential entry and `401/STEPUPOTP` failures after WebView login.

This change makes WebView login the single interactive auth path and keeps the authenticated bank session in the plugin state for subsequent requests.

## Validation

- `yarn build hapoalim`
- `yarn jest hapoalim`
- `yarn test hapoalim`
