### PR TITLE
[zepterbank-by] Исправил Zepter bank после недавних изменений и довёл плагин до рабочего состояния в debug/runtime-сценарии.

### DIFF
--- a/src/plugins/zepterbank-by/__tests__/api/get-accounts.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-accounts.test.ts
@@ -1,0 +1,40 @@
+import { convertCardAccount, convertCurrentAccount } from '../../converters'
+import { TEST_ACCOUNTS } from '../../__mocks__/accounts.sample'
+import type { FetchAccountsOutput } from '../../types/fetch.types'
+
+const mockFetchAccounts = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  fetchAccounts: mockFetchAccounts
+}))
+
+describe('getAccounts', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getAccounts } = require('../../api') as typeof import('../../api')
+
+  afterEach(() => {
+    mockFetchAccounts.mockReset()
+  })
+
+  it.each([
+    [
+      'card-only responses',
+      { products: { cards: [TEST_ACCOUNTS.CARD[0]] } },
+      [convertCardAccount(TEST_ACCOUNTS.CARD[0])]
+    ],
+    [
+      'current-account-only responses',
+      { products: { accounts: [TEST_ACCOUNTS.CURRENT[0]] } },
+      [convertCurrentAccount(TEST_ACCOUNTS.CURRENT[0])]
+    ]
+  ])('converts accounts for %s', async (_caseName: string, data: FetchAccountsOutput, expectedAccounts) => {
+    mockFetchAccounts.mockResolvedValue({
+      status: 200,
+      data,
+      error: null
+    })
+
+    await expect(getAccounts({ sessionToken: 'session-token' })).resolves.toEqual(expectedAccounts)
+  })
+})

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -1,0 +1,77 @@
+import { convertCardAccount, convertCardTransaction, convertStatementTransaction } from '../../converters'
+import { TEST_ACCOUNTS } from '../../__mocks__/accounts.sample'
+import { TEST_CARD_TRANSACTIONS, TEST_STATEMENT_TRANSACTIONS } from '../../__mocks__/transactions.sample'
+import type { FetchCardTransaction, FetchProductStatementOutput, FetchTransactionsOutput } from '../../types/fetch.types'
+
+const mockFetchCardTransactions = jest.fn()
+const mockFetchProductStatement = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  fetchCardTransactions: mockFetchCardTransactions,
+  fetchProductStatement: mockFetchProductStatement
+}))
+
+describe('getTransactions', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getTransactions } = require('../../api') as typeof import('../../api')
+
+  afterEach(() => {
+    mockFetchCardTransactions.mockReset()
+    mockFetchProductStatement.mockReset()
+  })
+
+  it('prefers statement transactions over matching card history duplicates', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const uniqueHistoryTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-02-14T11:00:00',
+      transacName: 'POS PURCHASE ',
+      amount: '2.50',
+      currencyIso: 'BYN',
+      cardAcceptor: 'UNIQUE SHOP',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5411'
+    }
+
+    const historyTransactions: FetchTransactionsOutput = [
+      ...TEST_CARD_TRANSACTIONS.Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8,
+      uniqueHistoryTransaction
+    ]
+
+    const statementResponse: FetchProductStatementOutput = {
+      incomeForPeriod: '0.00',
+      outcomeForPeriod: '0.00',
+      ibanNum: rawCardAccount.ibanNum,
+      contractCurrency: String(rawCardAccount.currency),
+      contractCurrencyISO: rawCardAccount.currencyIso,
+      operations: TEST_STATEMENT_TRANSACTIONS[rawCardAccount.productId]
+    }
+
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: historyTransactions,
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: statementResponse,
+      error: null
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-02-01T00:00:00.000Z'),
+      toDate: new Date('2026-02-28T23:59:59.000Z')
+    }, account)).resolves.toEqual([
+      ...statementResponse.operations.map((operation) => convertStatementTransaction(operation, account)),
+      convertCardTransaction(uniqueHistoryTransaction, account)
+    ])
+  })
+})

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
@@ -21,7 +21,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-13T07:21:30.000Z'),
-        comment: '',
+        comment: 'P2P DEBIT\nMCC 6012 ❌',
         movements: [
           {
             id: null,
@@ -43,7 +43,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T18:46:07.000Z'),
-        comment: '',
+        comment: 'POS PURCHASE\nMCC 6012 ❌',
         movements: [
           {
             id: null,
@@ -65,7 +65,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T17:58:51.000Z'),
-        comment: '',
+        comment: 'P2P DEBIT\nMCC 6012 ❌',
         movements: [
           {
             id: null,
@@ -87,7 +87,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T14:53:47.000Z'),
-        comment: '',
+        comment: 'POS PURCHASE\nMCC 5411 ✅',
         movements: [
           {
             id: null,
@@ -109,7 +109,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T14:31:39.000Z'),
-        comment: '',
+        comment: 'POS CASH DEPOSIT\nMCC 4900 ❌',
         movements: [
           {
             id: null,
@@ -136,7 +136,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-13T07:23:28.000Z'),
-        comment: '',
+        comment: 'POS PURCHASE\nMCC 5411 ✅',
         movements: [
           {
             id: null,
@@ -158,7 +158,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-13T07:21:30.000Z'),
-        comment: '',
+        comment: 'P2P CREDIT\nMCC 6012 ❌',
         movements: [
           {
             id: null,
@@ -180,7 +180,7 @@ describe('convertCardTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T17:58:52.000Z'),
-        comment: '',
+        comment: 'P2P CREDIT\nMCC 6012 ❌',
         movements: [
           {
             id: null,
@@ -214,7 +214,7 @@ describe('convertCardTransaction', () => {
     }, cardAccount2)).toEqual({
       hold: null,
       date: new Date('2026-05-05T13:48:41.000Z'),
-      comment: '',
+      comment: 'P2P CREDIT\nMCC не указан ❌',
       movements: [
         {
           id: null,

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
@@ -200,4 +200,31 @@ describe('convertCardTransaction', () => {
   ])('converts transactions for card account 2', (apiTransaction: FetchCardTransaction, transaction: Transaction) => {
     expect(convertCardTransaction(apiTransaction, cardAccount2)).toEqual(transaction)
   })
+
+  it('returns null merchant when card transaction does not provide merchant details', () => {
+    expect(convertCardTransaction({
+      effectiveDate: '2026-05-05T16:48:41',
+      transacName: 'P2P CREDIT',
+      amount: '0.08',
+      currencyIso: 'EUR',
+      repeatable: false,
+      transOperType: 'credit',
+      cardAcceptor: undefined,
+      transMcc: ''
+    }, cardAccount2)).toEqual({
+      hold: null,
+      date: new Date('2026-05-05T13:48:41.000Z'),
+      comment: '',
+      movements: [
+        {
+          id: null,
+          account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
+          fee: 0,
+          invoice: null,
+          sum: 0.08
+        }
+      ],
+      merchant: null
+    })
+  })
 })

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-statement-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-statement-transaction.test.ts
@@ -23,7 +23,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-13T07:21:30.000Z'),
-        comment: '',
+        comment: 'Списание P2P в устройствах банка\nMCC 6012 ❌',
         movements: [{
           id: null,
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
@@ -39,7 +39,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T18:46:07.000Z'),
-        comment: '',
+        comment: 'Оплата товаров и услуг в устройствах банка\nMCC 6012 ❌',
         movements: [{
           id: null,
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
@@ -55,7 +55,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T17:58:51.000Z'),
-        comment: '',
+        comment: 'Списание P2P в устройствах банка\nMCC 6012 ❌',
         movements: [{
           id: null,
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
@@ -71,7 +71,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T14:53:18.000Z'),
-        comment: '',
+        comment: 'Оплата товаров и услуг в устройствах других банков\nMCC 5411 ✅',
         movements: [{
           id: null,
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
@@ -87,7 +87,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T14:31:39.000Z'),
-        comment: '',
+        comment: 'Пополнение карт-счета по карточке\nMCC 4900 ❌',
         movements: [{
           id: null,
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
@@ -108,7 +108,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-13T07:21:30.000Z'),
-        comment: '',
+        comment: 'Зачисление P2P в устройствах банка (конверсия)\nMCC 6012 ❌',
         movements: [{
           id: null,
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
@@ -124,7 +124,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T17:58:52.000Z'),
-        comment: '',
+        comment: 'Зачисление P2P в устройствах банка (конверсия)\nMCC 6012 ❌',
         movements: [{
           id: null,
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
@@ -140,7 +140,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T21:00:00.000Z'),
-        comment: '',
+        comment: 'Оплата товаров и услуг в устройствах других банка (конверсия)\nMCC 5411 ✅',
         movements: [{
           id: null,
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
@@ -161,7 +161,7 @@ describe('convertStatementTransaction', () => {
       {
         hold: null,
         date: new Date('2026-02-12T18:46:07.000Z'),
-        comment: '',
+        comment: 'On-line пополнение вкладного/текущего счета (списание с карты)\nMCC не указан ❌',
         movements: [{
           id: null,
           account: { id: '3p6Kf9JU2RQW4HFE42QGVB556Sv4hgVxg4vZ7ZP2' },

--- a/src/plugins/zepterbank-by/api.ts
+++ b/src/plugins/zepterbank-by/api.ts
@@ -3,6 +3,7 @@ import type { Account, Transaction } from '../../types/zenmoney'
 import { convertCardAccount, convertCurrentAccount, convertCardTransaction, convertStatementTransaction } from './converters'
 import { BankMessageError, InvalidLoginOrPasswordError } from '../../errors'
 import { convertDateToYyyyMmDd } from './helpers'
+import { mergeTransactions } from './mergeTransactions'
 import { FetchAccountMeta } from './types/fetch.types'
 
 export const authenticate = async (login: string, password: string): Promise<{ sessionToken: string }> => {
@@ -69,12 +70,13 @@ export const getTransactions = async ({ sessionToken, fromDate, toDate }: { sess
     throw new BankMessageError(productStatementResponse.error.errorInfo.errorText)
   }
 
-  return [
-    ...(cardTransactionsResponse?.data ?? [])
-      .filter((op) => op.amount !== '0.00')
-      .map((op) => convertCardTransaction(op, account)),
-    ...productStatementResponse.data.operations
-      .filter((op) => op.operationSum !== '0.00')
-      .map((op) => convertStatementTransaction(op, account))
-  ]
+  const historyTransactions = (cardTransactionsResponse?.data ?? [])
+    .filter((op) => op.amount !== '0.00')
+    .map((op) => convertCardTransaction(op, account))
+
+  const statementTransactions = productStatementResponse.data.operations
+    .filter((op) => op.operationSum !== '0.00')
+    .map((op) => convertStatementTransaction(op, account))
+
+  return mergeTransactions(historyTransactions, statementTransactions)
 }

--- a/src/plugins/zepterbank-by/api.ts
+++ b/src/plugins/zepterbank-by/api.ts
@@ -31,9 +31,11 @@ export const getAccounts = async ({ sessionToken }: { sessionToken: string }): P
     throw new BankMessageError(error.errorInfo.errorText)
   }
 
+  const { cards = [], accounts = [] } = data.products
+
   return [
-    ...data.products.cards.map((acc) => convertCardAccount(acc)),
-    ...data.products.accounts.map((acc) => convertCurrentAccount(acc))
+    ...cards.map((acc) => convertCardAccount(acc)),
+    ...accounts.map((acc) => convertCurrentAccount(acc))
   ]
 }
 

--- a/src/plugins/zepterbank-by/cashback.d.ts
+++ b/src/plugins/zepterbank-by/cashback.d.ts
@@ -1,0 +1,7 @@
+export const QUALIFIED_CASHBACK_MCCS: Set<number>
+
+export function isCashbackQualified (mcc: number | null | undefined): boolean
+
+export function getCashbackCommentLine (mcc: number | null | undefined): string
+
+export function appendCashbackComment (comment: string | null | undefined, mcc: number | null | undefined): string

--- a/src/plugins/zepterbank-by/cashback.js
+++ b/src/plugins/zepterbank-by/cashback.js
@@ -1,0 +1,72 @@
+const QUALIFIED_CASHBACK_MCCS = new Set([
+  7999,
+  5552,
+  5462,
+  4111,
+  4112,
+  5262,
+  5300,
+  5309,
+  5962,
+  4511,
+  7011,
+  3501,
+  5912,
+  5541,
+  5542,
+  5943,
+  5641,
+  5942,
+  5311,
+  5812,
+  5814,
+  4121,
+  7512,
+  3351,
+  5411,
+  5499,
+  5094,
+  5945,
+  5995,
+  5719,
+  5999,
+  7832,
+  7996,
+  7998
+])
+
+function normalizeComment (comment) {
+  const normalizedComment = comment?.trim()
+
+  return normalizedComment || ''
+}
+
+function isCashbackQualified (mcc) {
+  return typeof mcc === 'number' && QUALIFIED_CASHBACK_MCCS.has(mcc)
+}
+
+function getCashbackCommentLine (mcc) {
+  if (typeof mcc !== 'number') {
+    return 'MCC не указан ❌'
+  }
+
+  return `MCC ${mcc} ${isCashbackQualified(mcc) ? '✅' : '❌'}`
+}
+
+function appendCashbackComment (comment, mcc) {
+  const normalizedComment = normalizeComment(comment)
+  const cashbackCommentLine = getCashbackCommentLine(mcc)
+
+  if (normalizedComment === '') {
+    return cashbackCommentLine
+  }
+
+  return `${normalizedComment}\n${cashbackCommentLine}`
+}
+
+module.exports = {
+  QUALIFIED_CASHBACK_MCCS,
+  isCashbackQualified,
+  getCashbackCommentLine,
+  appendCashbackComment
+}

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -8,6 +8,7 @@ import {
   FetchCurrentAccountMeta
 } from './types/fetch.types'
 import { convertIsoDateStringToDate } from './helpers'
+import { appendCashbackComment } from './cashback.js'
 
 const parseMcc = (mcc: string | undefined): number | null => {
   const digits = mcc?.replace(/\D/g, '') ?? ''
@@ -74,7 +75,7 @@ export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, a
   return {
     hold: null,
     date: convertIsoDateStringToDate(fetchTransaction.effectiveDate),
-    comment: '',
+    comment: appendCashbackComment(fetchTransaction.transacName, mcc),
     movements: [
       {
         id: null, // no transaction id presented
@@ -90,15 +91,7 @@ export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, a
           mcc,
           location: null
         }
-      : mcc !== null
-        ? {
-            title: '',
-            country: null,
-            city: null,
-            mcc,
-            location: null
-          }
-        : null
+      : null
   }
 }
 
@@ -114,7 +107,7 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
   return {
     hold: null,
     date: convertIsoDateStringToDate(fetchTransaction.transactionDate),
-    comment: '',
+    comment: appendCashbackComment(fetchTransaction.operationName, mcc),
     movements: [
       {
         id: null, // no transaction id presented

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -9,6 +9,28 @@ import {
 } from './types/fetch.types'
 import { convertIsoDateStringToDate } from './helpers'
 
+const parseMcc = (mcc: string | undefined): number | null => {
+  const digits = mcc?.replace(/\D/g, '') ?? ''
+
+  if (digits === '') {
+    return null
+  }
+
+  const parsedMcc = Number(digits)
+
+  return Number.isInteger(parsedMcc) && parsedMcc > 0
+    ? parsedMcc
+    : null
+}
+
+const normalizeMerchantTitle = (title: string | undefined): string | null => {
+  const normalizedTitle = title?.trim()
+
+  return normalizedTitle != null && normalizedTitle !== ''
+    ? normalizedTitle
+    : null
+}
+
 export const convertCardAccount = (fetchAccount: FetchCardAccount): Account & FetchCardAccountMeta => {
   return {
     id: fetchAccount.productCardId,
@@ -46,6 +68,8 @@ export const convertCurrentAccount = (fetchAccount: FetchCurrentAccount): Accoun
 export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, account: Account): Transaction => {
   const isInDifferentCurrency = fetchTransaction.currencyIso !== account.instrument
   const amount = Number(`${fetchTransaction.transOperType === 'debit' ? '-' : ''}${fetchTransaction.amount}`)
+  const merchantTitle = normalizeMerchantTitle(fetchTransaction.cardAcceptor)
+  const mcc = parseMcc(fetchTransaction.transMcc)
 
   return {
     hold: null,
@@ -60,11 +84,21 @@ export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, a
         sum: isInDifferentCurrency ? null : amount
       }
     ],
-    merchant: {
-      fullTitle: fetchTransaction.cardAcceptor,
-      mcc: Number(fetchTransaction.transMcc.replace(/\D/g, '')),
-      location: null
-    }
+    merchant: merchantTitle !== null
+      ? {
+          fullTitle: merchantTitle,
+          mcc,
+          location: null
+        }
+      : mcc !== null
+        ? {
+            title: '',
+            country: null,
+            city: null,
+            mcc,
+            location: null
+          }
+        : null
   }
 }
 
@@ -75,7 +109,7 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
 
   const payee = fetchTransaction.terminalLocation ?? ''
   const [country = '', city = ''] = (fetchTransaction.merchant ?? '').split(' ')
-  const mcc = fetchTransaction.MCC != null ? Number(fetchTransaction.MCC.replace(/\D/g, '')) : null
+  const mcc = parseMcc(fetchTransaction.MCC)
 
   return {
     hold: null,

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -1,0 +1,95 @@
+import { Transaction } from '../../types/zenmoney'
+
+type TransactionSource = 'history' | 'statement'
+
+interface SourcedTransaction {
+  source: TransactionSource
+  transaction: Transaction
+}
+
+const normalizeText = (text: string | null | undefined): string =>
+  (text ?? '').replace(/\s+/g, ' ').trim()
+
+const getMerchantTitle = (transaction: Transaction): string => {
+  const { merchant } = transaction
+
+  if (merchant == null) {
+    return ''
+  }
+
+  return 'fullTitle' in merchant
+    ? merchant.fullTitle
+    : merchant.title
+}
+
+const getMovementAccountId = (transaction: Transaction): string => {
+  const account = transaction.movements[0]?.account
+
+  if (account != null && 'id' in account) {
+    return account.id
+  }
+
+  return ''
+}
+
+const getAmountSignature = (transaction: Transaction): string => {
+  const movement = transaction.movements[0]
+
+  if (movement == null) {
+    return ''
+  }
+
+  if (movement.invoice != null) {
+    return `invoice|${movement.invoice.instrument}|${movement.invoice.sum}`
+  }
+
+  return `sum|${movement.sum ?? ''}`
+}
+
+const getMccSignature = (transaction: Transaction): string => {
+  const { merchant } = transaction
+
+  return merchant != null ? String(merchant.mcc ?? '') : ''
+}
+
+const getDaySignature = (transaction: Transaction): string =>
+  transaction.date.toISOString().slice(0, 10)
+
+const getDuplicateFingerprint = (transaction: Transaction): string => [
+  getMovementAccountId(transaction),
+  getDaySignature(transaction),
+  getAmountSignature(transaction),
+  getMccSignature(transaction),
+  normalizeText(getMerchantTitle(transaction))
+].join('|')
+
+const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean =>
+  getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
+
+export const mergeTransactions = (historyTransactions: Transaction[], statementTransactions: Transaction[]): Transaction[] => {
+  const mergedTransactions: SourcedTransaction[] = historyTransactions.map((transaction) => ({
+    source: 'history',
+    transaction
+  }))
+
+  for (const statementTransaction of statementTransactions) {
+    const duplicateHistoryIndex = mergedTransactions.findIndex(({ source, transaction }) =>
+      source === 'history' && isMatchingDuplicate(transaction, statementTransaction)
+    )
+
+    if (duplicateHistoryIndex !== -1) {
+      mergedTransactions[duplicateHistoryIndex] = {
+        source: 'statement',
+        transaction: statementTransaction
+      }
+      continue
+    }
+
+    mergedTransactions.push({
+      source: 'statement',
+      transaction: statementTransaction
+    })
+  }
+
+  return mergedTransactions.map(({ transaction }) => transaction)
+}

--- a/src/plugins/zepterbank-by/types/fetch.types.ts
+++ b/src/plugins/zepterbank-by/types/fetch.types.ts
@@ -101,7 +101,7 @@ export interface FetchCardTransaction {
   'amount': string
   'currencyIso': string
   /** Place of payment **/
-  'cardAcceptor': string
+  'cardAcceptor'?: string
   'repeatable': false
   /** credit - income, debit - outcome **/
   'transOperType': 'debit' | 'credit'
@@ -109,7 +109,7 @@ export interface FetchCardTransaction {
    * MCC code (MCC is cyrillic)
    * @example MCC0000
    * **/
-  'transMcc': string
+  'transMcc'?: string
 }
 
 export interface FetchTransactionsInput extends BaseFetchInput {

--- a/src/plugins/zepterbank-by/types/fetch.types.ts
+++ b/src/plugins/zepterbank-by/types/fetch.types.ts
@@ -82,8 +82,8 @@ export interface FetchAccountsInput extends BaseFetchInput {}
 
 export interface FetchAccountsOutput {
   products: {
-    cards: FetchCardAccount[]
-    accounts: FetchCurrentAccount[]
+    cards?: FetchCardAccount[]
+    accounts?: FetchCurrentAccount[]
   }
 }
 


### PR DESCRIPTION

Что сделано

 - исправил падение на загрузке счетов, когда банк возвращает products без одного из массивов (cards или accounts);
 - обновил типы ответа банка под частично неполный payload;
 - исправил падение на карточных операциях, где банк не присылает cardAcceptor и/или присылает невалидный MCC;
 - добавил отдельный helper для определения qualification под cashback по MCC;
 - добавил в комментарии операций вторую строку с форматом:
  - MCC #### ✅ — если операция подходит под cashback;
  - MCC #### ❌ — если не подходит;
  - MCC не указан ❌ — если MCC нет;
 - устранил задвоение операций при одновременной загрузке из history и statement:
  - overlapping-операции теперь merge’ятся;
  - при конфликте приоритет отдаётся statement;
  - уникальные операции из history сохраняются.

Технически

Добавлены и/или изменены:

 - обработка account response в api.ts;
 - нормализация merchant/MCC в converters.ts;
 - отдельный helper cashback.js (+ typing bridge);
 - helper для merge/deduplicate транзакций между history и statement;
 - regression tests на:
  - неполный account payload;
  - пустой merchant у карточных операций;
  - cashback-комментарии;
  - дедупликацию history + statement.

Результат

 - плагин больше не падает на описанных runtime-кейсах;
 - операции не дублируются;
 - в комментариях видно qualification под cashback;
 - тесты zepterbank-by проходят.
