### PR TITLE
[hapoalim] recover webview cookie login

### DIFF
--- a/src/plugins/hapoalim/__tests__/api.login.test.js
+++ b/src/plugins/hapoalim/__tests__/api.login.test.js
@@ -5,10 +5,14 @@ describe('hapoalim api login', () => {
   let openWebViewAndInterceptRequestMock
   let fetchMock
   let fetchJsonMock
+  let consoleSpies
 
   beforeEach(() => {
     jest.resetModules()
     jest.clearAllMocks()
+    consoleSpies = ['debug', 'info', 'log', 'warn', 'error'].map(method =>
+      jest.spyOn(console, method).mockImplementation(() => {})
+    )
 
     openWebViewAndInterceptRequestMock = jest.fn(async ({ url, intercept }) => {
       expect(url).toBe('https://login.bankhapoalim.co.il/cgi-bin/poalwwwc?reqName=getLogonPage')
@@ -21,18 +25,18 @@ describe('hapoalim api login', () => {
       })
       expect(apiRequestResult).toBeNull()
 
-      const portalRequestResult = intercept({
-        url: 'https://login.bankhapoalim.co.il/portalserver/HomePage',
-        headers: {
-          cookie: 'TS=portal-cookie; XSRF-TOKEN=portal-xsrf'
-        }
+      return await new Promise((resolve, reject) => {
+        const portalRequestResult = intercept.call({
+          close: (error, closeResult) => error ? reject(error) : resolve(closeResult)
+        }, {
+          url: 'https://login.bankhapoalim.co.il/portalserver/HomePage',
+          headers: {
+            cookie: 'TS=portal-cookie; SMSESSION=portal-session; XSRF-TOKEN=portal-xsrf'
+          }
+        })
+
+        expect(portalRequestResult).toBeNull()
       })
-
-      expect(portalRequestResult.auth.cookieHeader).toContain('TS=portal-cookie')
-      expect(portalRequestResult.auth.cookieHeader).toContain('XSRF-TOKEN=portal-xsrf')
-      expect(portalRequestResult.auth.xsrfToken).toBe('portal-xsrf')
-
-      return portalRequestResult
     })
 
     fetchMock = jest.fn().mockResolvedValue({
@@ -41,10 +45,16 @@ describe('hapoalim api login', () => {
       headers: {},
       body: 'window.bnhpApp = { restContext: "/pib" }'
     })
-    fetchJsonMock = jest.fn()
+    fetchJsonMock = jest.fn().mockResolvedValue({
+      status: 200,
+      url: 'https://login.bankhapoalim.co.il/ServerServices/general/accounts?lang=he',
+      headers: {},
+      body: [{ accountNumber: '1' }, { accountNumber: '2' }]
+    })
 
     global.ZenMoney = {
-      openWebView: jest.fn()
+      openWebView: jest.fn(),
+      getCookies: jest.fn().mockResolvedValue([])
     }
 
     jest.doMock('../../../common/network', () => ({
@@ -56,6 +66,12 @@ describe('hapoalim api login', () => {
     }))
 
     login = require('../api').login
+  })
+
+  afterEach(() => {
+    for (const spy of consoleSpies) {
+      spy.mockRestore()
+    }
   })
 
   it('waits for an authenticated portal request, restores rest context and refreshes cookies from response headers', async () => {
@@ -86,6 +102,183 @@ describe('hapoalim api login', () => {
       restContext: 'pib'
     })
     expect(auth.cookieHeader).toContain('TS=rotated-cookie')
+    expect(auth.cookieHeader).toContain('SMSESSION=portal-session')
     expect(auth.cookieHeader).toContain('XSRF-TOKEN=rotated-xsrf')
+  })
+
+  it('completes web login from ZenMoney cookie store when intercepted request has no cookie header', async () => {
+    global.ZenMoney.getCookies.mockResolvedValue([
+      { domain: '.bankhapoalim.co.il', name: 'SMSESSION', value: 'store-session' },
+      { domain: 'login.bankhapoalim.co.il', name: 'XSRF-TOKEN', value: 'store-xsrf' },
+      { domain: 'example.com', name: 'ignored', value: 'ignored' }
+    ])
+    openWebViewAndInterceptRequestMock.mockImplementationOnce(async ({ intercept }) => {
+      return await new Promise((resolve, reject) => {
+        const result = intercept.call({
+          close: (error, closeResult) => error ? reject(error) : resolve(closeResult)
+        }, {
+          url: 'https://login.bankhapoalim.co.il/ng-portals/rb/he/homepage',
+          headers: {}
+        })
+
+        if (result) {
+          resolve(result)
+        }
+      })
+    })
+
+    const auth = await login()
+
+    expect(global.ZenMoney.getCookies).toHaveBeenCalled()
+    expect(auth).toMatchObject({
+      xsrfToken: 'store-xsrf',
+      restContext: 'pib'
+    })
+    expect(auth.cookieHeader).toContain('SMSESSION=store-session')
+    expect(auth.cookieHeader).toContain('XSRF-TOKEN=store-xsrf')
+    expect(auth.cookieHeader).not.toContain('ignored=ignored')
+  })
+
+  it('recovers web login from ZenMoney cookie store after the WebView is closed', async () => {
+    global.ZenMoney.getCookies.mockResolvedValue([
+      { domain: '.bankhapoalim.co.il', name: 'SMSESSION', value: 'closed-session' },
+      { domain: '.bankhapoalim.co.il', name: 'XSRF-TOKEN', value: 'closed-xsrf' }
+    ])
+    openWebViewAndInterceptRequestMock.mockRejectedValueOnce(new Error('WebView closed'))
+
+    const auth = await login()
+
+    expect(global.ZenMoney.getCookies).toHaveBeenCalled()
+    expect(auth).toMatchObject({
+      xsrfToken: 'closed-xsrf',
+      restContext: 'pib'
+    })
+    expect(auth.cookieHeader).toContain('SMSESSION=closed-session')
+    expect(auth.cookieHeader).toContain('XSRF-TOKEN=closed-xsrf')
+  })
+
+  it('closes web login from cookie store polling without a success url', async () => {
+    const originalSetTimeout = global.setTimeout
+    const originalClearTimeout = global.clearTimeout
+    const scheduledCallbacks = []
+    global.setTimeout = jest.fn((callback) => {
+      scheduledCallbacks.push(callback)
+      return scheduledCallbacks.length
+    })
+    global.clearTimeout = jest.fn()
+
+    global.ZenMoney.getCookies
+      .mockResolvedValueOnce([
+        { domain: '.bankhapoalim.co.il', name: 'visid_incap_2405249', value: 'anti-bot' }
+      ])
+      .mockResolvedValueOnce([
+        { domain: '.bankhapoalim.co.il', name: 'SMSESSION', value: 'poll-session' },
+        { domain: '.bankhapoalim.co.il', name: 'XSRF-TOKEN', value: 'poll-xsrf' }
+      ])
+
+    openWebViewAndInterceptRequestMock.mockImplementationOnce(async ({ intercept }) => {
+      return await new Promise((resolve, reject) => {
+        const result = intercept.call({
+          close: (error, closeResult) => error ? reject(error) : resolve(closeResult)
+        }, {
+          url: 'https://login.bankhapoalim.co.il/ng-portals/auth/he/',
+          headers: {}
+        })
+
+        if (result) {
+          resolve(result)
+        }
+      })
+    })
+
+    try {
+      const authPromise = login()
+
+      expect(scheduledCallbacks).toHaveLength(1)
+      await scheduledCallbacks.shift()()
+      expect(scheduledCallbacks).toHaveLength(1)
+      await scheduledCallbacks.shift()()
+
+      const auth = await authPromise
+      expect(auth).toMatchObject({
+        xsrfToken: 'poll-xsrf',
+        restContext: 'pib'
+      })
+      expect(auth.cookieHeader).toContain('SMSESSION=poll-session')
+      expect(auth.cookieHeader).toContain('XSRF-TOKEN=poll-xsrf')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    } finally {
+      global.setTimeout = originalSetTimeout
+      global.clearTimeout = originalClearTimeout
+    }
+  })
+
+  it('does not recover web login from unauthenticated anti-bot cookies only', async () => {
+    global.ZenMoney.getCookies.mockResolvedValue([
+      { domain: '.bankhapoalim.co.il', name: 'visid_incap_2405249', value: 'anti-bot' },
+      { domain: '.bankhapoalim.co.il', name: 'incap_ses_3302_2405249', value: 'anti-bot' }
+    ])
+    openWebViewAndInterceptRequestMock.mockRejectedValueOnce(new Error('WebView closed'))
+
+    await expect(login()).rejects.toMatchObject({
+      message: 'Could not complete Bank Hapoalim web login. Finish the bank login in the opened page and retry sync.'
+    })
+
+    expect(global.ZenMoney.getCookies).toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not recover web login from session cookies until accounts access is verified', async () => {
+    global.ZenMoney.getCookies.mockResolvedValue([
+      { domain: '.bankhapoalim.co.il', name: 'SMSESSION', value: 'stale-session' },
+      { domain: '.bankhapoalim.co.il', name: 'XSRF-TOKEN', value: 'stale-xsrf' }
+    ])
+    fetchJsonMock.mockResolvedValue({
+      status: 403,
+      url: 'https://login.bankhapoalim.co.il/ServerServices/general/accounts?lang=he',
+      headers: {},
+      body: { error: { errCode: 'STEPUPOTP' } }
+    })
+    openWebViewAndInterceptRequestMock.mockRejectedValueOnce(new Error('WebView closed'))
+
+    await expect(login()).rejects.toMatchObject({
+      message: 'Could not complete Bank Hapoalim web login. Finish the bank login in the opened page and retry sync.'
+    })
+
+    expect(global.ZenMoney.getCookies).toHaveBeenCalled()
+    expect(fetchJsonMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('does not complete request-cookie login until accounts access is verified', async () => {
+    global.ZenMoney.getCookies.mockResolvedValue([])
+    fetchJsonMock.mockResolvedValue({
+      status: 403,
+      url: 'https://login.bankhapoalim.co.il/ServerServices/general/accounts?lang=he',
+      headers: {},
+      body: { error: { errCode: 'STEPUPOTP' } }
+    })
+    openWebViewAndInterceptRequestMock.mockImplementationOnce(async ({ intercept }) => {
+      const result = intercept.call({
+        close: () => {
+          throw new Error('WebView should not close before accounts access is verified')
+        }
+      }, {
+        url: 'https://login.bankhapoalim.co.il/ng-portals/rb/he/homepage',
+        headers: {
+          cookie: 'SMSESSION=request-session; XSRF-TOKEN=request-xsrf'
+        }
+      })
+      expect(result).toBeNull()
+      await Promise.resolve()
+      throw new Error('WebView still open')
+    })
+
+    await expect(login()).rejects.toMatchObject({
+      message: 'Could not complete Bank Hapoalim web login. Finish the bank login in the opened page and retry sync.'
+    })
+
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 })

--- a/src/plugins/hapoalim/api.js
+++ b/src/plugins/hapoalim/api.js
@@ -7,6 +7,12 @@ import { fetch, fetchJson, ParseError, openWebViewAndInterceptRequest } from '..
 import { generateRandomString } from '../../common/utils'
 
 const OFFICIAL_BASE_URL = 'https://login.bankhapoalim.co.il'
+const OFFICIAL_COOKIE_DOMAINS = [
+  'bankhapoalim.co.il',
+  '.bankhapoalim.co.il',
+  'login.bankhapoalim.co.il',
+  '.login.bankhapoalim.co.il'
+]
 const WEB_LOGIN_URL = `${OFFICIAL_BASE_URL}/cgi-bin/poalwwwc?reqName=getLogonPage`
 const WEB_SUCCESS_PATTERNS = [
   /\/portalserver\/HomePage/i,
@@ -14,6 +20,7 @@ const WEB_SUCCESS_PATTERNS = [
   /\/ng--portals\/rb\/he\//i,
   /\/ng-portals\/rb\/he\//i
 ]
+const WEB_LOGIN_INCOMPLETE_MESSAGE = 'Could not complete Bank Hapoalim web login. Finish the bank login in the opened page and retry sync.'
 const PORTAL_PAGE_PATHS = [
   '/portalserver/HomePage',
   '/ng-portals-bt/rb/he/homepage',
@@ -45,6 +52,8 @@ const EXCLUDED_REST_CONTEXTS = new Set([
 ])
 const OFFICIAL_TRANSACTION_PAGE_UUID = '/current-account/transactions'
 const OFFICIAL_TRANSACTION_LIMIT = 1000
+const COOKIE_STORE_POLL_INTERVAL_MS = 1000
+const COOKIE_STORE_POLL_TIMEOUT_MS = 10 * 60 * 1000
 
 function summarizeResponse (response) {
   return response
@@ -164,6 +173,64 @@ function getCookieValue (cookieHeader, cookieName) {
   return cookies[cookieName] || null
 }
 
+function isOfficialCookieDomain (domain) {
+  if (typeof domain !== 'string' || domain === '') {
+    return false
+  }
+
+  const normalizedDomain = domain.toLowerCase()
+  return OFFICIAL_COOKIE_DOMAINS.includes(normalizedDomain) ||
+    normalizedDomain.endsWith('.bankhapoalim.co.il')
+}
+
+function sanitizeOfficialUrlForLog (rawUrl) {
+  try {
+    const url = new URL(rawUrl)
+    return `${url.origin}${url.pathname}`
+  } catch (error) {
+    return null
+  }
+}
+
+function getCookieHeaderNames (cookieHeader) {
+  return String(cookieHeader || '')
+    .split(';')
+    .map(cookie => cookie.split('=')[0].trim())
+    .filter(Boolean)
+    .sort()
+}
+
+function hasLikelyOfficialAuthCookie (cookieHeader) {
+  const cookies = parseCookieHeader(cookieHeader)
+  return Boolean(cookies.SMSESSION || cookies['XSRF-TOKEN'])
+}
+
+function hasOfficialSessionCookie (cookieHeader) {
+  return Boolean(parseCookieHeader(cookieHeader).SMSESSION)
+}
+
+function summarizeOfficialCookieStore (cookies) {
+  return (Array.isArray(cookies) ? cookies : [])
+    .filter(cookie => isOfficialCookieDomain(cookie?.domain))
+    .filter(cookie => typeof cookie?.name === 'string' && cookie.name !== '')
+    .filter(cookie => typeof cookie?.value === 'string' && cookie.value !== '')
+    .map(cookie => `${cookie.domain || ''}:${cookie.name}`)
+    .sort()
+}
+
+function buildCookieHeaderFromCookieStore (cookies) {
+  if (!Array.isArray(cookies)) {
+    return ''
+  }
+
+  return cookies
+    .filter(cookie => isOfficialCookieDomain(cookie?.domain))
+    .filter(cookie => typeof cookie?.name === 'string' && cookie.name !== '')
+    .filter(cookie => typeof cookie?.value === 'string' && cookie.value !== '')
+    .map(cookie => `${cookie.name}=${cookie.value}`)
+    .join('; ')
+}
+
 function normalizeRestContext (value) {
   if (typeof value !== 'string') {
     return null
@@ -231,6 +298,74 @@ function updateAuthFromResponse (auth, response) {
 
   nextAuth.restContext = nextAuth.restContext || extractRestContextFromUrl(response?.url)
   return nextAuth
+}
+
+async function updateAuthFromCookieStore (auth, { requireSessionCookie = false, logMissingAuth = true } = {}) {
+  if (!ZenMoney?.getCookies) {
+    return auth
+  }
+
+  try {
+    const cookies = await ZenMoney.getCookies()
+    const officialCookieStore = summarizeOfficialCookieStore(cookies)
+    const cookieHeader = buildCookieHeaderFromCookieStore(cookies)
+    if (!cookieHeader) {
+      if (logMissingAuth) {
+        console.warn('Bank Hapoalim cookie store has no official cookies')
+      }
+      return auth
+    }
+
+    const cookieNames = getCookieHeaderNames(cookieHeader)
+    const hasLikelyAuthCookie = hasLikelyOfficialAuthCookie(cookieHeader)
+    if (officialCookieStore.length > 0 && (logMissingAuth || hasLikelyAuthCookie)) {
+      console.log('Bank Hapoalim cookie store contains official cookies', officialCookieStore)
+    }
+    if (!hasLikelyAuthCookie) {
+      if (logMissingAuth) {
+        console.warn('Bank Hapoalim cookie store has no likely auth cookies', {
+          cookieNames
+        })
+      }
+      return auth
+    }
+    if (requireSessionCookie && !hasOfficialSessionCookie(cookieHeader)) {
+      if (logMissingAuth) {
+        console.warn('Bank Hapoalim cookie store has no session cookie', {
+          cookieNames
+        })
+      }
+      return auth
+    }
+
+    const nextAuth = { ...auth }
+    nextAuth.cookieHeader = mergeCookieHeaders(nextAuth.cookieHeader, cookieHeader)
+    nextAuth.xsrfToken = getCookieValue(nextAuth.cookieHeader, 'XSRF-TOKEN') || nextAuth.xsrfToken
+    console.log('Bank Hapoalim cookie store auth snapshot', {
+      cookieNames,
+      hasXsrfToken: Boolean(nextAuth.xsrfToken)
+    })
+    return nextAuth
+  } catch (error) {
+    console.warn('failed to read Bank Hapoalim cookies from ZenMoney cookie store', error?.message || error)
+    return auth
+  }
+}
+
+async function hasAuthenticatedAccountsAccess (auth) {
+  try {
+    const response = await fetchOfficialJson('/ServerServices/general/accounts?lang=he', auth, { log: false })
+    const hasAccess = response.status === 200 && Array.isArray(response.body)
+    console.log('Bank Hapoalim accounts access probe', {
+      status: response.status,
+      hasAccountsArray: hasAccess,
+      accountCount: hasAccess ? response.body.length : null
+    })
+    return hasAccess
+  } catch (error) {
+    console.warn('Bank Hapoalim accounts access probe failed', error?.responseSummary || error?.response?.status || error?.message || error)
+    return false
+  }
 }
 
 function applyAuthUpdate (targetAuth, nextAuth) {
@@ -382,6 +517,114 @@ async function captureOfficialSessionFromWebView () {
   }
 
   let auth = createEmptyAuth()
+  let authCaptureInFlight = false
+  let cookieStorePollingStarted = false
+  let cookieStorePollingStopped = false
+  let cookieStorePollingTimeoutId = null
+  let cookieStorePollingStartedAt = 0
+  let webViewCloseRequested = false
+
+  function stopCookieStorePolling () {
+    cookieStorePollingStopped = true
+    if (cookieStorePollingTimeoutId != null && typeof clearTimeout === 'function') {
+      clearTimeout(cookieStorePollingTimeoutId)
+    }
+    cookieStorePollingTimeoutId = null
+  }
+
+  function closeWebViewWithAuth (close, nextAuth, source) {
+    if (webViewCloseRequested) {
+      return
+    }
+    webViewCloseRequested = true
+    auth = nextAuth
+    stopCookieStorePolling()
+    console.log('Bank Hapoalim WebView auth captured', {
+      source,
+      cookieNames: getCookieHeaderNames(auth.cookieHeader),
+      hasXsrfToken: Boolean(auth.xsrfToken)
+    })
+    close(null, { auth })
+  }
+
+  async function tryCloseWithVerifiedAuth ({ close, nextAuth, verifyAccountsAccess, source }) {
+    if (authCaptureInFlight || webViewCloseRequested) {
+      return false
+    }
+
+    authCaptureInFlight = true
+    try {
+      if (!hasOfficialSessionCookie(nextAuth.cookieHeader)) {
+        return false
+      }
+      if (verifyAccountsAccess && !await hasAuthenticatedAccountsAccess(nextAuth)) {
+        return false
+      }
+      closeWebViewWithAuth(close, nextAuth, source)
+      return true
+    } catch (error) {
+      console.warn('failed to complete Bank Hapoalim WebView login from verified auth', error?.message || error)
+      return false
+    } finally {
+      authCaptureInFlight = false
+    }
+  }
+
+  async function tryCompleteFromCookieStore ({ close, requireSessionCookie, verifyAccountsAccess, source }) {
+    if (authCaptureInFlight || webViewCloseRequested) {
+      return false
+    }
+
+    const nextAuth = await updateAuthFromCookieStore(auth, {
+      requireSessionCookie,
+      logMissingAuth: source !== 'cookie-store-poll'
+    })
+    const isComplete = requireSessionCookie
+      ? hasOfficialSessionCookie(nextAuth.cookieHeader)
+      : nextAuth.cookieHeader !== ''
+    if (!isComplete) {
+      return false
+    }
+
+    return await tryCloseWithVerifiedAuth({
+      close,
+      nextAuth,
+      verifyAccountsAccess,
+      source
+    })
+  }
+
+  function scheduleCookieStorePoll (close) {
+    if (cookieStorePollingStopped || webViewCloseRequested || typeof setTimeout !== 'function') {
+      return
+    }
+    if (Date.now() - cookieStorePollingStartedAt > COOKIE_STORE_POLL_TIMEOUT_MS) {
+      console.warn('Bank Hapoalim cookie store polling timed out')
+      return
+    }
+
+    cookieStorePollingTimeoutId = setTimeout(async () => {
+      cookieStorePollingTimeoutId = null
+      const isComplete = await tryCompleteFromCookieStore({
+        close,
+        requireSessionCookie: true,
+        verifyAccountsAccess: true,
+        source: 'cookie-store-poll'
+      })
+      if (!isComplete) {
+        scheduleCookieStorePoll(close)
+      }
+    }, COOKIE_STORE_POLL_INTERVAL_MS)
+  }
+
+  function startCookieStorePolling (close) {
+    if (cookieStorePollingStarted || !ZenMoney?.getCookies) {
+      return
+    }
+    cookieStorePollingStarted = true
+    cookieStorePollingStartedAt = Date.now()
+    scheduleCookieStorePoll(close)
+  }
 
   try {
     const result = await openWebViewAndInterceptRequest({
@@ -395,29 +638,78 @@ async function captureOfficialSessionFromWebView () {
         }
       },
       intercept (request) {
+        const close = typeof this?.close === 'function' ? this.close.bind(this) : null
         if (typeof request?.url === 'string' && request.url.indexOf(OFFICIAL_BASE_URL) === 0) {
+          if (close) {
+            startCookieStorePolling(close)
+          }
           auth = updateAuthFromRequest(auth, request)
         }
 
         const isAuthenticatedPortalRequest = WEB_SUCCESS_PATTERNS.some(pattern => pattern.test(request?.url || ''))
-        if (auth.cookieHeader !== '' && isAuthenticatedPortalRequest) {
-          return { auth }
+        if (isAuthenticatedPortalRequest) {
+          console.log('Bank Hapoalim WebView reached authenticated portal request', {
+            url: sanitizeOfficialUrlForLog(request?.url),
+            hasRequestCookies: getCookieHeaderNames(getHeaderValue(request?.headers, 'cookie') || getHeaderValue(request?.headers, 'Cookie')).length > 0,
+            authCookieNames: getCookieHeaderNames(auth.cookieHeader)
+          })
+        }
+        if (hasOfficialSessionCookie(auth.cookieHeader) && isAuthenticatedPortalRequest) {
+          if (!close) {
+            return { auth }
+          }
+          tryCloseWithVerifiedAuth({
+            close,
+            nextAuth: auth,
+            verifyAccountsAccess: true,
+            source: 'authenticated-portal-request'
+          })
+            .catch(error => {
+              console.warn('failed to complete Bank Hapoalim WebView login from request auth', error?.message || error)
+            })
+          return null
+        }
+
+        if (close && isAuthenticatedPortalRequest && ZenMoney?.getCookies && !authCaptureInFlight) {
+          tryCompleteFromCookieStore({
+            close,
+            requireSessionCookie: true,
+            verifyAccountsAccess: true,
+            source: 'authenticated-portal-cookie-store'
+          })
+            .catch(error => {
+              console.warn('failed to complete Bank Hapoalim WebView login from cookie store', error?.message || error)
+            })
         }
 
         return null
       }
     })
 
+    stopCookieStorePolling()
     auth = restoreAuth(result?.auth) || auth
-    ensure(auth.cookieHeader !== '', 'web login did not produce an authenticated session')
+    auth = await updateAuthFromCookieStore(auth)
+    if (!hasOfficialSessionCookie(auth.cookieHeader)) {
+      throw new Error('web login did not produce an authenticated session')
+    }
+    if (!await hasAuthenticatedAccountsAccess(auth)) {
+      throw new Error('web login did not produce authenticated API access')
+    }
     await ensureRestContext(auth)
     return auth
   } catch (error) {
+    stopCookieStorePolling()
+    auth = await updateAuthFromCookieStore(auth, { requireSessionCookie: true })
+    if (hasOfficialSessionCookie(auth.cookieHeader) && await hasAuthenticatedAccountsAccess(auth)) {
+      await ensureRestContext(auth)
+      return auth
+    }
+
     if (error instanceof TemporaryError) {
       throw error
     }
     console.warn('interactive web login failed', error?.message || error)
-    throw new TemporaryError('Could not complete Bank Hapoalim web login. Finish the bank login in the opened page and retry sync.')
+    throw new TemporaryError(WEB_LOGIN_INCOMPLETE_MESSAGE)
   }
 }
 


### PR DESCRIPTION
## Summary

- add a Bank Hapoalim cookie-store fallback for the official WebView login flow
- poll `ZenMoney.getCookies()` while the bank WebView is open, and recover auth from the cookie store after WebView close
- require `SMSESSION` plus a successful `/ServerServices/general/accounts?lang=he` JSON-array probe before treating WebView login as complete
- avoid closing the WebView from request cookies until the accounts probe succeeds
- keep diagnostics sanitized: cookie names/status/counts only, no cookie values or account data
- cover empty intercepted `Cookie`, missing success URL, Back/WebView close, anti-bot cookies, stale sessions, and failed accounts access

## Root Cause

After the user completes Bank Hapoalim OTP, the official bank page can be authenticated while the ZenMoney WebView bridge still does not expose a usable `Cookie` header or a stable callback URL to the plugin. The previous flow waited for an authenticated portal URL with request cookies, so the user could browse the bank page while sync stayed blocked.

## Validation

- `yarn jest src/plugins/hapoalim/__tests__/api.login.test.js --runInBand`
- `yarn build hapoalim`
- `yarn test hapoalim`
- `git diff --check`
- Local live-session validation confirmed the cookie-store recovery path without printing cookie values or account data; temporary cookie/profile artifacts were removed.
