### PR TITLE
[vtb-by]: Реализация плагина ВТБ Беларусь

### DIFF
--- a/src/plugins/vtb-by/ZenmoneyManifest.xml
+++ b/src/plugins/vtb-by/ZenmoneyManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>vtb-by</id>
+    <company>0</company>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <codeRequired>false</codeRequired>
+</provider>

--- a/src/plugins/vtb-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/vtb-by/__tests__/api/get-transactions.test.ts
@@ -1,10 +1,12 @@
 import { AccountType } from '../../../../types/zenmoney'
 
 const mockFetchDepositAccountStatement = jest.fn()
+const mockFetchMiniCardStatement = jest.fn()
 
 jest.mock('../../fetchApi', () => ({
   ...jest.requireActual('../../fetchApi'),
-  fetchDepositAccountStatement: mockFetchDepositAccountStatement
+  fetchDepositAccountStatement: mockFetchDepositAccountStatement,
+  fetchMiniCardStatement: mockFetchMiniCardStatement
 }))
 
 describe('getTransactions', () => {
@@ -13,6 +15,7 @@ describe('getTransactions', () => {
 
   afterEach(() => {
     mockFetchDepositAccountStatement.mockReset()
+    mockFetchMiniCardStatement.mockReset()
   })
 
   it('treats missing deposit operations as an empty statement', async () => {
@@ -49,5 +52,68 @@ describe('getTransactions', () => {
         statementCardHash: null
       }
     })).resolves.toEqual([])
+  })
+
+  it('prefers posted mini card operation over matching hold duplicate', async () => {
+    mockFetchMiniCardStatement.mockResolvedValue({
+      errorInfo: {
+        error: '0',
+        errorText: null,
+        errorDescription: null
+      },
+      statement: [
+        {
+          operationDate: new Date('2026-05-10T12:00:00.000Z').getTime(),
+          operationDescription: 'Авторизация',
+          operationAmount: 10,
+          operationCurrency: '933',
+          operationPlace: 'STORE',
+          operationState: 0,
+          transactionAmount: 10,
+          transactionCurrency: '933',
+          transactionAuthCode: '999'
+        },
+        {
+          operationDate: new Date('2026-05-10T12:00:00.000Z').getTime(),
+          operationDescription: 'Покупка',
+          operationAmount: 10,
+          operationCurrency: '933',
+          operationPlace: 'STORE',
+          operationState: 1,
+          transactionAmount: 10,
+          transactionCurrency: '933',
+          transactionAuthCode: '999'
+        }
+      ]
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, {
+      id: 'card-account',
+      type: AccountType.ccard,
+      title: 'Тестовая карта',
+      balance: 1000,
+      instrument: 'BYN',
+      syncIds: ['TEST-CARD-IBAN'],
+      _meta: {
+        productKind: 'card',
+        statementInternalAccountId: 'account-id',
+        statementCardHash: 'card-hash'
+      }
+    })).resolves.toMatchObject([
+      {
+        hold: false,
+        comment: 'Покупка\nSTORE',
+        movements: [
+          {
+            id: 'card-account:auth:999',
+            sum: 10
+          }
+        ]
+      }
+    ])
   })
 })

--- a/src/plugins/vtb-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/vtb-by/__tests__/api/get-transactions.test.ts
@@ -1,0 +1,53 @@
+import { AccountType } from '../../../../types/zenmoney'
+
+const mockFetchDepositAccountStatement = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  fetchDepositAccountStatement: mockFetchDepositAccountStatement
+}))
+
+describe('getTransactions', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { getTransactions } = require('../../api') as typeof import('../../api')
+
+  afterEach(() => {
+    mockFetchDepositAccountStatement.mockReset()
+  })
+
+  it('treats missing deposit operations as an empty statement', async () => {
+    mockFetchDepositAccountStatement.mockResolvedValue({
+      errorInfo: {
+        error: '0',
+        errorText: null,
+        errorDescription: null
+      }
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, {
+      id: 'deposit-account',
+      type: AccountType.deposit,
+      title: 'Тестовый вклад',
+      balance: 1000,
+      instrument: 'RUB',
+      syncIds: ['TEST-DEPOSIT-IBAN'],
+      startDate: new Date('2026-01-01T00:00:00.000Z'),
+      startBalance: 1000,
+      capitalization: true,
+      percent: 12,
+      endDateOffsetInterval: 'month',
+      endDateOffset: 12,
+      payoffInterval: 'month',
+      payoffStep: 1,
+      _meta: {
+        productKind: 'deposit',
+        statementInternalAccountId: '6431251001260',
+        statementCardHash: null
+      }
+    })).resolves.toEqual([])
+  })
+})

--- a/src/plugins/vtb-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/vtb-by/__tests__/api/get-transactions.test.ts
@@ -109,11 +109,63 @@ describe('getTransactions', () => {
         comment: 'Покупка\nSTORE',
         movements: [
           {
-            id: 'card-account:auth:999',
+            id: 'card-account:auth:1778414400000:999',
             sum: 10
           }
         ]
       }
     ])
+  })
+
+  it('keeps repeated mini card auth codes distinct across operation dates', async () => {
+    mockFetchMiniCardStatement.mockResolvedValue({
+      errorInfo: {
+        error: '0',
+        errorText: null,
+        errorDescription: null
+      },
+      statement: [
+        {
+          operationDate: new Date('2026-05-10T12:00:00.000Z').getTime(),
+          operationDescription: 'Покупка',
+          operationAmount: 10,
+          operationCurrency: '933',
+          operationPlace: 'STORE',
+          operationState: 1,
+          transactionAmount: 10,
+          transactionCurrency: '933',
+          transactionAuthCode: '999'
+        },
+        {
+          operationDate: new Date('2026-05-11T12:00:00.000Z').getTime(),
+          operationDescription: 'Покупка',
+          operationAmount: 10,
+          operationCurrency: '933',
+          operationPlace: 'STORE',
+          operationState: 1,
+          transactionAmount: 10,
+          transactionCurrency: '933',
+          transactionAuthCode: '999'
+        }
+      ]
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, {
+      id: 'card-account',
+      type: AccountType.ccard,
+      title: 'Тестовая карта',
+      balance: 1000,
+      instrument: 'BYN',
+      syncIds: ['TEST-CARD-IBAN'],
+      _meta: {
+        productKind: 'card',
+        statementInternalAccountId: 'account-id',
+        statementCardHash: 'card-hash'
+      }
+    })).resolves.toHaveLength(2)
   })
 })

--- a/src/plugins/vtb-by/__tests__/converters/convert-card-account.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-account.test.ts
@@ -1,0 +1,54 @@
+import { AccountType } from '../../../../types/zenmoney'
+import { convertCardAccount } from '../../converters'
+import type { FetchCardAccount } from '../../types/fetch'
+
+describe('convertCardAccount', () => {
+  it('converts a VTB card account', () => {
+    const account: FetchCardAccount = {
+      internalAccountId: 'internal-card-account-1',
+      currency: '933',
+      openDate: 1627506000000,
+      accountNumber: 'TEST-CARD-ACCOUNT-0001',
+      cardAccountNumber: 'card-account-0001',
+      productCode: 'CARD-TEST',
+      productName: 'Тестовая карта BYN',
+      contractId: 'contract-card-1',
+      interestRate: 0.01,
+      accountStatus: 'INACTIVE',
+      ibanNum: 'TEST-IBAN-CARD-0001',
+      cards: [
+        {
+          cardNumberMasked: '555544******1111',
+          cardHash: 'card-hash',
+          cardStatus: 'CLOSED',
+          cardStatusCode: 9,
+          owner: 'TEST USER',
+          tariffName: 'Test BYN',
+          balance: 0,
+          payment: '0',
+          accountId: 'card-account-0001',
+          stateSignature: 'CLOSED',
+          cardProductId: 162,
+          cardId: 857411864,
+          salary: false,
+          virtual: false
+        }
+      ]
+    }
+
+    expect(convertCardAccount(account)).toEqual({
+      id: 'contract-card-1',
+      title: 'Тестовая карта BYN *1111',
+      balance: 0,
+      instrument: 'BYN',
+      syncIds: ['TEST-IBAN-CARD-0001', 'TEST-CARD-ACCOUNT-0001', 'contract-card-1', '1111'],
+      type: AccountType.ccard,
+      archived: true,
+      _meta: {
+        productKind: 'card',
+        statementInternalAccountId: 'internal-card-account-1',
+        statementCardHash: 'card-hash'
+      }
+    })
+  })
+})

--- a/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
@@ -1,6 +1,6 @@
 import { Account, AccountType } from '../../../../types/zenmoney'
-import { convertMiniCardStatementOperation } from '../../converters'
-import type { FetchMiniCardStatementOperation } from '../../types/fetch'
+import { convertFullStatementOperation, convertMiniCardStatementOperation } from '../../converters'
+import type { FetchCardStatementOperation, FetchMiniCardStatementOperation } from '../../types/fetch'
 
 describe('convertMiniCardStatementOperation', () => {
   it('uses transaction amount sign for a VTB mini card statement operation', () => {
@@ -38,6 +38,56 @@ describe('convertMiniCardStatementOperation', () => {
             instrument: 'USD'
           },
           sum: -32
+        }
+      ],
+      merchant: null
+    })
+  })
+
+  it('converts a full statement operation for deposit accounts', () => {
+    const operation: FetchCardStatementOperation = {
+      accountNumber: 'deposit-account-1',
+      operationName: 'Капитализация',
+      transactionDate: 1778389322000,
+      operationDate: 1778389322000,
+      transactionAmount: 13155.4,
+      transactionCurrency: '643',
+      operationAmount: 13155.4,
+      operationCurrency: '643',
+      operationSign: '1',
+      actionGroup: 19,
+      operationClosingBalance: 965877.97,
+      operationCode: 999
+    }
+
+    const account: Account = {
+      id: 'test-deposit-contract-1',
+      type: AccountType.deposit,
+      title: 'Тестовый вклад',
+      balance: 965877.97,
+      instrument: 'RUB',
+      syncIds: ['TEST-IBAN-DEPOSIT-0001'],
+      startDate: new Date(1736283600000),
+      startBalance: 1225.71,
+      capitalization: true,
+      percent: 15.9,
+      endDateOffsetInterval: 'year',
+      endDateOffset: 1,
+      payoffInterval: 'month',
+      payoffStep: 1
+    }
+
+    expect(convertFullStatementOperation(operation, account)).toEqual({
+      hold: null,
+      date: new Date(1778389322000),
+      comment: 'Капитализация',
+      movements: [
+        {
+          id: 'test-deposit-contract-1:1778389322000:999:13155.4:13155.4',
+          account: { id: 'test-deposit-contract-1' },
+          fee: 0,
+          invoice: null,
+          sum: 13155.4
         }
       ],
       merchant: null

--- a/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
@@ -25,12 +25,12 @@ describe('convertMiniCardStatementOperation', () => {
     }
 
     expect(convertMiniCardStatementOperation(operation, account)).toEqual({
-      hold: null,
+      hold: false,
       date: new Date(1777561115000),
       comment: 'Покупка\nSTORE',
       movements: [
         {
-          id: 'test-card-contract-1:1777561115000:999:-10:32:Покупка',
+          id: 'test-card-contract-1:auth:999',
           account: { id: 'test-card-contract-1' },
           fee: 0,
           invoice: {
@@ -42,6 +42,41 @@ describe('convertMiniCardStatementOperation', () => {
       ],
       merchant: null
     })
+  })
+
+  it('keeps mini card movement id stable when a held operation clears', () => {
+    const operation: FetchMiniCardStatementOperation = {
+      operationDate: 1777561115000,
+      operationDescription: 'Авторизация',
+      operationAmount: 32,
+      operationCurrency: '933',
+      operationPlace: 'STORE',
+      operationState: 0,
+      transactionAmount: -10,
+      transactionCurrency: '840',
+      transactionAuthCode: '999'
+    }
+
+    const account: Account = {
+      id: 'test-card-contract-1',
+      type: AccountType.ccard,
+      title: 'Тестовая карта BYN *1111',
+      instrument: 'BYN',
+      syncIds: ['TEST-IBAN-CARD-0001']
+    }
+
+    const holdTransaction = convertMiniCardStatementOperation(operation, account)
+    const postedTransaction = convertMiniCardStatementOperation({
+      ...operation,
+      operationDescription: 'Покупка',
+      operationAmount: 33,
+      transactionAmount: -11,
+      operationState: 1
+    }, account)
+
+    expect(holdTransaction.hold).toBe(true)
+    expect(postedTransaction.hold).toBe(false)
+    expect(postedTransaction.movements[0].id).toBe(holdTransaction.movements[0].id)
   })
 
   it('converts a full statement operation for deposit accounts', () => {
@@ -83,7 +118,7 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Капитализация',
       movements: [
         {
-          id: 'test-deposit-contract-1:1778389322000:999:1:13155.4:13155.4',
+          id: 'test-deposit-contract-1:1778389322000:999:19:1:13155.4:13155.4:965877.97:Капитализация',
           account: { id: 'test-deposit-contract-1' },
           fee: 0,
           invoice: null,
@@ -133,7 +168,7 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Списание',
       movements: [
         {
-          id: 'test-deposit-contract-1:1778389322000:1:-1:-1000:-1000',
+          id: 'test-deposit-contract-1:1778389322000:1:1:-1:-1000:-1000:964877.97:Списание',
           account: { id: 'test-deposit-contract-1' },
           fee: 0,
           invoice: null,

--- a/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
@@ -1,0 +1,46 @@
+import { Account, AccountType } from '../../../../types/zenmoney'
+import { convertMiniCardStatementOperation } from '../../converters'
+import type { FetchMiniCardStatementOperation } from '../../types/fetch'
+
+describe('convertMiniCardStatementOperation', () => {
+  it('uses transaction amount sign for a VTB mini card statement operation', () => {
+    const operation: FetchMiniCardStatementOperation = {
+      operationDate: 1777561115000,
+      operationDescription: 'Покупка',
+      operationAmount: 32,
+      operationCurrency: '933',
+      operationPlace: 'STORE',
+      operationState: 1,
+      transactionAmount: -10,
+      transactionCurrency: '840',
+      transactionAuthCode: '999'
+    }
+
+    const account: Account = {
+      id: 'test-card-contract-1',
+      type: AccountType.ccard,
+      title: 'Тестовая карта BYN *1111',
+      instrument: 'BYN',
+      syncIds: ['TEST-IBAN-CARD-0001']
+    }
+
+    expect(convertMiniCardStatementOperation(operation, account)).toEqual({
+      hold: null,
+      date: new Date(1777561115000),
+      comment: 'Покупка\nSTORE',
+      movements: [
+        {
+          id: 'test-card-contract-1:1777561115000:999:-10:32:Покупка',
+          account: { id: 'test-card-contract-1' },
+          fee: 0,
+          invoice: {
+            sum: -10,
+            instrument: 'USD'
+          },
+          sum: -32
+        }
+      ],
+      merchant: null
+    })
+  })
+})

--- a/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
@@ -83,11 +83,61 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Капитализация',
       movements: [
         {
-          id: 'test-deposit-contract-1:1778389322000:999:13155.4:13155.4',
+          id: 'test-deposit-contract-1:1778389322000:999:1:13155.4:13155.4',
           account: { id: 'test-deposit-contract-1' },
           fee: 0,
           invoice: null,
           sum: 13155.4
+        }
+      ],
+      merchant: null
+    })
+  })
+
+  it('keeps outgoing full statement operations distinct and negative', () => {
+    const operation: FetchCardStatementOperation = {
+      accountNumber: 'deposit-account-1',
+      operationName: 'Списание',
+      transactionDate: 1778389322000,
+      operationDate: 1778389322000,
+      transactionAmount: 1000,
+      transactionCurrency: '643',
+      operationAmount: 1000,
+      operationCurrency: '643',
+      operationSign: '-1',
+      actionGroup: 1,
+      operationClosingBalance: 964877.97,
+      operationCode: 1
+    }
+
+    const account: Account = {
+      id: 'test-deposit-contract-1',
+      type: AccountType.deposit,
+      title: 'Тестовый вклад',
+      balance: 964877.97,
+      instrument: 'RUB',
+      syncIds: ['TEST-IBAN-DEPOSIT-0001'],
+      startDate: new Date(1736283600000),
+      startBalance: 1225.71,
+      capitalization: true,
+      percent: 15.9,
+      endDateOffsetInterval: 'year',
+      endDateOffset: 1,
+      payoffInterval: 'month',
+      payoffStep: 1
+    }
+
+    expect(convertFullStatementOperation(operation, account)).toEqual({
+      hold: null,
+      date: new Date(1778389322000),
+      comment: 'Списание',
+      movements: [
+        {
+          id: 'test-deposit-contract-1:1778389322000:1:-1:-1000:-1000',
+          account: { id: 'test-deposit-contract-1' },
+          fee: 0,
+          invoice: null,
+          sum: -1000
         }
       ],
       merchant: null

--- a/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
@@ -30,7 +30,7 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Покупка\nSTORE',
       movements: [
         {
-          id: 'test-card-contract-1:auth:999',
+          id: 'test-card-contract-1:auth:1777561115000:999',
           account: { id: 'test-card-contract-1' },
           fee: 0,
           invoice: {
@@ -77,6 +77,61 @@ describe('convertMiniCardStatementOperation', () => {
     expect(holdTransaction.hold).toBe(true)
     expect(postedTransaction.hold).toBe(false)
     expect(postedTransaction.movements[0].id).toBe(holdTransaction.movements[0].id)
+  })
+
+  it('keeps repeated mini card auth codes distinct across operation dates', () => {
+    const operation: FetchMiniCardStatementOperation = {
+      operationDate: 1777561115000,
+      operationDescription: 'Покупка',
+      operationAmount: 32,
+      operationCurrency: '933',
+      operationPlace: 'STORE',
+      operationState: 1,
+      transactionAmount: -10,
+      transactionCurrency: '840',
+      transactionAuthCode: '999'
+    }
+
+    const account: Account = {
+      id: 'test-card-contract-1',
+      type: AccountType.ccard,
+      title: 'Тестовая карта BYN *1111',
+      instrument: 'BYN',
+      syncIds: ['TEST-IBAN-CARD-0001']
+    }
+
+    const firstTransaction = convertMiniCardStatementOperation(operation, account)
+    const secondTransaction = convertMiniCardStatementOperation({
+      ...operation,
+      operationDate: 1777647515000
+    }, account)
+
+    expect(secondTransaction.movements[0].id).not.toBe(firstTransaction.movements[0].id)
+  })
+
+  it('includes stable fallback details when mini card auth code is missing', () => {
+    const operation: FetchMiniCardStatementOperation = {
+      operationDate: 1777561115000,
+      operationDescription: 'Покупка',
+      operationAmount: 32,
+      operationCurrency: '933',
+      operationPlace: 'STORE',
+      operationState: 1,
+      transactionAmount: -10,
+      transactionCurrency: '840',
+      mcc: 5411
+    }
+
+    const account: Account = {
+      id: 'test-card-contract-1',
+      type: AccountType.ccard,
+      title: 'Тестовая карта BYN *1111',
+      instrument: 'BYN',
+      syncIds: ['TEST-IBAN-CARD-0001']
+    }
+
+    expect(convertMiniCardStatementOperation(operation, account).movements[0].id)
+      .toBe('test-card-contract-1:details:1777561115000:-10:840:32:933:Покупка:STORE:5411')
   })
 
   it('converts a full statement operation for deposit accounts', () => {

--- a/src/plugins/vtb-by/__tests__/converters/convert-current-account.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-current-account.test.ts
@@ -1,0 +1,36 @@
+import { AccountType } from '../../../../types/zenmoney'
+import { convertCurrentAccount } from '../../converters'
+import type { FetchCurrentAccount } from '../../types/fetch'
+
+describe('convertCurrentAccount', () => {
+  it('converts a VTB current account', () => {
+    const account: FetchCurrentAccount = {
+      internalAccountId: 'internal-current-account-1',
+      currency: '643',
+      openDate: 1736283600000,
+      accountNumber: 'TEST-CURRENT-ACCOUNT-0001',
+      productCode: 'CURRENT-TEST',
+      productName: 'Тестовый текущий счет',
+      balanceAmount: 0,
+      contractId: 'contract-current-1',
+      interestRate: 0.01,
+      accountStatus: 'OPEN',
+      ibanNum: 'TEST-IBAN-CURRENT-0001'
+    }
+
+    expect(convertCurrentAccount(account)).toEqual({
+      id: 'contract-current-1',
+      title: 'Тестовый текущий счет',
+      balance: 0,
+      instrument: 'RUB',
+      syncIds: ['TEST-IBAN-CURRENT-0001', 'TEST-CURRENT-ACCOUNT-0001', 'contract-current-1'],
+      type: AccountType.checking,
+      archived: false,
+      _meta: {
+        productKind: 'current',
+        statementInternalAccountId: null,
+        statementCardHash: null
+      }
+    })
+  })
+})

--- a/src/plugins/vtb-by/__tests__/converters/convert-deposit-account.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-deposit-account.test.ts
@@ -40,7 +40,7 @@ describe('convertDepositAccount', () => {
     expect(converted.archived).toBe(false)
     expect(converted._meta).toEqual({
       productKind: 'deposit',
-      statementInternalAccountId: null,
+      statementInternalAccountId: 'internal-deposit-account-1',
       statementCardHash: null
     })
   })

--- a/src/plugins/vtb-by/__tests__/converters/convert-deposit-account.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-deposit-account.test.ts
@@ -1,0 +1,47 @@
+import { AccountType } from '../../../../types/zenmoney'
+import { convertDepositAccount } from '../../converters'
+import type { FetchDepositAccount } from '../../types/fetch'
+
+describe('convertDepositAccount', () => {
+  it('converts a VTB deposit account', () => {
+    const account: FetchDepositAccount = {
+      internalAccountId: 'internal-deposit-account-1',
+      currency: '643',
+      openDate: 1736283600000,
+      endDate: 1857243600000,
+      accountNumber: 'TEST-DEPOSIT-ACCOUNT-0001',
+      productCode: 'DEPOSIT-TEST',
+      productName: '"Тестовый вклад", RUB с капитализацией',
+      balanceAmount: 1225.71,
+      contractId: 'contract-deposit-1',
+      interestRate: 15.9,
+      accountStatus: 'OPEN',
+      ibanNum: 'TEST-IBAN-DEPOSIT-0001',
+      personalizedName: 'Тестовый вклад'
+    }
+
+    const converted = convertDepositAccount(account)
+
+    expect(converted.id).toBe('contract-deposit-1')
+    expect(converted.type).toBe(AccountType.deposit)
+
+    if (converted.type !== AccountType.deposit) {
+      throw new Error('Expected deposit account')
+    }
+
+    expect(converted.title).toBe('Тестовый вклад')
+    expect(converted.instrument).toBe('RUB')
+    expect(converted.syncIds).toEqual(['TEST-IBAN-DEPOSIT-0001', 'TEST-DEPOSIT-ACCOUNT-0001', 'contract-deposit-1'])
+    expect(converted.balance).toBe(1225.71)
+    expect(converted.percent).toBe(15.9)
+    expect(converted.capitalization).toBe(true)
+    expect(converted.payoffInterval).toBe('month')
+    expect(converted.payoffStep).toBe(1)
+    expect(converted.archived).toBe(false)
+    expect(converted._meta).toEqual({
+      productKind: 'deposit',
+      statementInternalAccountId: null,
+      statementCardHash: null
+    })
+  })
+})

--- a/src/plugins/vtb-by/__tests__/converters/should-sync-card-account.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/should-sync-card-account.test.ts
@@ -1,0 +1,55 @@
+import { shouldSyncCardAccount } from '../../converters'
+import type { FetchCardAccount } from '../../types/fetch'
+
+const makeAccount = (overrides: Partial<FetchCardAccount> = {}): FetchCardAccount => ({
+  internalAccountId: 'internal-card-account-1',
+  currency: '933',
+  openDate: 1627506000000,
+  accountNumber: 'TEST-CARD-ACCOUNT-0001',
+  cardAccountNumber: 'card-account-0001',
+  productCode: 'CARD-TEST',
+  productName: 'Тестовая карта BYN',
+  contractId: 'contract-card-1',
+  interestRate: 0.01,
+  accountStatus: 'OPEN',
+  ibanNum: 'TEST-IBAN-CARD-0001',
+  cards: [
+    {
+      cardNumberMasked: '555544******1111',
+      cardHash: 'card-hash',
+      cardStatus: 'OPEN',
+      cardStatusCode: 1,
+      owner: 'TEST USER',
+      tariffName: 'Test BYN',
+      balance: 0,
+      payment: '0',
+      accountId: 'card-account-0001',
+      stateSignature: 'OPEN',
+      cardProductId: 162,
+      cardId: 857411864,
+      salary: false,
+      virtual: false
+    }
+  ],
+  ...overrides
+})
+
+describe('shouldSyncCardAccount', () => {
+  it('returns false for closed card accounts', () => {
+    expect(shouldSyncCardAccount(makeAccount({
+      accountStatus: 'INACTIVE',
+      cards: [
+        {
+          ...makeAccount().cards[0],
+          cardStatus: 'CLOSED',
+          cardStatusCode: 9,
+          stateSignature: 'CLOSED'
+        }
+      ]
+    }))).toBe(false)
+  })
+
+  it('returns true for open card accounts with active cards', () => {
+    expect(shouldSyncCardAccount(makeAccount())).toBe(true)
+  })
+})

--- a/src/plugins/vtb-by/api.ts
+++ b/src/plugins/vtb-by/api.ts
@@ -9,14 +9,26 @@ import type { FetchMiniCardStatementOperation } from './types/fetch'
 const INVALID_LOGIN_ERROR_CODES = new Set(['10008', '10812'])
 
 const deduplicateTransactions = (transactions: Transaction[]): Transaction[] => {
-  const seenIds = new Set<string>()
+  const transactionIndexesById = new Map<string, number>()
+  const uniqueTransactions: Transaction[] = []
 
-  return transactions.filter((transaction) => {
+  for (const transaction of transactions) {
     const movementId = transaction.movements[0]?.id
-    if (movementId == null || seenIds.has(movementId)) return false
-    seenIds.add(movementId)
-    return true
-  })
+    if (movementId == null) continue
+
+    const existingIndex = transactionIndexesById.get(movementId)
+    if (existingIndex == null) {
+      transactionIndexesById.set(movementId, uniqueTransactions.length)
+      uniqueTransactions.push(transaction)
+      continue
+    }
+
+    if (uniqueTransactions[existingIndex].hold && !transaction.hold) {
+      uniqueTransactions[existingIndex] = transaction
+    }
+  }
+
+  return uniqueTransactions
 }
 
 const assertSuccessfulResponse = (response: ResponseWithErrorInfo, context: string): void => {

--- a/src/plugins/vtb-by/api.ts
+++ b/src/plugins/vtb-by/api.ts
@@ -1,7 +1,7 @@
 import { BankMessageError, InvalidLoginOrPasswordError } from '../../errors'
 import type { Account, Transaction } from '../../types/zenmoney'
-import { convertCardAccount, convertCurrentAccount, convertDepositAccount, convertMiniCardStatementOperation, shouldSyncCardAccount } from './converters'
-import { fetchAccountsOverview, fetchLogin, fetchMiniCardStatement } from './fetchApi'
+import { convertCardAccount, convertCurrentAccount, convertDepositAccount, convertFullStatementOperation, convertMiniCardStatementOperation, shouldSyncCardAccount } from './converters'
+import { fetchAccountsOverview, fetchDepositAccountStatement, fetchLogin, fetchMiniCardStatement } from './fetchApi'
 import { getMiniStatementIntervals, isDateInRange } from './helpers'
 import type { FetchAccountMeta, ResponseWithErrorInfo } from './types/base'
 import type { FetchMiniCardStatementOperation } from './types/fetch'
@@ -50,38 +50,58 @@ export const getTransactions = async (
   { sessionToken, fromDate, toDate }: { sessionToken: string, fromDate: Date, toDate: Date | undefined },
   account: Account & FetchAccountMeta
 ): Promise<Transaction[]> => {
-  if (account._meta.productKind !== 'card' || account._meta.statementCardHash == null) {
-    return []
+  if (account._meta.productKind === 'card' && account._meta.statementCardHash != null) {
+    const operations: FetchMiniCardStatementOperation[] = []
+
+    for (const interval of getMiniStatementIntervals(fromDate, toDate)) {
+      const response = await fetchMiniCardStatement({
+        sessionToken,
+        cardHash: account._meta.statementCardHash,
+        from: interval.from,
+        till: interval.till
+      })
+
+      assertSuccessfulResponse(response, 'GET_TRANSACTIONS')
+      operations.push(...(response.statement ?? []))
+    }
+
+    const seenIds = new Set<string>()
+
+    return operations
+      .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
+      .filter((operation) => isDateInRange(
+        new Date(operation.operationDate),
+        fromDate,
+        toDate
+      ))
+      .map((operation) => convertMiniCardStatementOperation(operation, account))
+      .filter((transaction) => {
+        const movementId = transaction.movements[0]?.id
+        if (movementId == null || seenIds.has(movementId)) return false
+        seenIds.add(movementId)
+        return true
+      })
   }
 
-  const operations: FetchMiniCardStatementOperation[] = []
-
-  for (const interval of getMiniStatementIntervals(fromDate, toDate)) {
-    const response = await fetchMiniCardStatement({
+  if (account._meta.productKind === 'deposit' && account._meta.statementInternalAccountId != null) {
+    const response = await fetchDepositAccountStatement({
       sessionToken,
-      cardHash: account._meta.statementCardHash,
-      from: interval.from,
-      till: interval.till
+      internalAccountId: account._meta.statementInternalAccountId,
+      from: fromDate.getTime(),
+      till: (toDate ?? new Date()).getTime()
     })
 
     assertSuccessfulResponse(response, 'GET_TRANSACTIONS')
-    operations.push(...(response.statement ?? []))
+
+    return response.operations
+      .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
+      .filter((operation) => isDateInRange(
+        new Date(operation.transactionDate > 0 ? operation.transactionDate : operation.operationDate),
+        fromDate,
+        toDate
+      ))
+      .map((operation) => convertFullStatementOperation(operation, account))
   }
 
-  const seenIds = new Set<string>()
-
-  return operations
-    .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
-    .filter((operation) => isDateInRange(
-      new Date(operation.operationDate),
-      fromDate,
-      toDate
-    ))
-    .map((operation) => convertMiniCardStatementOperation(operation, account))
-    .filter((transaction) => {
-      const movementId = transaction.movements[0]?.id
-      if (movementId == null || seenIds.has(movementId)) return false
-      seenIds.add(movementId)
-      return true
-    })
+  return []
 }

--- a/src/plugins/vtb-by/api.ts
+++ b/src/plugins/vtb-by/api.ts
@@ -8,6 +8,17 @@ import type { FetchMiniCardStatementOperation } from './types/fetch'
 
 const INVALID_LOGIN_ERROR_CODES = new Set(['10008', '10812'])
 
+const deduplicateTransactions = (transactions: Transaction[]): Transaction[] => {
+  const seenIds = new Set<string>()
+
+  return transactions.filter((transaction) => {
+    const movementId = transaction.movements[0]?.id
+    if (movementId == null || seenIds.has(movementId)) return false
+    seenIds.add(movementId)
+    return true
+  })
+}
+
 const assertSuccessfulResponse = (response: ResponseWithErrorInfo, context: string): void => {
   if (response.errorInfo.error === '0') return
 
@@ -65,9 +76,7 @@ export const getTransactions = async (
       operations.push(...(response.statement ?? []))
     }
 
-    const seenIds = new Set<string>()
-
-    return operations
+    return deduplicateTransactions(operations
       .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
       .filter((operation) => isDateInRange(
         new Date(operation.operationDate),
@@ -75,12 +84,7 @@ export const getTransactions = async (
         toDate
       ))
       .map((operation) => convertMiniCardStatementOperation(operation, account))
-      .filter((transaction) => {
-        const movementId = transaction.movements[0]?.id
-        if (movementId == null || seenIds.has(movementId)) return false
-        seenIds.add(movementId)
-        return true
-      })
+    )
   }
 
   if (account._meta.productKind === 'deposit' && account._meta.statementInternalAccountId != null) {
@@ -93,7 +97,7 @@ export const getTransactions = async (
 
     assertSuccessfulResponse(response, 'GET_TRANSACTIONS')
 
-    return response.operations
+    return deduplicateTransactions(response.operations
       .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
       .filter((operation) => isDateInRange(
         new Date(operation.transactionDate > 0 ? operation.transactionDate : operation.operationDate),
@@ -101,6 +105,7 @@ export const getTransactions = async (
         toDate
       ))
       .map((operation) => convertFullStatementOperation(operation, account))
+    )
   }
 
   return []

--- a/src/plugins/vtb-by/api.ts
+++ b/src/plugins/vtb-by/api.ts
@@ -23,7 +23,7 @@ const deduplicateTransactions = (transactions: Transaction[]): Transaction[] => 
       continue
     }
 
-    if (uniqueTransactions[existingIndex].hold && !transaction.hold) {
+    if (uniqueTransactions[existingIndex].hold === true && transaction.hold !== true) {
       uniqueTransactions[existingIndex] = transaction
     }
   }

--- a/src/plugins/vtb-by/api.ts
+++ b/src/plugins/vtb-by/api.ts
@@ -97,7 +97,7 @@ export const getTransactions = async (
 
     assertSuccessfulResponse(response, 'GET_TRANSACTIONS')
 
-    return deduplicateTransactions(response.operations
+    return deduplicateTransactions((response.operations ?? [])
       .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
       .filter((operation) => isDateInRange(
         new Date(operation.transactionDate > 0 ? operation.transactionDate : operation.operationDate),

--- a/src/plugins/vtb-by/api.ts
+++ b/src/plugins/vtb-by/api.ts
@@ -1,0 +1,87 @@
+import { BankMessageError, InvalidLoginOrPasswordError } from '../../errors'
+import type { Account, Transaction } from '../../types/zenmoney'
+import { convertCardAccount, convertCurrentAccount, convertDepositAccount, convertMiniCardStatementOperation, shouldSyncCardAccount } from './converters'
+import { fetchAccountsOverview, fetchLogin, fetchMiniCardStatement } from './fetchApi'
+import { getMiniStatementIntervals, isDateInRange } from './helpers'
+import type { FetchAccountMeta, ResponseWithErrorInfo } from './types/base'
+import type { FetchMiniCardStatementOperation } from './types/fetch'
+
+const INVALID_LOGIN_ERROR_CODES = new Set(['10008', '10812'])
+
+const assertSuccessfulResponse = (response: ResponseWithErrorInfo, context: string): void => {
+  if (response.errorInfo.error === '0') return
+
+  console.error(`[${context}] Error`, response.errorInfo)
+
+  throw new BankMessageError(response.errorInfo.errorDescription ?? response.errorInfo.errorText)
+}
+
+export const authenticate = async (login: string, password: string): Promise<{ sessionToken: string }> => {
+  const response = await fetchLogin({ login, password })
+
+  if (response.errorInfo.error !== '0') {
+    if (INVALID_LOGIN_ERROR_CODES.has(response.errorInfo.error)) {
+      throw new InvalidLoginOrPasswordError()
+    }
+
+    throw new BankMessageError(response.errorInfo.errorDescription ?? response.errorInfo.errorText)
+  }
+
+  return {
+    sessionToken: response.sessionToken
+  }
+}
+
+export const getAccounts = async ({ sessionToken }: { sessionToken: string }): Promise<Array<Account & FetchAccountMeta>> => {
+  const response = await fetchAccountsOverview({ sessionToken })
+
+  assertSuccessfulResponse(response, 'GET_ACCOUNTS')
+
+  return [
+    ...(response.overviewResponse.cardAccount ?? [])
+      .filter((account) => shouldSyncCardAccount(account))
+      .map((account) => convertCardAccount(account)),
+    ...(response.overviewResponse.currentAccount ?? []).map((account) => convertCurrentAccount(account)),
+    ...(response.overviewResponse.depositAccount ?? []).map((account) => convertDepositAccount(account))
+  ]
+}
+
+export const getTransactions = async (
+  { sessionToken, fromDate, toDate }: { sessionToken: string, fromDate: Date, toDate: Date | undefined },
+  account: Account & FetchAccountMeta
+): Promise<Transaction[]> => {
+  if (account._meta.productKind !== 'card' || account._meta.statementCardHash == null) {
+    return []
+  }
+
+  const operations: FetchMiniCardStatementOperation[] = []
+
+  for (const interval of getMiniStatementIntervals(fromDate, toDate)) {
+    const response = await fetchMiniCardStatement({
+      sessionToken,
+      cardHash: account._meta.statementCardHash,
+      from: interval.from,
+      till: interval.till
+    })
+
+    assertSuccessfulResponse(response, 'GET_TRANSACTIONS')
+    operations.push(...(response.statement ?? []))
+  }
+
+  const seenIds = new Set<string>()
+
+  return operations
+    .filter((operation) => operation.operationAmount !== 0 || operation.transactionAmount !== 0)
+    .filter((operation) => isDateInRange(
+      new Date(operation.operationDate),
+      fromDate,
+      toDate
+    ))
+    .map((operation) => convertMiniCardStatementOperation(operation, account))
+    .filter((transaction) => {
+      const movementId = transaction.movements[0]?.id
+      if (movementId == null || seenIds.has(movementId)) return false
+      seenIds.add(movementId)
+      return true
+    })
+}

--- a/src/plugins/vtb-by/converters.ts
+++ b/src/plugins/vtb-by/converters.ts
@@ -155,6 +155,25 @@ const getFullStatementSign = (fetchTransaction: FetchCardStatementOperation): nu
   throw new Error(`Unknown operation sign for full statement operation "${fetchTransaction.operationName}"`)
 }
 
+const getMiniCardOperationId = (fetchTransaction: FetchMiniCardStatementOperation, account: Account): string => {
+  if (isNonEmptyString(fetchTransaction.transactionAuthCode)) {
+    return [
+      account.id,
+      'auth',
+      fetchTransaction.transactionAuthCode
+    ].join(':')
+  }
+
+  return [
+    account.id,
+    'details',
+    fetchTransaction.operationDate,
+    fetchTransaction.transactionAmount,
+    fetchTransaction.operationAmount,
+    fetchTransaction.operationDescription
+  ].join(':')
+}
+
 export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCardStatementOperation, account: Account): Transaction => {
   const operationCurrency = ensureCurrency(fetchTransaction.operationCurrency) ?? account.instrument
   const transactionCurrency = ensureCurrency(fetchTransaction.transactionCurrency) ?? operationCurrency
@@ -164,21 +183,14 @@ export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCar
   const hasInvoice = transactionCurrency !== account.instrument
 
   return {
-    hold: null,
+    hold: fetchTransaction.operationState !== 1,
     date: new Date(fetchTransaction.operationDate),
     comment: [fetchTransaction.operationDescription, fetchTransaction.operationPlace]
       .filter(isNonEmptyString)
       .join('\n'),
     movements: [
       {
-        id: [
-          account.id,
-          fetchTransaction.operationDate,
-          fetchTransaction.transactionAuthCode ?? '',
-          fetchTransaction.transactionAmount,
-          fetchTransaction.operationAmount,
-          fetchTransaction.operationDescription
-        ].join(':'),
+        id: getMiniCardOperationId(fetchTransaction, account),
         account: { id: account.id },
         fee: 0,
         invoice: hasInvoice
@@ -214,9 +226,12 @@ export const convertFullStatementOperation = (fetchTransaction: FetchCardStateme
           account.id,
           fetchTransaction.operationDate,
           fetchTransaction.operationCode,
+          fetchTransaction.actionGroup,
           operationSign,
           transactionAmount,
-          operationAmount
+          operationAmount,
+          fetchTransaction.operationClosingBalance,
+          fetchTransaction.operationName
         ].join(':'),
         account: { id: account.id },
         fee: 0,

--- a/src/plugins/vtb-by/converters.ts
+++ b/src/plugins/vtb-by/converters.ts
@@ -1,0 +1,209 @@
+import { getIntervalBetweenDates } from '../../common/momentDateUtils'
+import { Account, AccountType, Transaction } from '../../types/zenmoney'
+import { ensureCurrency, getMaskedCardLastDigits, isNonEmptyString } from './helpers'
+import type { FetchAccountMeta } from './types/base'
+import type { FetchCardAccount, FetchCardStatementOperation, FetchCurrentAccount, FetchDepositAccount, FetchMiniCardStatementOperation } from './types/fetch'
+
+const getActiveCards = (cards: FetchCardAccount['cards']): FetchCardAccount['cards'] =>
+  cards.filter((card) => card.cardStatus !== 'CLOSED')
+
+export const shouldSyncCardAccount = (fetchAccount: FetchCardAccount): boolean =>
+  fetchAccount.accountStatus === 'OPEN' && getActiveCards(fetchAccount.cards).length > 0
+
+const getCardAccountTitle = (fetchAccount: FetchCardAccount): string => {
+  const [card] = getActiveCards(fetchAccount.cards).length > 0
+    ? getActiveCards(fetchAccount.cards)
+    : fetchAccount.cards
+
+  if (card == null) return fetchAccount.productName
+
+  const suffix = getMaskedCardLastDigits(card.cardNumberMasked)
+  return suffix.length > 0
+    ? `${fetchAccount.productName} *${suffix}`
+    : fetchAccount.productName
+}
+
+export const convertCardAccount = (fetchAccount: FetchCardAccount): Account & FetchAccountMeta => {
+  if (fetchAccount.cards.length === 0) throw new Error('No cards linked to card account')
+
+  const currency = ensureCurrency(fetchAccount.currency)
+
+  if (!isNonEmptyString(currency)) throw new Error(`Unknown currency - ${fetchAccount.currency}`)
+
+  const [balanceCard] = getActiveCards(fetchAccount.cards).length > 0
+    ? getActiveCards(fetchAccount.cards)
+    : fetchAccount.cards
+
+  return {
+    id: fetchAccount.contractId,
+    title: getCardAccountTitle(fetchAccount),
+    balance: balanceCard.balance,
+    instrument: currency,
+    syncIds: [
+      fetchAccount.ibanNum,
+      fetchAccount.accountNumber,
+      fetchAccount.contractId,
+      ...fetchAccount.cards
+        .map((card) => getMaskedCardLastDigits(card.cardNumberMasked))
+        .filter(isNonEmptyString)
+    ],
+    type: AccountType.ccard,
+    archived: fetchAccount.accountStatus !== 'OPEN' || getActiveCards(fetchAccount.cards).length === 0,
+    _meta: {
+      productKind: 'card',
+      statementInternalAccountId: fetchAccount.internalAccountId,
+      statementCardHash: balanceCard.cardHash
+    }
+  }
+}
+
+export const convertCurrentAccount = (fetchAccount: FetchCurrentAccount): Account & FetchAccountMeta => {
+  const currency = ensureCurrency(fetchAccount.currency)
+
+  if (!isNonEmptyString(currency)) throw new Error(`Unknown currency - ${fetchAccount.currency}`)
+
+  return {
+    id: fetchAccount.contractId,
+    title: fetchAccount.productName,
+    balance: fetchAccount.balanceAmount,
+    instrument: currency,
+    syncIds: [fetchAccount.ibanNum, fetchAccount.accountNumber, fetchAccount.contractId],
+    type: AccountType.checking,
+    archived: fetchAccount.accountStatus !== 'OPEN',
+    _meta: {
+      productKind: 'current',
+      statementInternalAccountId: null,
+      statementCardHash: null
+    }
+  }
+}
+
+export const convertDepositAccount = (fetchAccount: FetchDepositAccount): Account & FetchAccountMeta => {
+  const currency = ensureCurrency(fetchAccount.currency)
+
+  if (!isNonEmptyString(currency)) throw new Error(`Unknown currency - ${fetchAccount.currency}`)
+
+  const startDate = new Date(fetchAccount.openDate)
+  const endDate = new Date(fetchAccount.endDate)
+  const { count: endDateOffset, interval: endDateOffsetInterval } = getIntervalBetweenDates(startDate, endDate)
+
+  return {
+    id: fetchAccount.contractId,
+    title: fetchAccount.personalizedName ?? fetchAccount.productName,
+    balance: fetchAccount.balanceAmount,
+    instrument: currency,
+    syncIds: [fetchAccount.ibanNum, fetchAccount.accountNumber, fetchAccount.contractId],
+    type: AccountType.deposit,
+    startDate,
+    startBalance: fetchAccount.balanceAmount,
+    capitalization: /капитал/i.test(fetchAccount.productName),
+    percent: fetchAccount.interestRate,
+    endDateOffsetInterval,
+    endDateOffset,
+    payoffInterval: 'month',
+    payoffStep: 1,
+    archived: fetchAccount.accountStatus !== 'OPEN',
+    _meta: {
+      productKind: 'deposit',
+      statementInternalAccountId: null,
+      statementCardHash: null
+    }
+  }
+}
+
+const getSignedAmount = (amount: number, fallbackAmount: number): number => {
+  if (amount !== 0) return amount
+  return fallbackAmount
+}
+
+const getMiniStatementSign = (fetchTransaction: FetchMiniCardStatementOperation): number => {
+  if (fetchTransaction.transactionAmount !== 0) {
+    return Math.sign(fetchTransaction.transactionAmount)
+  }
+
+  if (fetchTransaction.operationAmount !== 0) {
+    return Math.sign(fetchTransaction.operationAmount)
+  }
+
+  return 1
+}
+
+export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCardStatementOperation, account: Account): Transaction => {
+  const operationCurrency = ensureCurrency(fetchTransaction.operationCurrency) ?? account.instrument
+  const transactionCurrency = ensureCurrency(fetchTransaction.transactionCurrency) ?? operationCurrency
+  const sign = getMiniStatementSign(fetchTransaction)
+  const operationAmount = Math.abs(getSignedAmount(fetchTransaction.operationAmount, fetchTransaction.transactionAmount)) * sign
+  const transactionAmount = Math.abs(getSignedAmount(fetchTransaction.transactionAmount, fetchTransaction.operationAmount)) * sign
+  const hasInvoice = transactionCurrency !== account.instrument
+
+  return {
+    hold: null,
+    date: new Date(fetchTransaction.operationDate),
+    comment: [fetchTransaction.operationDescription, fetchTransaction.operationPlace]
+      .filter(isNonEmptyString)
+      .join('\n'),
+    movements: [
+      {
+        id: [
+          account.id,
+          fetchTransaction.operationDate,
+          fetchTransaction.transactionAuthCode ?? '',
+          fetchTransaction.transactionAmount,
+          fetchTransaction.operationAmount,
+          fetchTransaction.operationDescription
+        ].join(':'),
+        account: { id: account.id },
+        fee: 0,
+        invoice: hasInvoice
+          ? {
+              sum: transactionAmount,
+              instrument: transactionCurrency
+            }
+          : null,
+        sum: operationCurrency === account.instrument
+          ? operationAmount
+          : (transactionCurrency === account.instrument ? transactionAmount : null)
+      }
+    ],
+    merchant: null
+  }
+}
+
+export const convertCardStatementOperation = (fetchTransaction: FetchCardStatementOperation, account: Account): Transaction => {
+  const sign = Number(fetchTransaction.operationSign)
+  const operationSign = Number.isFinite(sign) && sign !== 0 ? sign : 1
+  const operationCurrency = ensureCurrency(fetchTransaction.operationCurrency) ?? account.instrument
+  const transactionCurrency = ensureCurrency(fetchTransaction.transactionCurrency) ?? operationCurrency
+  const operationAmount = fetchTransaction.operationAmount * operationSign
+  const transactionAmount = fetchTransaction.transactionAmount * operationSign
+  const hasInvoice = transactionCurrency !== account.instrument
+
+  return {
+    hold: null,
+    date: new Date(fetchTransaction.transactionDate > 0 ? fetchTransaction.transactionDate : fetchTransaction.operationDate),
+    comment: fetchTransaction.operationName,
+    movements: [
+      {
+        id: [
+          account.id,
+          fetchTransaction.operationDate,
+          fetchTransaction.operationCode,
+          fetchTransaction.transactionAmount,
+          fetchTransaction.operationAmount
+        ].join(':'),
+        account: { id: account.id },
+        fee: 0,
+        invoice: hasInvoice
+          ? {
+              sum: transactionAmount,
+              instrument: transactionCurrency
+            }
+          : null,
+        sum: operationCurrency === account.instrument
+          ? operationAmount
+          : (transactionCurrency === account.instrument ? transactionAmount : null)
+      }
+    ],
+    merchant: null
+  }
+}

--- a/src/plugins/vtb-by/converters.ts
+++ b/src/plugins/vtb-by/converters.ts
@@ -105,7 +105,7 @@ export const convertDepositAccount = (fetchAccount: FetchDepositAccount): Accoun
     archived: fetchAccount.accountStatus !== 'OPEN',
     _meta: {
       productKind: 'deposit',
-      statementInternalAccountId: null,
+      statementInternalAccountId: fetchAccount.internalAccountId,
       statementCardHash: null
     }
   }
@@ -169,7 +169,7 @@ export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCar
   }
 }
 
-export const convertCardStatementOperation = (fetchTransaction: FetchCardStatementOperation, account: Account): Transaction => {
+export const convertFullStatementOperation = (fetchTransaction: FetchCardStatementOperation, account: Account): Transaction => {
   const sign = Number(fetchTransaction.operationSign)
   const operationSign = Number.isFinite(sign) && sign !== 0 ? sign : 1
   const operationCurrency = ensureCurrency(fetchTransaction.operationCurrency) ?? account.instrument

--- a/src/plugins/vtb-by/converters.ts
+++ b/src/plugins/vtb-by/converters.ts
@@ -128,6 +128,33 @@ const getMiniStatementSign = (fetchTransaction: FetchMiniCardStatementOperation)
   return 1
 }
 
+const getFullStatementSign = (fetchTransaction: FetchCardStatementOperation): number => {
+  const operationSign = Number(fetchTransaction.operationSign)
+
+  if (Number.isFinite(operationSign) && operationSign !== 0) {
+    return Math.sign(operationSign)
+  }
+
+  const amountSigns = [
+    fetchTransaction.transactionAmount,
+    fetchTransaction.operationAmount
+  ]
+    .filter((amount) => amount !== 0)
+    .map((amount) => Math.sign(amount))
+
+  if (amountSigns.includes(-1)) {
+    console.warn('[VTB-BY] Invalid operationSign, using negative amount fallback for operation:', fetchTransaction.operationName)
+    return -1
+  }
+
+  if (amountSigns.length > 0 && amountSigns.every((sign) => sign === 1)) {
+    console.warn('[VTB-BY] Invalid operationSign, using positive amount fallback for operation:', fetchTransaction.operationName)
+    return 1
+  }
+
+  throw new Error(`Unknown operation sign for full statement operation "${fetchTransaction.operationName}"`)
+}
+
 export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCardStatementOperation, account: Account): Transaction => {
   const operationCurrency = ensureCurrency(fetchTransaction.operationCurrency) ?? account.instrument
   const transactionCurrency = ensureCurrency(fetchTransaction.transactionCurrency) ?? operationCurrency
@@ -170,12 +197,11 @@ export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCar
 }
 
 export const convertFullStatementOperation = (fetchTransaction: FetchCardStatementOperation, account: Account): Transaction => {
-  const sign = Number(fetchTransaction.operationSign)
-  const operationSign = Number.isFinite(sign) && sign !== 0 ? sign : 1
+  const operationSign = getFullStatementSign(fetchTransaction)
   const operationCurrency = ensureCurrency(fetchTransaction.operationCurrency) ?? account.instrument
   const transactionCurrency = ensureCurrency(fetchTransaction.transactionCurrency) ?? operationCurrency
-  const operationAmount = fetchTransaction.operationAmount * operationSign
-  const transactionAmount = fetchTransaction.transactionAmount * operationSign
+  const operationAmount = Math.abs(fetchTransaction.operationAmount) * operationSign
+  const transactionAmount = Math.abs(fetchTransaction.transactionAmount) * operationSign
   const hasInvoice = transactionCurrency !== account.instrument
 
   return {
@@ -188,8 +214,9 @@ export const convertFullStatementOperation = (fetchTransaction: FetchCardStateme
           account.id,
           fetchTransaction.operationDate,
           fetchTransaction.operationCode,
-          fetchTransaction.transactionAmount,
-          fetchTransaction.operationAmount
+          operationSign,
+          transactionAmount,
+          operationAmount
         ].join(':'),
         account: { id: account.id },
         fee: 0,

--- a/src/plugins/vtb-by/converters.ts
+++ b/src/plugins/vtb-by/converters.ts
@@ -160,6 +160,7 @@ const getMiniCardOperationId = (fetchTransaction: FetchMiniCardStatementOperatio
     return [
       account.id,
       'auth',
+      fetchTransaction.operationDate,
       fetchTransaction.transactionAuthCode
     ].join(':')
   }
@@ -169,8 +170,12 @@ const getMiniCardOperationId = (fetchTransaction: FetchMiniCardStatementOperatio
     'details',
     fetchTransaction.operationDate,
     fetchTransaction.transactionAmount,
+    fetchTransaction.transactionCurrency,
     fetchTransaction.operationAmount,
-    fetchTransaction.operationDescription
+    fetchTransaction.operationCurrency,
+    fetchTransaction.operationDescription,
+    fetchTransaction.operationPlace ?? '',
+    fetchTransaction.mcc ?? ''
   ].join(':')
 }
 

--- a/src/plugins/vtb-by/fetchApi.ts
+++ b/src/plugins/vtb-by/fetchApi.ts
@@ -1,0 +1,135 @@
+import { fetchJson } from '../../common/network'
+import { RetryError, retry, toNodeCallbackArguments } from '../../common/retry'
+import { TemporaryUnavailableError } from '../../errors'
+import type * as T from './types/fetch'
+import { BASE_API_URL, CLIENT_KIND, LOGIN_DEVICE_INFO } from './models'
+
+const makeUrl = (path: string): string => `${BASE_API_URL}${path}`
+const NETWORK_ERROR_PATTERN = /\[NER]|\[NTI]|ECONNRESET|ETIMEDOUT|socket hang up/i
+const MAX_FETCH_ATTEMPTS = 3
+const FETCH_RETRY_DELAY_MS = 1500
+type FetchJsonResult = Awaited<ReturnType<typeof fetchJson>>
+type FetchAttemptResult = [Error | null, FetchJsonResult | null]
+
+const isFetchAttemptResult = (value: unknown): value is FetchAttemptResult => {
+  if (!Array.isArray(value) || value.length !== 2) return false
+
+  const [error, response] = value
+
+  if (!(error == null || error instanceof Error)) return false
+  if (response == null) return true
+  if (typeof response !== 'object') return false
+
+  return 'status' in response && 'body' in response
+}
+
+const fetchApi = async (path: string, body: unknown, sessionToken?: string): Promise<unknown> => {
+  const headers: Record<string, string> = {
+    Accept: 'application/json;charset=utf-8',
+    'Content-Type': 'application/json;charset=UTF-8',
+    clientKind: CLIENT_KIND
+  }
+
+  if (sessionToken != null) {
+    headers.Authorization = sessionToken
+    headers.session_token = sessionToken
+  }
+
+  let result: FetchAttemptResult
+
+  try {
+    const retryResult = await retry({
+      getter: toNodeCallbackArguments(async () => await fetchJson(makeUrl(path), {
+        method: 'POST',
+        headers,
+        body,
+        sanitizeRequestLog: {
+          headers: {
+            Authorization: true,
+            session_token: true
+          },
+          body: {
+            login: true,
+            password: true
+          }
+        },
+        sanitizeResponseLog: {
+          body: {
+            sessionToken: true
+          }
+        }
+      })),
+      predicate: (value) => isFetchAttemptResult(value) && value[0] == null && value[1] != null && value[1].status < 500,
+      maxAttempts: MAX_FETCH_ATTEMPTS,
+      delayMs: FETCH_RETRY_DELAY_MS
+    })
+
+    if (!isFetchAttemptResult(retryResult)) {
+      throw new TemporaryUnavailableError()
+    }
+
+    result = retryResult
+  } catch (error) {
+    if (
+      error instanceof RetryError ||
+      (error instanceof Error && NETWORK_ERROR_PATTERN.test(error.message))
+    ) {
+      throw new TemporaryUnavailableError()
+    }
+
+    throw error
+  }
+
+  const [networkError, response] = result
+
+  if (
+    networkError != null ||
+    response == null
+  ) {
+    throw new TemporaryUnavailableError()
+  }
+
+  const { status, body: responseBody } = response
+
+  if (status !== 200) {
+    throw new TemporaryUnavailableError()
+  }
+
+  return responseBody
+}
+
+export const fetchLogin = async ({ login, password }: T.AuthenticateInput): Promise<T.AuthenticateOutput> => {
+  return await fetchApi('/services/v2/session/login', {
+    ...LOGIN_DEVICE_INFO,
+    login,
+    password
+  }) as T.AuthenticateOutput
+}
+
+export const fetchAccountsOverview = async ({ sessionToken }: { sessionToken: string }): Promise<T.FetchAccountsOverviewOutput> => {
+  return await fetchApi('/services/v2/products/getUserAccountsOverview', {
+    concurrently: false,
+    cardAccount: {},
+    depositAccount: {},
+    currentAccount: {},
+    returnStatus: '1',
+    stateFilter: 'ACTIVE_AND_CLOSED',
+    corpoCardAccount: {},
+    additionCardAccount: {},
+    creditAccount: {}
+  }, sessionToken) as T.FetchAccountsOverviewOutput
+}
+
+export const fetchCardAccountFullStatement = async ({ sessionToken, internalAccountId }: T.FetchCardAccountFullStatementInput): Promise<T.FetchCardAccountFullStatementOutput> => {
+  return await fetchApi('/services/v2/products/getCardAccountFullStatement', {
+    internalAccountId
+  }, sessionToken) as T.FetchCardAccountFullStatementOutput
+}
+
+export const fetchMiniCardStatement = async ({ sessionToken, cardHash, from, till }: T.FetchMiniCardStatementInput): Promise<T.FetchMiniCardStatementOutput> => {
+  return await fetchApi('/services/v2/card/getMiniCardStatement', {
+    cardHash,
+    from,
+    till
+  }, sessionToken) as T.FetchMiniCardStatementOutput
+}

--- a/src/plugins/vtb-by/fetchApi.ts
+++ b/src/plugins/vtb-by/fetchApi.ts
@@ -133,3 +133,16 @@ export const fetchMiniCardStatement = async ({ sessionToken, cardHash, from, til
     till
   }, sessionToken) as T.FetchMiniCardStatementOutput
 }
+
+export const fetchDepositAccountStatement = async (
+  { sessionToken, internalAccountId, from, till }: T.FetchDepositAccountStatementInput
+): Promise<T.FetchDepositAccountStatementOutput> => {
+  return await fetchApi('/services/v2/products/getDepositAccountStatement', {
+    accountType: '0',
+    internalAccountId,
+    reportData: {
+      from,
+      till
+    }
+  }, sessionToken) as T.FetchDepositAccountStatementOutput
+}

--- a/src/plugins/vtb-by/helpers.ts
+++ b/src/plugins/vtb-by/helpers.ts
@@ -1,0 +1,57 @@
+import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
+
+export const ensureCurrency = (codeOrName: string): string | undefined =>
+  isNaN(Number(codeOrName))
+    ? codeOrName
+    : codeToCurrencyLookup[codeOrName]
+
+export const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0
+
+export const getMaskedCardLastDigits = (cardNumberMasked: string): string =>
+  cardNumberMasked.replace(/\D/g, '').slice(-4)
+
+export const isDateInRange = (date: Date, fromDate: Date, toDate?: Date): boolean =>
+  date.getTime() >= fromDate.getTime() &&
+  (toDate == null || date.getTime() <= toDate.getTime())
+
+const MAX_MINI_STATEMENT_DAYS = 31
+
+const getStartOfDay = (date: Date): Date => {
+  const normalized = new Date(date)
+  normalized.setHours(0, 0, 0, 0)
+  return normalized
+}
+
+const getEndOfDay = (date: Date): Date => {
+  const normalized = new Date(date)
+  normalized.setHours(23, 59, 59, 999)
+  return normalized
+}
+
+export const getMiniStatementIntervals = (fromDate: Date, toDate?: Date): Array<{ from: number, till: number }> => {
+  const intervals: Array<{ from: number, till: number }> = []
+  const rangeEnd = getEndOfDay(toDate ?? new Date())
+  const earliestAvailableDate = getStartOfDay(new Date())
+  earliestAvailableDate.setDate(earliestAvailableDate.getDate() - MAX_MINI_STATEMENT_DAYS + 1)
+
+  let cursor = getStartOfDay(fromDate)
+
+  if (cursor.getTime() < earliestAvailableDate.getTime()) {
+    cursor = earliestAvailableDate
+  }
+
+  while (cursor.getTime() <= rangeEnd.getTime()) {
+    const intervalEnd = getEndOfDay(cursor)
+    intervalEnd.setDate(intervalEnd.getDate() + MAX_MINI_STATEMENT_DAYS - 1)
+
+    intervals.push({
+      from: cursor.getTime(),
+      till: Math.min(intervalEnd.getTime(), rangeEnd.getTime())
+    })
+
+    cursor = new Date(intervals[intervals.length - 1].till + 1)
+  }
+
+  return intervals
+}

--- a/src/plugins/vtb-by/index.ts
+++ b/src/plugins/vtb-by/index.ts
@@ -1,0 +1,24 @@
+import type { ScrapeFunc, Transaction } from '../../types/zenmoney'
+import { authenticate, getAccounts, getTransactions } from './api'
+import type { PreferenceInput } from './types/base'
+
+export const scrape: ScrapeFunc<PreferenceInput> = async ({ preferences, fromDate, toDate }) => {
+  const { login, password } = preferences
+
+  const { sessionToken } = await authenticate(login, password)
+
+  console.log('[SCRAPE:AUTHENTICATE] Success')
+
+  const accounts = await getAccounts({ sessionToken })
+
+  console.log('[SCRAPE:ACCOUNTS] Successfully fetched', accounts.length, 'account(s)')
+
+  const transactions: Transaction[] = []
+
+  for (const account of accounts) {
+    const accountTransactions = await getTransactions({ sessionToken, fromDate, toDate }, account)
+    transactions.push(...accountTransactions)
+  }
+
+  return { accounts, transactions }
+}

--- a/src/plugins/vtb-by/models.ts
+++ b/src/plugins/vtb-by/models.ts
@@ -1,0 +1,16 @@
+export const BASE_API_URL = 'https://online.vtb.by'
+
+export const CLIENT_KIND = '5'
+
+export const APPLICATION_ID = '3.5.2'
+
+export const LOGIN_DEVICE_INFO = {
+  applicID: APPLICATION_ID,
+  clientKind: CLIENT_KIND,
+  deviceUDID: 'ib',
+  browser: 'Google Chrome',
+  browserVersion: '0',
+  platform: 'Windows',
+  platformVersion: '10',
+  pushId: 'unknown'
+} as const

--- a/src/plugins/vtb-by/preferences.xml
+++ b/src/plugins/vtb-by/preferences.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="login"
+        obligatory="true"
+        title="Логин от VTB Online"
+        dialogTitle="Логин от VTB Online"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||{@s}"
+    />
+    <EditTextPreference
+        key="password"
+        obligatory="true"
+        inputType="textPassword"
+        title="Пароль от VTB Online"
+        dialogTitle="Пароль от VTB Online"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||***********"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2026-01-01T00:00:00.000Z"
+        dialogTitle="С какой даты загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>

--- a/src/plugins/vtb-by/types/base.ts
+++ b/src/plugins/vtb-by/types/base.ts
@@ -1,0 +1,22 @@
+export interface PreferenceInput {
+  login: string
+  password: string
+}
+
+export interface FetchErrorInfo {
+  error: string
+  errorText: string
+  errorDescription?: string
+}
+
+export interface ResponseWithErrorInfo {
+  errorInfo: FetchErrorInfo
+}
+
+export interface FetchAccountMeta {
+  _meta: {
+    productKind: 'card' | 'current' | 'deposit'
+    statementInternalAccountId: string | null
+    statementCardHash: string | null
+  }
+}

--- a/src/plugins/vtb-by/types/fetch.ts
+++ b/src/plugins/vtb-by/types/fetch.ts
@@ -126,6 +126,13 @@ export interface FetchMiniCardStatementInput {
   till: number
 }
 
+export interface FetchDepositAccountStatementInput {
+  sessionToken: string
+  internalAccountId: string
+  from: number
+  till: number
+}
+
 export interface FetchCardAccountFullStatementOutput extends ResponseWithErrorInfo {
   operations: FetchCardStatementOperation[]
   incomingBalance: number
@@ -146,3 +153,5 @@ export interface FetchCardAccountFullStatementOutput extends ResponseWithErrorIn
 export interface FetchMiniCardStatementOutput extends ResponseWithErrorInfo {
   statement: FetchMiniCardStatementOperation[]
 }
+
+export interface FetchDepositAccountStatementOutput extends FetchCardAccountFullStatementOutput {}

--- a/src/plugins/vtb-by/types/fetch.ts
+++ b/src/plugins/vtb-by/types/fetch.ts
@@ -134,7 +134,7 @@ export interface FetchDepositAccountStatementInput {
 }
 
 export interface FetchCardAccountFullStatementOutput extends ResponseWithErrorInfo {
-  operations: FetchCardStatementOperation[]
+  operations?: FetchCardStatementOperation[]
   incomingBalance: number
   closingBalance: number
   debitAmount: number

--- a/src/plugins/vtb-by/types/fetch.ts
+++ b/src/plugins/vtb-by/types/fetch.ts
@@ -1,0 +1,148 @@
+import type { ResponseWithErrorInfo } from './base'
+
+export interface AuthenticateInput {
+  login: string
+  password: string
+}
+
+export interface AuthenticateOutput extends ResponseWithErrorInfo {
+  sessionToken: string
+}
+
+export interface FetchCard {
+  cardNumberMasked: string
+  cardHash: string
+  cardStatus: string
+  cardStatusCode: number
+  owner: string
+  tariffName: string
+  balance: number
+  payment: string
+  accountId: string
+  stateSignature: string
+  cardProductId: number
+  cardId: number
+  salary: boolean
+  virtual: boolean
+  cardType?: {
+    name: string
+    paySystemName?: string
+  }
+}
+
+export interface FetchCardAccount {
+  internalAccountId: string
+  currency: string
+  openDate: number
+  accountNumber: string
+  cardAccountNumber: string
+  productCode: string
+  productName: string
+  contractId: string
+  interestRate: number
+  accountStatus: string
+  cards: FetchCard[]
+  ibanNum: string
+}
+
+export interface FetchCurrentAccount {
+  internalAccountId: string
+  currency: string
+  openDate: number
+  accountNumber: string
+  productCode: string
+  productName: string
+  balanceAmount: number
+  contractId: string
+  interestRate: number
+  accountStatus: string
+  ibanNum: string
+}
+
+export interface FetchDepositAccount {
+  internalAccountId: string
+  currency: string
+  openDate: number
+  endDate: number
+  accountNumber: string
+  productCode: string
+  productName: string
+  balanceAmount: number
+  contractId: string
+  interestRate: number
+  accountStatus: string
+  ibanNum: string
+  personalizedName?: string
+}
+
+export interface FetchAccountsOverviewOutput extends ResponseWithErrorInfo {
+  overviewResponse: {
+    cardAccount?: FetchCardAccount[]
+    currentAccount?: FetchCurrentAccount[]
+    depositAccount?: FetchDepositAccount[]
+  }
+}
+
+export interface FetchCardStatementOperation {
+  accountNumber: string
+  operationName: string
+  transactionDate: number
+  operationDate: number
+  transactionAmount: number
+  transactionCurrency: string
+  operationAmount: number
+  operationCurrency: string
+  operationSign: string
+  actionGroup: number
+  clientName?: string
+  operationClosingBalance: number
+  operationCode: number
+  merchantName?: string
+  mcc?: string
+}
+
+export interface FetchMiniCardStatementOperation {
+  operationDate: number
+  operationDescription: string
+  operationAmount: number
+  operationCurrency: string
+  operationPlace?: string
+  operationState: number
+  transactionAmount: number
+  transactionCurrency: string
+  mcc?: number
+  transactionAuthCode?: string
+}
+
+export interface FetchCardAccountFullStatementInput {
+  sessionToken: string
+  internalAccountId: string
+}
+
+export interface FetchMiniCardStatementInput {
+  sessionToken: string
+  cardHash: string
+  from: number
+  till: number
+}
+
+export interface FetchCardAccountFullStatementOutput extends ResponseWithErrorInfo {
+  operations: FetchCardStatementOperation[]
+  incomingBalance: number
+  closingBalance: number
+  debitAmount: number
+  creditAmount: number
+  accountNumber: string
+  accountName: string
+  accountCurrency: string
+  ibanNumber: string
+  incomeOverLimit: number
+  outcomeOverLimit: number
+  incomeForPeriod: number
+  outcomeForPeriod: number
+  lastActionDate: number
+}
+
+export interface FetchMiniCardStatementOutput extends ResponseWithErrorInfo {
+  statement: FetchMiniCardStatementOperation[]
+}


### PR DESCRIPTION
 Добавлена и доработана интеграция vtb-by.

  Что входит в PR:

   - новый плагин vtb-by: manifest, preferences, scrape entrypoint, API layer, модели и типы ответов VTB Online;
   - авторизация через /services/v2/session/login;
   - загрузка списка продуктов через getUserAccountsOverview;
   - конвертация карточных, текущих и депозитных счетов;
   - загрузка карточных операций через getMiniCardStatement;
   - загрузка депозитных операций через getDepositAccountStatement;
   - retry для временных сетевых ошибок;
   - ограничение mini statement интервалами, которые поддерживает API;
   - фильтрация закрытых карточных счетов без активных карт.

  Отдельно исправлено по транзакциям:

   - пустая депозитная выписка без operations теперь считается пустым списком, а не ошибкой;
   - hold-операции по карте заменяются posted-операциями с тем же movement id;
   - ID mini-card операций с transactionAuthCode усилен до account + operationDate + transactionAuthCode, чтобы одинаковый auth code в разные даты не схлопывал разные операции;
   - fallback-ID для mini-card операций без auth code дополнен стабильными деталями операции;
   - full statement операции получают детальный ID из даты, кодов операции, знака, сумм, баланса и названия.

  Тесты добавлены для:

   - конвертации карточных, текущих и депозитных счетов;
   - фильтрации закрытых карточных счетов;
   - mini-card и full-statement операций;
   - пустой депозитной выписки;
   - hold → posted dedup;
   - повторяющихся auth code в разные даты.