### PR TITLE
 [mtbank]: Исправление работы с session cookies

### DIFF
--- a/src/plugins/mtbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/mtbank/__tests__/converters/transactions/transactions.test.js
@@ -1,4 +1,4 @@
-import { convertTransaction } from '../../../converters'
+import { convertTransaction, filterDuplicates } from '../../../converters'
 
 describe('convertTransaction', () => {
   const accounts = [
@@ -458,5 +458,44 @@ describe('convertTransaction', () => {
     }, accounts)
 
     expect(transaction).toEqual(null)
+  })
+
+  it('prefers posted transaction over matching hold duplicate', () => {
+    const holdTransaction = convertTransaction({
+      accountId: 'BY36MTBK10110008000001111000',
+      amount: '3.13',
+      balance: '',
+      cardPan: '111111******1111',
+      curr: 'BYN',
+      debitFlag: '0',
+      description: 'Оплата товаров и услуг',
+      error: '',
+      operationDate: null,
+      orderStatus: '2',
+      place: 'SHOP "SOSEDI"            / MINSK        / BY',
+      status: 'A',
+      transAmount: '3.13',
+      transDate: '2019-01-28 07:51:13',
+      transactionId: '1111111'
+    }, accounts)
+    const postedTransaction = convertTransaction({
+      accountId: 'BY36MTBK10110008000001111000',
+      amount: '3.13',
+      balance: '',
+      cardPan: '111111******1111',
+      curr: 'BYN',
+      debitFlag: '0',
+      description: 'Оплата товаров и услуг',
+      error: '',
+      operationDate: null,
+      orderStatus: '1',
+      place: 'SHOP "SOSEDI"            / MINSK        / BY',
+      status: 'T',
+      transAmount: '3.13',
+      transDate: '2019-01-28 07:51:13',
+      transactionId: '1111111'
+    }, accounts)
+
+    expect(filterDuplicates([holdTransaction, postedTransaction])).toEqual([postedTransaction])
   })
 })

--- a/src/plugins/mtbank/__tests__/index.test.js
+++ b/src/plugins/mtbank/__tests__/index.test.js
@@ -1,7 +1,12 @@
 import fetchMock from 'fetch-mock'
 import { scrape } from '..'
+import { fetchTransactions } from '../api'
 
 describe('scrape', () => {
+  afterEach(() => {
+    fetchMock.restore()
+  })
+
   it('should hit the mocks and return results', async () => {
     mockIdentity()
     mockCheckPassword()
@@ -84,6 +89,447 @@ describe('scrape', () => {
       },
       comment: 'Возврат денежных средств'
     }])
+  })
+
+  it('should keep cookies fresh for userRole and sequential statements', async () => {
+    const seenCookies = {
+      checkPassword: [],
+      userRole: [],
+      loadUser: [],
+      statements: []
+    }
+
+    fetchMock.once({
+      method: 'POST',
+      matcher: (url) => url === 'https://mybank.by/api/v1/login/userIdentityByPhone',
+      response: {
+        status: 200,
+        body: JSON.stringify({
+          ResponseType: 'ResponseOfUserIdentityByPhoneData',
+          error: null,
+          sessionId: null,
+          success: true,
+          validateErrors: null,
+          data: {
+            smsCode: null,
+            userLinkedAbs: true
+          }
+        }),
+        statusText: 'OK',
+        headers: { 'set-cookie': 'identity-cookie=1' },
+        sendAsJson: false
+      }
+    })
+
+    fetchMock.once({
+      method: 'POST',
+      matcher: (url, { headers }) => {
+        if (url !== 'https://mybank.by/api/v1/login/checkPassword4') return false
+        seenCookies.checkPassword.push(headers.Cookie)
+        return true
+      },
+      response: {
+        status: 200,
+        body: JSON.stringify({
+          ResponseType: 'ResponseOfCheckPasswordResponse',
+          error: null,
+          sessionId: null,
+          success: true,
+          validateErrors: null,
+          data: {
+            fingerToken: null,
+            nextOperation: null,
+            userInfo: {
+              email: 'TEST@GMAIL.COM',
+              firstName: 'Вася',
+              middleName: 'Петрович',
+              isCustomLogin: false,
+              lastName: 'Осюк',
+              login: 'login',
+              phone: '',
+              isResident: true,
+              dboContracts: [{
+                contractNum: 'IB_I/123456',
+                status: 'REGISTERED',
+                role: 'F',
+                isAdmin: null,
+                name: 'Осюк В.П.',
+                longname: 'Осюк Вася Петрович',
+                smsConfirmation: false
+              }]
+            }
+          }
+        }),
+        statusText: 'OK',
+        headers: { 'set-cookie': 'password-cookie=1' },
+        sendAsJson: false
+      }
+    })
+
+    fetchMock.once({
+      method: 'POST',
+      matcher: (url, { headers }) => {
+        if (url !== 'https://mybank.by/api/v1/user/userRole') return false
+        seenCookies.userRole.push(headers.Cookie)
+        return true
+      },
+      response: {
+        status: 200,
+        body: JSON.stringify({
+          ResponseType: 'ResponseOfstring',
+          error: null,
+          sessionId: null,
+          success: true,
+          validateErrors: null,
+          data: null
+        }),
+        statusText: 'OK',
+        headers: { 'set-cookie': 'role-cookie=1' },
+        sendAsJson: false
+      }
+    })
+
+    fetchMock.once({
+      method: 'GET',
+      matcher: (url, { headers }) => {
+        if (url !== 'https://mybank.by/api/v1/user/loadUser') return false
+        seenCookies.loadUser.push(headers.Cookie)
+        return true
+      },
+      response: {
+        status: 200,
+        body: JSON.stringify({
+          ResponseType: 'ResponseOfUserResponse',
+          error: null,
+          sessionId: '1111111111111',
+          success: true,
+          validateErrors: null,
+          data: {
+            addInfo: [],
+            products: [{
+              productType: 'PC',
+              accountId: '1111111',
+              id: 1,
+              productCode: '1111111|PC',
+              show: true,
+              variationId: '[MASTERCARD][MCW INSTANT BYR 3Y (PAYOKAY)]',
+              accruedInterest: null,
+              avlBalance: '999.9',
+              avlLimit: null,
+              cardAccounts: [{
+                accType: null,
+                accountId: 'BY36MTBK10110001000001111000',
+                accountIdenType: 'PC',
+                availableBalance: null,
+                contractCode: '1111111',
+                currencyCode: 'BYN',
+                productType: 'PC'
+              }],
+              cardContract: [{
+                productType: 'MTBANK_CARD',
+                closeDate: '2020-01-31',
+                contractNum: '11111111',
+                openDate: '2018-01-31',
+                cardTerm: '11/11',
+                rateBal: '0.0001',
+                servicePaySum: null,
+                servicePayTerm: null,
+                smsNotification: '1',
+                tariffPlan: 'PayOkay'
+              }],
+              cards: [{
+                blockReason: null,
+                cardCurr: 'BYN',
+                commisDate: '2011-01-31',
+                commisSum: '1.1',
+                description: 'MASTERCARD',
+                embossedName: 'ANDREI IOKSHA',
+                isOfAccntHolder: '1',
+                limits: [],
+                mainCard: '1',
+                over: '0',
+                pan: '111111_1111',
+                smsNotification: '1',
+                status: 'A',
+                term: '11/11',
+                type: 'MASTERCARD',
+                vpan: '1111111111111111',
+                rbs: '1111111',
+                pinPhoneNumber: '111111111111'
+              }],
+              debtPayment: null,
+              debtPaymentSumCom: null,
+              description: 'PayOkay',
+              gracePeriodAvalDays: null,
+              gracePeriodEnd: null,
+              gracePeriodLength: null,
+              gracePeriodOutRateCashless: null,
+              gracePeriodRateCashless: null,
+              gracePeriodStart: null,
+              isActive: true,
+              isOverdraft: false,
+              loanContractDate: null,
+              loanContractNumber: null,
+              loanNextPaymentAmmount: null,
+              loanNextPaymentDate: null,
+              minPaymentFee: null,
+              minPaymentMainDept: null,
+              minPaymentOverFee: null,
+              minPaymentOverMainDept: null,
+              minPaymentOverPer: null,
+              minPaymentPenalty: null,
+              minPaymentPer: null,
+              minPaymentStandardOper: null,
+              minPaymentStandardOperPer: null,
+              minPaymentStateDue: null,
+              minPaymentUBS: null,
+              over: null,
+              overStandardOperationRate: null,
+              overdueDebts: null,
+              ownFunds: null,
+              points: '',
+              pointsDate: null,
+              productIdenType: null,
+              rate: '0.0001',
+              rateAvalInstalment: null,
+              rateAvalInstalmentHistory: [],
+              rateCache: null,
+              rateCacheHistory: [],
+              rateCacheless: null,
+              rateCachelessHistory: [],
+              rateChangingHistory: [],
+              rateExpirPayment: null,
+              rateExpirPaymentHistory: [],
+              standardOperationRate: null
+            }],
+            userEripId: null,
+            userInfo: {
+              crmId: '1111111111',
+              email: '',
+              firstName: 'Иван',
+              isCustomLogin: false,
+              lastName: 'Иванов',
+              login: '1111111111111111111111111111111111',
+              phone: '111111111111',
+              isResident: true
+            }
+          }
+        }),
+        statusText: 'OK',
+        headers: { 'set-cookie': 'load-user-cookie=1' },
+        sendAsJson: false
+      }
+    })
+
+    fetchMock.once({
+      method: 'POST',
+      matcher: (url, { headers }) => {
+        if (url !== 'https://mybank.by/api/v1/product/loadOperationStatements') return false
+        seenCookies.statements.push(headers.Cookie)
+        return true
+      },
+      response: {
+        status: 200,
+        body: JSON.stringify({
+          ResponseType: 'ResponseOfListOfTransactionStatement',
+          error: null,
+          sessionId: null,
+          success: true,
+          validateErrors: null,
+          data: [{
+            accountCurr: 'BYN',
+            accountId: 'BY36MTBK10110001000001111000',
+            avlBalance: '791.3',
+            client: 'Иванов Иван Иванович',
+            dateFrom: '2018-12-27',
+            dateTo: '2019-01-16',
+            incomingBalance: '999.9',
+            numDateContract: '11111111 от 1111.11.11',
+            operations: [{
+              amount: '29.68',
+              balance: '531.57',
+              cardPan: '111111******1111',
+              curr: 'BYN',
+              debitFlag: '0',
+              description: 'Оплата товаров и услуг',
+              error: '',
+              operationDate: '2019-01-02',
+              orderStatus: '1',
+              place: 'Магазин',
+              status: 'T',
+              transAmount: '29.68',
+              transDate: '2018-12-29 01:07:39',
+              transactionId: '1111112'
+            }],
+            outgoingBalance: '999.9',
+            receivedAmount: '999.9',
+            time: '2019-01-16 17:30:49',
+            writtenOffAmount: '999.9'
+          }]
+        }),
+        statusText: 'OK',
+        headers: { 'set-cookie': 'statement-cookie-1=1' },
+        sendAsJson: false
+      }
+    })
+
+    fetchMock.once({
+      method: 'POST',
+      matcher: (url, { headers }) => {
+        if (url !== 'https://mybank.by/api/v1/product/loadOperationStatements') return false
+        seenCookies.statements.push(headers.Cookie)
+        return true
+      },
+      response: {
+        status: 200,
+        body: JSON.stringify({
+          ResponseType: 'ResponseOfListOfTransactionStatement',
+          error: null,
+          sessionId: null,
+          success: true,
+          validateErrors: null,
+          data: [{
+            accountCurr: 'BYN',
+            accountId: 'BY36MTBK10110001000001111000',
+            avlBalance: '791.3',
+            client: 'Иванов Иван Иванович',
+            dateFrom: '2019-01-16',
+            dateTo: '2019-01-18',
+            incomingBalance: '999.9',
+            numDateContract: '11111111 от 1111.11.11',
+            operations: [],
+            outgoingBalance: '999.9',
+            receivedAmount: '999.9',
+            time: '2019-01-18 17:30:49',
+            writtenOffAmount: '999.9'
+          }]
+        }),
+        statusText: 'OK',
+        headers: { 'set-cookie': 'statement-cookie-2=1' },
+        sendAsJson: false
+      }
+    })
+
+    const result = await scrape({
+      preferences: { phone: '123456789', password: 'pass' },
+      fromDate: new Date('2018-12-27T00:00:00.000+03:00'),
+      toDate: new Date('2019-01-18T00:00:00.000+03:00')
+    })
+
+    expect(result.accounts).toHaveLength(1)
+    expect(result.transactions).toHaveLength(1)
+    expect(seenCookies.checkPassword).toEqual(['identity-cookie=1'])
+    expect(seenCookies.userRole).toEqual(['identity-cookie=1; password-cookie=1'])
+    expect(seenCookies.loadUser).toEqual(['identity-cookie=1; password-cookie=1; role-cookie=1'])
+    expect(seenCookies.statements).toEqual([
+      'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1',
+      'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1; statement-cookie-1=1'
+    ])
+  })
+
+  it('should retry timed out statement requests', async () => {
+    let statementAttempts = 0
+
+    fetchMock.mock({
+      method: 'POST',
+      matcher: (url) => url === 'https://mybank.by/api/v1/product/loadOperationStatements',
+      response: () => {
+        statementAttempts++
+        if (statementAttempts === 1) {
+          throw new Error('[NTI] Request timed out')
+        }
+
+        return {
+          status: 200,
+          body: JSON.stringify({
+            ResponseType: 'ResponseOfListOfTransactionStatement',
+            error: null,
+            sessionId: null,
+            success: true,
+            validateErrors: null,
+            data: [{
+              accountCurr: 'BYN',
+              accountId: 'BY36MTBK10110001000001111000',
+              avlBalance: '791.3',
+              client: 'Иванов Иван Иванович',
+              dateFrom: '2018-12-27',
+              dateTo: '2019-01-16',
+              incomingBalance: '999.9',
+              numDateContract: '11111111 от 1111.11.11',
+              operations: [{
+                amount: '29.68',
+                balance: '531.57',
+                cardPan: '111111******1111',
+                curr: 'BYN',
+                debitFlag: '0',
+                description: 'Оплата товаров и услуг',
+                error: '',
+                operationDate: '2019-01-02',
+                orderStatus: '1',
+                place: 'Магазин',
+                status: 'T',
+                transAmount: '29.68',
+                transDate: '2018-12-29 01:07:39',
+                transactionId: '1111112'
+              }],
+              outgoingBalance: '999.9',
+              receivedAmount: '999.9',
+              time: '2019-01-16 17:30:49',
+              writtenOffAmount: '999.9'
+            }]
+          }),
+          statusText: 'OK',
+          headers: { 'set-cookie': 'statement-cookie=1' },
+          sendAsJson: false
+        }
+      }
+    })
+
+    const operations = await fetchTransactions(
+      new Map([['identity-cookie', '1']]),
+      [{ id: '1111111', productType: 'PC' }],
+      new Date('2018-12-27T00:00:00.000+03:00'),
+      new Date('2019-01-02T00:00:00.000+03:00')
+    )
+
+    expect(operations).toHaveLength(1)
+    expect(statementAttempts).toBe(2)
+  })
+
+  it('should fail with a contextual error on malformed statement responses', async () => {
+    fetchMock.once('https://mybank.by/api/v1/product/loadOperationStatements', {
+      status: 200,
+      body: JSON.stringify({
+        ResponseType: 'ResponseOfListOfTransactionStatement',
+        error: null,
+        sessionId: null,
+        success: true,
+        validateErrors: null,
+        data: [{
+          accountCurr: 'BYN',
+          accountId: 'BY36MTBK10110001000001111000',
+          operations: null
+        }]
+      }),
+      statusText: 'OK',
+      sendAsJson: false
+    })
+
+    let error
+
+    try {
+      await fetchTransactions(
+        new Map([['identity-cookie', '1']]),
+        [{ id: '1111111', productType: 'PC' }],
+        new Date('2018-12-27T00:00:00.000+03:00'),
+        new Date('2019-01-02T00:00:00.000+03:00')
+      )
+    } catch (caughtError) {
+      error = caughtError
+    }
+
+    expect(error).toBeDefined()
+    expect(error.message).toContain('Не удалось загрузить операции (счет 1111111, период')
   })
 })
 

--- a/src/plugins/mtbank/__tests__/index.test.js
+++ b/src/plugins/mtbank/__tests__/index.test.js
@@ -422,7 +422,7 @@ describe('scrape', () => {
     expect(seenCookies.loadUser).toEqual(['identity-cookie=1; password-cookie=1; role-cookie=1'])
     expect(seenCookies.statements).toEqual([
       'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1',
-      'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1'
+      'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1; statement-cookie-1=1'
     ])
   })
 })

--- a/src/plugins/mtbank/__tests__/index.test.js
+++ b/src/plugins/mtbank/__tests__/index.test.js
@@ -531,6 +531,102 @@ describe('scrape', () => {
     expect(error).toBeDefined()
     expect(error.message).toContain('Не удалось загрузить операции (счет 1111111, период')
   })
+
+  it('should load account statements with controlled parallelism', async () => {
+    let activeRequests = 0
+    let maxActiveRequests = 0
+
+    fetchMock.mock({
+      method: 'POST',
+      matcher: (url) => url === 'https://mybank.by/api/v1/product/loadOperationStatements',
+      response: async (url, options) => {
+        const requestBody = JSON.parse(options.body)
+        activeRequests++
+        maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
+        await new Promise(resolve => setTimeout(resolve, 20))
+        activeRequests--
+
+        return {
+          status: 200,
+          body: JSON.stringify({
+            ResponseType: 'ResponseOfListOfTransactionStatement',
+            error: null,
+            sessionId: null,
+            success: true,
+            validateErrors: null,
+            data: [{
+              accountCurr: 'BYN',
+              accountId: requestBody.contractCode,
+              operations: []
+            }]
+          }),
+          statusText: 'OK',
+          sendAsJson: false
+        }
+      }
+    })
+
+    const operations = await fetchTransactions(
+      new Map([['identity-cookie', '1']]),
+      [
+        { id: '1111111', productType: 'PC' },
+        { id: '2222222', productType: 'PC' }
+      ],
+      new Date('2018-12-27T00:00:00.000+03:00'),
+      new Date('2019-01-02T00:00:00.000+03:00')
+    )
+
+    expect(operations).toHaveLength(0)
+    expect(maxActiveRequests).toBeGreaterThan(1)
+  })
+
+  it('should fall back to sequential loading when parallel statement loading fails', async () => {
+    let requestCount = 0
+
+    fetchMock.mock({
+      method: 'POST',
+      matcher: (url) => url === 'https://mybank.by/api/v1/product/loadOperationStatements',
+      response: (url, options) => {
+        requestCount++
+        const requestBody = JSON.parse(options.body)
+
+        if (requestCount === 1) {
+          throw new Error('parallel worker failed')
+        }
+
+        return {
+          status: 200,
+          body: JSON.stringify({
+            ResponseType: 'ResponseOfListOfTransactionStatement',
+            error: null,
+            sessionId: null,
+            success: true,
+            validateErrors: null,
+            data: [{
+              accountCurr: 'BYN',
+              accountId: requestBody.contractCode,
+              operations: []
+            }]
+          }),
+          statusText: 'OK',
+          sendAsJson: false
+        }
+      }
+    })
+
+    const operations = await fetchTransactions(
+      new Map([['identity-cookie', '1']]),
+      [
+        { id: '1111111', productType: 'PC' },
+        { id: '2222222', productType: 'PC' }
+      ],
+      new Date('2018-12-27T00:00:00.000+03:00'),
+      new Date('2019-01-02T00:00:00.000+03:00')
+    )
+
+    expect(operations).toHaveLength(0)
+    expect(requestCount).toBe(4)
+  })
 })
 
 function mockLoadOperationStatements () {

--- a/src/plugins/mtbank/__tests__/index.test.js
+++ b/src/plugins/mtbank/__tests__/index.test.js
@@ -1,6 +1,5 @@
 import fetchMock from 'fetch-mock'
 import { scrape } from '..'
-import { fetchTransactions } from '../api'
 
 describe('scrape', () => {
   afterEach(() => {
@@ -91,7 +90,7 @@ describe('scrape', () => {
     }])
   })
 
-  it('should keep cookies fresh for userRole and sequential statements', async () => {
+  it('should keep cookies fresh for userRole before parallel statements', async () => {
     const seenCookies = {
       checkPassword: [],
       userRole: [],
@@ -423,209 +422,8 @@ describe('scrape', () => {
     expect(seenCookies.loadUser).toEqual(['identity-cookie=1; password-cookie=1; role-cookie=1'])
     expect(seenCookies.statements).toEqual([
       'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1',
-      'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1; statement-cookie-1=1'
+      'identity-cookie=1; password-cookie=1; role-cookie=1; load-user-cookie=1'
     ])
-  })
-
-  it('should retry timed out statement requests', async () => {
-    let statementAttempts = 0
-
-    fetchMock.mock({
-      method: 'POST',
-      matcher: (url) => url === 'https://mybank.by/api/v1/product/loadOperationStatements',
-      response: () => {
-        statementAttempts++
-        if (statementAttempts === 1) {
-          throw new Error('[NTI] Request timed out')
-        }
-
-        return {
-          status: 200,
-          body: JSON.stringify({
-            ResponseType: 'ResponseOfListOfTransactionStatement',
-            error: null,
-            sessionId: null,
-            success: true,
-            validateErrors: null,
-            data: [{
-              accountCurr: 'BYN',
-              accountId: 'BY36MTBK10110001000001111000',
-              avlBalance: '791.3',
-              client: 'Иванов Иван Иванович',
-              dateFrom: '2018-12-27',
-              dateTo: '2019-01-16',
-              incomingBalance: '999.9',
-              numDateContract: '11111111 от 1111.11.11',
-              operations: [{
-                amount: '29.68',
-                balance: '531.57',
-                cardPan: '111111******1111',
-                curr: 'BYN',
-                debitFlag: '0',
-                description: 'Оплата товаров и услуг',
-                error: '',
-                operationDate: '2019-01-02',
-                orderStatus: '1',
-                place: 'Магазин',
-                status: 'T',
-                transAmount: '29.68',
-                transDate: '2018-12-29 01:07:39',
-                transactionId: '1111112'
-              }],
-              outgoingBalance: '999.9',
-              receivedAmount: '999.9',
-              time: '2019-01-16 17:30:49',
-              writtenOffAmount: '999.9'
-            }]
-          }),
-          statusText: 'OK',
-          headers: { 'set-cookie': 'statement-cookie=1' },
-          sendAsJson: false
-        }
-      }
-    })
-
-    const operations = await fetchTransactions(
-      new Map([['identity-cookie', '1']]),
-      [{ id: '1111111', productType: 'PC' }],
-      new Date('2018-12-27T00:00:00.000+03:00'),
-      new Date('2019-01-02T00:00:00.000+03:00')
-    )
-
-    expect(operations).toHaveLength(1)
-    expect(statementAttempts).toBe(2)
-  })
-
-  it('should fail with a contextual error on malformed statement responses', async () => {
-    fetchMock.once('https://mybank.by/api/v1/product/loadOperationStatements', {
-      status: 200,
-      body: JSON.stringify({
-        ResponseType: 'ResponseOfListOfTransactionStatement',
-        error: null,
-        sessionId: null,
-        success: true,
-        validateErrors: null,
-        data: [{
-          accountCurr: 'BYN',
-          accountId: 'BY36MTBK10110001000001111000',
-          operations: null
-        }]
-      }),
-      statusText: 'OK',
-      sendAsJson: false
-    })
-
-    let error
-
-    try {
-      await fetchTransactions(
-        new Map([['identity-cookie', '1']]),
-        [{ id: '1111111', productType: 'PC' }],
-        new Date('2018-12-27T00:00:00.000+03:00'),
-        new Date('2019-01-02T00:00:00.000+03:00')
-      )
-    } catch (caughtError) {
-      error = caughtError
-    }
-
-    expect(error).toBeDefined()
-    expect(error.message).toContain('Не удалось загрузить операции (счет 1111111, период')
-  })
-
-  it('should load account statements with controlled parallelism', async () => {
-    let activeRequests = 0
-    let maxActiveRequests = 0
-
-    fetchMock.mock({
-      method: 'POST',
-      matcher: (url) => url === 'https://mybank.by/api/v1/product/loadOperationStatements',
-      response: async (url, options) => {
-        const requestBody = JSON.parse(options.body)
-        activeRequests++
-        maxActiveRequests = Math.max(maxActiveRequests, activeRequests)
-        await new Promise(resolve => setTimeout(resolve, 20))
-        activeRequests--
-
-        return {
-          status: 200,
-          body: JSON.stringify({
-            ResponseType: 'ResponseOfListOfTransactionStatement',
-            error: null,
-            sessionId: null,
-            success: true,
-            validateErrors: null,
-            data: [{
-              accountCurr: 'BYN',
-              accountId: requestBody.contractCode,
-              operations: []
-            }]
-          }),
-          statusText: 'OK',
-          sendAsJson: false
-        }
-      }
-    })
-
-    const operations = await fetchTransactions(
-      new Map([['identity-cookie', '1']]),
-      [
-        { id: '1111111', productType: 'PC' },
-        { id: '2222222', productType: 'PC' }
-      ],
-      new Date('2018-12-27T00:00:00.000+03:00'),
-      new Date('2019-01-02T00:00:00.000+03:00')
-    )
-
-    expect(operations).toHaveLength(0)
-    expect(maxActiveRequests).toBeGreaterThan(1)
-  })
-
-  it('should fall back to sequential loading when parallel statement loading fails', async () => {
-    let requestCount = 0
-
-    fetchMock.mock({
-      method: 'POST',
-      matcher: (url) => url === 'https://mybank.by/api/v1/product/loadOperationStatements',
-      response: (url, options) => {
-        requestCount++
-        const requestBody = JSON.parse(options.body)
-
-        if (requestCount === 1) {
-          throw new Error('parallel worker failed')
-        }
-
-        return {
-          status: 200,
-          body: JSON.stringify({
-            ResponseType: 'ResponseOfListOfTransactionStatement',
-            error: null,
-            sessionId: null,
-            success: true,
-            validateErrors: null,
-            data: [{
-              accountCurr: 'BYN',
-              accountId: requestBody.contractCode,
-              operations: []
-            }]
-          }),
-          statusText: 'OK',
-          sendAsJson: false
-        }
-      }
-    })
-
-    const operations = await fetchTransactions(
-      new Map([['identity-cookie', '1']]),
-      [
-        { id: '1111111', productType: 'PC' },
-        { id: '2222222', productType: 'PC' }
-      ],
-      new Date('2018-12-27T00:00:00.000+03:00'),
-      new Date('2019-01-02T00:00:00.000+03:00')
-    )
-
-    expect(operations).toHaveLength(0)
-    expect(requestCount).toBe(4)
   })
 })
 

--- a/src/plugins/mtbank/api.js
+++ b/src/plugins/mtbank/api.js
@@ -5,7 +5,8 @@ import { BankMessageError, InvalidOtpCodeError, TemporaryError } from '../../err
 import { getDate } from './converters'
 
 const baseUrl = 'https://mybank.by/api/v1/'
-const statementRequestDelayMs = 250
+const statementRequestDelayMs = 50
+const statementParallelWorkerCount = 2
 const statementRetryCount = 2
 const statementRetryDelayMs = 1000
 
@@ -110,6 +111,7 @@ function parseCookies (response) {
 }
 
 const mapToCookieHeader = (map) => [...map.entries()].map(([key, value]) => `${key}=${value}`).join('; ')
+const cloneCookies = (map) => new Map(map)
 
 function updateCookies (sessionCookies, response) {
   if (!response || !response.headers) return
@@ -283,6 +285,68 @@ async function fetchStatementOperations (sessionCookies, account, startDate, end
   return []
 }
 
+async function fetchAccountOperations (sessionCookies, account, intervals) {
+  const operations = []
+
+  for (const [intervalIndex, [startDate, endDate]] of intervals.entries()) {
+    operations.push(...await fetchStatementOperations(sessionCookies, account, startDate, endDate))
+
+    if (statementRequestDelayMs > 0 && intervalIndex < intervals.length - 1) {
+      await delay(statementRequestDelayMs)
+    }
+  }
+
+  return operations
+}
+
+async function fetchTransactionsSequentially (sessionCookies, accounts, intervals) {
+  const operations = []
+
+  for (const account of accounts) {
+    operations.push(...await fetchAccountOperations(sessionCookies, account, intervals))
+  }
+
+  return operations
+}
+
+function shouldUseParallelAccountWorkers (accounts) {
+  return accounts.length > 1
+}
+
+async function fetchTransactionsWithParallelAccountWorkers (sessionCookies, accounts, intervals) {
+  const workerCount = Math.min(statementParallelWorkerCount, accounts.length)
+  let nextAccountIndex = 0
+  let workerError = null
+
+  const workers = Array.from({ length: workerCount }, async () => {
+    const workerCookies = cloneCookies(sessionCookies)
+    const workerOperations = []
+
+    while (!workerError) {
+      const accountIndex = nextAccountIndex++
+      if (accountIndex >= accounts.length) {
+        break
+      }
+
+      try {
+        workerOperations.push(...await fetchAccountOperations(workerCookies, accounts[accountIndex], intervals))
+      } catch (error) {
+        workerError = workerError || error
+      }
+    }
+
+    return workerOperations
+  })
+
+  const workerResults = await Promise.all(workers)
+
+  if (workerError) {
+    throw workerError
+  }
+
+  return flatMap(workerResults, operations => operations)
+}
+
 export function createDateIntervals (fromDate, toDate) {
   const interval = 20 * 24 * 60 * 60 * 1000 // 20-day interval for fetching data
   const gapMs = 1
@@ -298,17 +362,19 @@ export async function fetchTransactions (sessionCookies, accounts, fromDate, toD
   console.log('>>> Загрузка списка транзакций...')
 
   const intervals = createDateIntervals(fromDate, toDate || new Date())
-  const operations = []
+  const sessionCookiesSnapshot = cloneCookies(sessionCookies)
+  let operations
 
-  for (const [accountIndex, account] of accounts.entries()) {
-    for (const [intervalIndex, [startDate, endDate]] of intervals.entries()) {
-      operations.push(...await fetchStatementOperations(sessionCookies, account, startDate, endDate))
-
-      const isLastRequest = accountIndex === accounts.length - 1 && intervalIndex === intervals.length - 1
-      if (!isLastRequest) {
-        await delay(statementRequestDelayMs)
-      }
+  if (shouldUseParallelAccountWorkers(accounts)) {
+    console.log(`>>> Параллельная загрузка операций по счетам (${Math.min(statementParallelWorkerCount, accounts.length)} workers)...`)
+    try {
+      operations = await fetchTransactionsWithParallelAccountWorkers(sessionCookiesSnapshot, accounts, intervals)
+    } catch (error) {
+      console.log(`>>> Параллельная загрузка операций не удалась, повторяем последовательно: ${error.message || error}`)
+      operations = await fetchTransactionsSequentially(cloneCookies(sessionCookiesSnapshot), accounts, intervals)
     }
+  } else {
+    operations = await fetchTransactionsSequentially(sessionCookiesSnapshot, accounts, intervals)
   }
 
   const filteredOperations = operations.filter(function (op) {

--- a/src/plugins/mtbank/api.js
+++ b/src/plugins/mtbank/api.js
@@ -1,7 +1,7 @@
 import { defaultsDeep, flatMap } from 'lodash'
 import { createDateIntervals as commonCreateDateIntervals } from '../../common/dateUtils'
 import { fetchJson } from '../../common/network'
-import { BankMessageError, InvalidOtpCodeError, TemporaryError } from '../../errors'
+import { BankMessageError, InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../errors'
 import { getDate } from './converters'
 
 const baseUrl = 'https://mybank.by/api/v1/'
@@ -225,8 +225,9 @@ export async function fetchTransactions (sessionCookies, accounts, fromDate, toD
   const operations = []
 
   for (const account of accounts) {
-    const responses = await Promise.all(intervals.map(([startDate, endDate]) => {
-      return fetchApiJsonWithSessionCookies(sessionCookies, 'product/loadOperationStatements', {
+    const responses = []
+    for (const [startDate, endDate] of intervals) {
+      responses.push(await fetchApiJsonWithSessionCookies(sessionCookies, 'product/loadOperationStatements', {
         method: 'POST',
         body: {
           contractCode: account.id,
@@ -235,8 +236,8 @@ export async function fetchTransactions (sessionCookies, accounts, fromDate, toD
           endDate: formatDate(endDate),
           halva: false
         }
-      }, response => response.body)
-    }))
+      }, response => response.body))
+    }
 
     for (const response of responses) {
       if (!response) continue

--- a/src/plugins/mtbank/api.js
+++ b/src/plugins/mtbank/api.js
@@ -5,10 +5,6 @@ import { BankMessageError, InvalidOtpCodeError, TemporaryError } from '../../err
 import { getDate } from './converters'
 
 const baseUrl = 'https://mybank.by/api/v1/'
-const statementRequestDelayMs = 50
-const statementParallelWorkerCount = 2
-const statementRetryCount = 2
-const statementRetryDelayMs = 1000
 
 async function fetchApiJson (url, options, predicate = () => true, error = (message) => console.assert(false, message)) {
   options = defaultsDeep(
@@ -111,7 +107,6 @@ function parseCookies (response) {
 }
 
 const mapToCookieHeader = (map) => [...map.entries()].map(([key, value]) => `${key}=${value}`).join('; ')
-const cloneCookies = (map) => new Map(map)
 
 function updateCookies (sessionCookies, response) {
   if (!response || !response.headers) return
@@ -212,141 +207,6 @@ function formatDate (date) {
   return date.toISOString().replace('T', ' ').split('.')[0]
 }
 
-function delay (ms) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-function isRetriableStatementError (error) {
-  const message = String(error && error.message ? error.message : error)
-  return message.includes('[NTI]') ||
-    message.includes('[NER]') ||
-    message.includes('Request timed out')
-}
-
-function getStatementContext (account, startDate, endDate) {
-  return `счет ${account.id}, период ${formatDate(startDate)} - ${formatDate(endDate)}`
-}
-
-function validateStatementResponse (response, account, startDate, endDate) {
-  const context = getStatementContext(account, startDate, endDate)
-
-  if (!response || !response.body || response.body.success !== true || !Array.isArray(response.body.data)) {
-    throw new TemporaryError(`Банк вернул некорректный ответ при загрузке операций (${context})`)
-  }
-
-  for (const statement of response.body.data) {
-    if (!statement || !Array.isArray(statement.operations)) {
-      throw new TemporaryError(`Банк вернул некорректный ответ при загрузке операций (${context})`)
-    }
-  }
-}
-
-async function fetchStatementOperations (sessionCookies, account, startDate, endDate) {
-  const context = getStatementContext(account, startDate, endDate)
-
-  for (let attempt = 0; attempt <= statementRetryCount; attempt++) {
-    try {
-      const response = await fetchApiJsonWithSessionCookies(sessionCookies, 'product/loadOperationStatements', {
-        method: 'POST',
-        body: {
-          contractCode: account.id,
-          accountIdenType: account.productType,
-          startDate: formatDate(startDate),
-          endDate: formatDate(endDate),
-          halva: false
-        }
-      }, response => response.body)
-
-      if (!response) {
-        return []
-      }
-
-      validateStatementResponse(response, account, startDate, endDate)
-
-      return flatMap(response.body.data, statement => statement.operations.map(operation => ({
-        ...operation,
-        accountId: statement.accountId,
-        description: operation.description || ''
-      })))
-    } catch (error) {
-      if (!isRetriableStatementError(error) || attempt === statementRetryCount) {
-        if (error instanceof BankMessageError) {
-          throw error
-        }
-        throw new TemporaryError(`Не удалось загрузить операции (${context}): ${error.message || error}`)
-      }
-
-      const retryDelayMs = statementRetryDelayMs * Math.pow(2, attempt)
-      console.log(`>>> Повтор загрузки операций (${context}), попытка ${attempt + 2}/${statementRetryCount + 1} через ${retryDelayMs} мс...`)
-      await delay(retryDelayMs)
-    }
-  }
-
-  return []
-}
-
-async function fetchAccountOperations (sessionCookies, account, intervals) {
-  const operations = []
-
-  for (const [intervalIndex, [startDate, endDate]] of intervals.entries()) {
-    operations.push(...await fetchStatementOperations(sessionCookies, account, startDate, endDate))
-
-    if (statementRequestDelayMs > 0 && intervalIndex < intervals.length - 1) {
-      await delay(statementRequestDelayMs)
-    }
-  }
-
-  return operations
-}
-
-async function fetchTransactionsSequentially (sessionCookies, accounts, intervals) {
-  const operations = []
-
-  for (const account of accounts) {
-    operations.push(...await fetchAccountOperations(sessionCookies, account, intervals))
-  }
-
-  return operations
-}
-
-function shouldUseParallelAccountWorkers (accounts) {
-  return accounts.length > 1
-}
-
-async function fetchTransactionsWithParallelAccountWorkers (sessionCookies, accounts, intervals) {
-  const workerCount = Math.min(statementParallelWorkerCount, accounts.length)
-  let nextAccountIndex = 0
-  let workerError = null
-
-  const workers = Array.from({ length: workerCount }, async () => {
-    const workerCookies = cloneCookies(sessionCookies)
-    const workerOperations = []
-
-    while (!workerError) {
-      const accountIndex = nextAccountIndex++
-      if (accountIndex >= accounts.length) {
-        break
-      }
-
-      try {
-        workerOperations.push(...await fetchAccountOperations(workerCookies, accounts[accountIndex], intervals))
-      } catch (error) {
-        workerError = workerError || error
-      }
-    }
-
-    return workerOperations
-  })
-
-  const workerResults = await Promise.all(workers)
-
-  if (workerError) {
-    throw workerError
-  }
-
-  return flatMap(workerResults, operations => operations)
-}
-
 export function createDateIntervals (fromDate, toDate) {
   const interval = 20 * 24 * 60 * 60 * 1000 // 20-day interval for fetching data
   const gapMs = 1
@@ -362,19 +222,31 @@ export async function fetchTransactions (sessionCookies, accounts, fromDate, toD
   console.log('>>> Загрузка списка транзакций...')
 
   const intervals = createDateIntervals(fromDate, toDate || new Date())
-  const sessionCookiesSnapshot = cloneCookies(sessionCookies)
-  let operations
+  const operations = []
 
-  if (shouldUseParallelAccountWorkers(accounts)) {
-    console.log(`>>> Параллельная загрузка операций по счетам (${Math.min(statementParallelWorkerCount, accounts.length)} workers)...`)
-    try {
-      operations = await fetchTransactionsWithParallelAccountWorkers(sessionCookiesSnapshot, accounts, intervals)
-    } catch (error) {
-      console.log(`>>> Параллельная загрузка операций не удалась, повторяем последовательно: ${error.message || error}`)
-      operations = await fetchTransactionsSequentially(cloneCookies(sessionCookiesSnapshot), accounts, intervals)
+  for (const account of accounts) {
+    const responses = await Promise.all(intervals.map(([startDate, endDate]) => {
+      return fetchApiJsonWithSessionCookies(sessionCookies, 'product/loadOperationStatements', {
+        method: 'POST',
+        body: {
+          contractCode: account.id,
+          accountIdenType: account.productType,
+          startDate: formatDate(startDate),
+          endDate: formatDate(endDate),
+          halva: false
+        }
+      }, response => response.body)
+    }))
+
+    for (const response of responses) {
+      if (!response) continue
+
+      operations.push(...flatMap(response.body.data, d => d.operations.map(op => ({
+        ...op,
+        accountId: d.accountId,
+        description: op.description || ''
+      }))))
     }
-  } else {
-    operations = await fetchTransactionsSequentially(sessionCookiesSnapshot, accounts, intervals)
   }
 
   const filteredOperations = operations.filter(function (op) {

--- a/src/plugins/mtbank/api.js
+++ b/src/plugins/mtbank/api.js
@@ -1,10 +1,13 @@
 import { defaultsDeep, flatMap } from 'lodash'
 import { createDateIntervals as commonCreateDateIntervals } from '../../common/dateUtils'
 import { fetchJson } from '../../common/network'
-import { BankMessageError, InvalidOtpCodeError } from '../../errors'
+import { BankMessageError, InvalidOtpCodeError, TemporaryError } from '../../errors'
 import { getDate } from './converters'
 
 const baseUrl = 'https://mybank.by/api/v1/'
+const statementRequestDelayMs = 250
+const statementRetryCount = 2
+const statementRetryDelayMs = 1000
 
 async function fetchApiJson (url, options, predicate = () => true, error = (message) => console.assert(false, message)) {
   options = defaultsDeep(
@@ -77,9 +80,10 @@ async function fetchApiJson (url, options, predicate = () => true, error = (mess
   return response
 }
 
-function validateResponse (response, predicate, error = (message) => console.assert(false, message)) {
+function validateResponse (response, predicate, error = (message) => new TemporaryError(message)) {
   if (!predicate || !predicate(response)) {
-    error('non-successful response')
+    const maybeError = error('non-successful response')
+    throw maybeError !== undefined ? maybeError : new TemporaryError('non-successful response')
   }
 }
 
@@ -107,19 +111,41 @@ function parseCookies (response) {
 
 const mapToCookieHeader = (map) => [...map.entries()].map(([key, value]) => `${key}=${value}`).join('; ')
 
+function updateCookies (sessionCookies, response) {
+  if (!response || !response.headers) return
+
+  for (const [key, value] of parseCookies(response).entries()) {
+    sessionCookies.set(key, value)
+  }
+}
+
+async function fetchApiJsonWithSessionCookies (sessionCookies, url, options, predicate, error) {
+  const response = await fetchApiJson(url, {
+    ...options,
+    headers: {
+      ...options?.headers,
+      Cookie: mapToCookieHeader(sessionCookies)
+    }
+  }, predicate, error)
+  updateCookies(sessionCookies, response)
+  return response
+}
+
 export async function login (login, password) {
+  const cookies = new Map()
+
   let res = await fetchApiJson('login/userIdentityByPhone', {
     method: 'POST',
     body: { phoneNumber: login, loginWay: '1' },
     sanitizeRequestLog: { body: { phoneNumber: true } }
   }, response => response.body.success)
-  const cookies = parseCookies(res)
+  updateCookies(cookies, res)
 
-  res = await fetchApiJson(
+  res = await fetchApiJsonWithSessionCookies(
+    cookies,
     'login/checkPassword4',
     {
       method: 'POST',
-      headers: { Cookie: mapToCookieHeader(cookies) },
       body: { password, version: '2.1.18' },
       sanitizeRequestLog: { body: { password: true } },
       sanitizeResponseLog: {
@@ -144,11 +170,11 @@ export async function login (login, password) {
     if (!smsCode) {
       throw new InvalidOtpCodeError()
     }
-    await fetchApiJson(
+    await fetchApiJsonWithSessionCookies(
+      cookies,
       'login/checkSms',
       {
         method: 'POST',
-        headers: { Cookie: mapToCookieHeader(cookies) },
         body: { smsCode },
         sanitizeRequestLog: { body: { smsCode: true } }
       },
@@ -156,14 +182,16 @@ export async function login (login, password) {
     )
   }
 
-  await fetchApiJson(
+  await fetchApiJsonWithSessionCookies(
+    cookies,
     'user/userRole',
     {
       method: 'POST',
       body: res.body.data.userInfo.dboContracts[0],
       sanitizeRequestLog: { body: true }
     },
-    (response) => response.body.success
+    (response) => response.body.success,
+    (message) => new TemporaryError(message)
   )
 
   return cookies
@@ -172,21 +200,87 @@ export async function login (login, password) {
 export async function fetchAccounts (sessionCookies) {
   console.log('>>> Загрузка списка счетов...')
 
-  const response = await fetchApiJson('user/loadUser', {
-    headers: { Cookie: mapToCookieHeader(sessionCookies) }
-  }, response => response.body && response.body.data && response.body.data.products,
-  message => new TemporaryError(message))
-
-  // Update session cookies with new values
-  for (const [key, value] of parseCookies(response).entries()) {
-    sessionCookies.set(key, value)
-  }
+  const response = await fetchApiJsonWithSessionCookies(sessionCookies, 'user/loadUser', {}, response => response.body && response.body.data && response.body.data.products,
+    message => new TemporaryError(message))
 
   return response.body.data.products
 }
 
 function formatDate (date) {
   return date.toISOString().replace('T', ' ').split('.')[0]
+}
+
+function delay (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function isRetriableStatementError (error) {
+  const message = String(error && error.message ? error.message : error)
+  return message.includes('[NTI]') ||
+    message.includes('[NER]') ||
+    message.includes('Request timed out')
+}
+
+function getStatementContext (account, startDate, endDate) {
+  return `счет ${account.id}, период ${formatDate(startDate)} - ${formatDate(endDate)}`
+}
+
+function validateStatementResponse (response, account, startDate, endDate) {
+  const context = getStatementContext(account, startDate, endDate)
+
+  if (!response || !response.body || response.body.success !== true || !Array.isArray(response.body.data)) {
+    throw new TemporaryError(`Банк вернул некорректный ответ при загрузке операций (${context})`)
+  }
+
+  for (const statement of response.body.data) {
+    if (!statement || !Array.isArray(statement.operations)) {
+      throw new TemporaryError(`Банк вернул некорректный ответ при загрузке операций (${context})`)
+    }
+  }
+}
+
+async function fetchStatementOperations (sessionCookies, account, startDate, endDate) {
+  const context = getStatementContext(account, startDate, endDate)
+
+  for (let attempt = 0; attempt <= statementRetryCount; attempt++) {
+    try {
+      const response = await fetchApiJsonWithSessionCookies(sessionCookies, 'product/loadOperationStatements', {
+        method: 'POST',
+        body: {
+          contractCode: account.id,
+          accountIdenType: account.productType,
+          startDate: formatDate(startDate),
+          endDate: formatDate(endDate),
+          halva: false
+        }
+      }, response => response.body)
+
+      if (!response) {
+        return []
+      }
+
+      validateStatementResponse(response, account, startDate, endDate)
+
+      return flatMap(response.body.data, statement => statement.operations.map(operation => ({
+        ...operation,
+        accountId: statement.accountId,
+        description: operation.description || ''
+      })))
+    } catch (error) {
+      if (!isRetriableStatementError(error) || attempt === statementRetryCount) {
+        if (error instanceof BankMessageError) {
+          throw error
+        }
+        throw new TemporaryError(`Не удалось загрузить операции (${context}): ${error.message || error}`)
+      }
+
+      const retryDelayMs = statementRetryDelayMs * Math.pow(2, attempt)
+      console.log(`>>> Повтор загрузки операций (${context}), попытка ${attempt + 2}/${statementRetryCount + 1} через ${retryDelayMs} мс...`)
+      await delay(retryDelayMs)
+    }
+  }
+
+  return []
 }
 
 export function createDateIntervals (fromDate, toDate) {
@@ -206,29 +300,14 @@ export async function fetchTransactions (sessionCookies, accounts, fromDate, toD
   const intervals = createDateIntervals(fromDate, toDate || new Date())
   const operations = []
 
-  for (const account of accounts) {
-    const responses = await Promise.all(intervals.map(([startDate, endDate]) => {
-      return fetchApiJson('product/loadOperationStatements', {
-        method: 'POST',
-        headers: { Cookie: mapToCookieHeader(sessionCookies) },
-        body: {
-          contractCode: account.id,
-          accountIdenType: account.productType,
-          startDate: formatDate(startDate),
-          endDate: formatDate(endDate),
-          halva: false
-        }
-      }, response => response.body)
-    }))
+  for (const [accountIndex, account] of accounts.entries()) {
+    for (const [intervalIndex, [startDate, endDate]] of intervals.entries()) {
+      operations.push(...await fetchStatementOperations(sessionCookies, account, startDate, endDate))
 
-    for (const response of responses) {
-      if (!response) continue
-
-      operations.push(...flatMap(response.body.data, d => d.operations.map(op => ({
-        ...op,
-        accountId: d.accountId,
-        description: op.description || ''
-      }))))
+      const isLastRequest = accountIndex === accounts.length - 1 && intervalIndex === intervals.length - 1
+      if (!isLastRequest) {
+        await delay(statementRequestDelayMs)
+      }
     }
   }
 

--- a/src/plugins/mtbank/converters.js
+++ b/src/plugins/mtbank/converters.js
@@ -166,10 +166,12 @@ export function filterDuplicates (transactions) {
   const filtered = []
   for (const transaction of transactions) {
     const key = transaction.movements[0].id + '_' + Math.abs(transaction.movements[0].sum)
-    if (transactionIds[key]) { //
-    } else {
-      transactionIds[key] = true
+    const index = transactionIds[key]
+    if (index === undefined) {
+      transactionIds[key] = filtered.length
       filtered.push(transaction)
+    } else if (filtered[index].hold && !transaction.hold) {
+      filtered[index] = transaction
     }
   }
   return filtered

--- a/src/plugins/mtbank/preferences.xml
+++ b/src/plugins/mtbank/preferences.xml
@@ -25,7 +25,7 @@
         obligatory="true"
         inputType="date"
         title="С какой даты загружать операции"
-        defaultValue="2018-01-01T00:00:00.000Z"
+        defaultValue="2025-01-01T00:00:00.000Z"
         dialogTitle="С какой даты загружать операции"
         positiveButtonText="ОК"
         negativeButtonText="Отмена"

--- a/src/plugins/mtbank/preferences.xml
+++ b/src/plugins/mtbank/preferences.xml
@@ -25,7 +25,7 @@
         obligatory="true"
         inputType="date"
         title="С какой даты загружать операции"
-        defaultValue="2025-01-01T00:00:00.000Z"
+        defaultValue="2018-01-01T00:00:00.000Z"
         dialogTitle="С какой даты загружать операции"
         positiveButtonText="ОК"
         negativeButtonText="Отмена"


### PR DESCRIPTION
Исправлена работа с session cookies в mtbank и уточнена дедупликация hold/posting операций.

Что изменено:

 - cookie jar теперь обновляется после каждого ответа банка, а не только на отдельных шагах;
 - checkPassword4, checkSms, userRole, loadUser и запросы выписок идут с актуальным набором cookies;
 - запросы выписок по интервалам выполняются последовательно, чтобы следующий запрос видел cookies, выставленные предыдущим ответом;
 - неуспешные ответы теперь превращаются в явные ошибки, вместо console.assert;
 - для userRole/loadUser используются временные ошибки при неуспешном ответе;
 - filterDuplicates теперь заменяет hold на matching posted операцию, а не просто оставляет первую найденную.

Тесты добавлены/обновлены для:

 - проверки последовательного обновления cookies на login/userRole/loadUser/statements цепочке;
 - сценария, где posted операция должна заменить matching hold duplicate.

Итог:

 - session flow стал устойчивее к обновлению cookies банком между запросами;
 - при совпадающих ID и сумме posted операция имеет приоритет над hold.