### PR TITLE
[sberbank-by]: Исправление дедупликации и входящих P2P

### DIFF
--- a/src/plugins/sberbank-by/__tests__/converters/transactions/convertTransactionsFunc.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/convertTransactionsFunc.test.js
@@ -1,3 +1,4 @@
+import { adjustTransactions } from '../../../../../common/transactionGroupHandler.js'
 import { convertTransactions } from '../../../converters.js'
 
 describe('convertTransactions', () => {
@@ -388,8 +389,7 @@ describe('convertTransactions', () => {
               sum: -92.82
             }
           ],
-          comment: null,
-          groupKeys: ['2023-09-12_BYN_92.82']
+          comment: null
         },
         {
           date: new Date('2023-09-12T07:37:13.000Z'),
@@ -410,12 +410,115 @@ describe('convertTransactions', () => {
               sum: 92.82
             }
           ],
-          comment: null,
-          groupKeys: ['2023-09-12_BYN_92.82']
+          comment: null
         }
       ]
     ]
   ])('converts transactions', (apiTransactions, accountsByNumber, transactions) => {
     expect(convertTransactions(apiTransactions, accountsByNumber)).toEqual(transactions)
+  })
+
+  it('does not merge received P2P SOU Sber Bank money with a matching debit', () => {
+    const apiTransactions = [
+      {
+        sourceSystem: 4,
+        eventId: 'debit-event',
+        contractId: 'credit-contract',
+        cardPAN: '111111******1111',
+        cardId: 'credit-card',
+        eventDate: 1770000000000,
+        transactionCode: '01000F',
+        transactionName: 'P2P SOU Sber Bank > Minsk BLR Терминал: W2P90008 RRN:600000000001 AuthCode:111111',
+        merchantId: '0822061',
+        merchantPlace: 'P2P SOU Sber Bank > Minsk BLR',
+        transactionSum: -30,
+        transactionCurrency: '933',
+        commissionSum: 0,
+        commissionCurrency: '933',
+        rnnCode: '600000000001',
+        authorizationCode: '111111',
+        eventStatus: 0,
+        payAvailable: false
+      },
+      {
+        sourceSystem: 4,
+        eventId: 'income-event',
+        contractId: 'income-contract',
+        cardPAN: '222222******4370',
+        cardId: 'income-card',
+        eventDate: 1770000000000,
+        transactionCode: '01000P',
+        transactionName: 'P2P SOU Sber Bank > Minsk BLR Терминал: W2P90008 RRN:600000000002 AuthCode:222222',
+        merchantId: '0822061',
+        merchantPlace: 'P2P SOU Sber Bank > Minsk BLR',
+        transactionSum: 30,
+        transactionCurrency: '933',
+        commissionSum: 0,
+        commissionCurrency: '933',
+        rnnCode: '600000000002',
+        authorizationCode: '222222',
+        eventStatus: 0,
+        payAvailable: false
+      }
+    ]
+    const accountsByNumber = {
+      'credit-contract': {
+        id: 'credit-account',
+        instrument: 'BYN'
+      },
+      'income-contract': {
+        id: 'card-4370',
+        instrument: 'BYN'
+      }
+    }
+
+    const transactions = adjustTransactions({
+      transactions: convertTransactions(apiTransactions, accountsByNumber)
+    })
+
+    expect(transactions).toEqual([
+      {
+        date: new Date(1770000000000),
+        hold: true,
+        merchant: {
+          city: 'Minsk',
+          country: 'BLR',
+          location: null,
+          mcc: null,
+          title: 'P2P SOU Sber Bank'
+        },
+        movements: [
+          {
+            account: { id: 'credit-account' },
+            fee: 0,
+            id: 'debit-event',
+            invoice: null,
+            sum: -30
+          }
+        ],
+        comment: null
+      },
+      {
+        date: new Date(1770000000000),
+        hold: true,
+        merchant: {
+          city: 'Minsk',
+          country: 'BLR',
+          location: null,
+          mcc: null,
+          title: 'P2P SOU Sber Bank'
+        },
+        movements: [
+          {
+            account: { id: 'card-4370' },
+            fee: 0,
+            id: 'income-event',
+            invoice: null,
+            sum: 30
+          }
+        ],
+        comment: null
+      }
+    ])
   })
 })

--- a/src/plugins/sberbank-by/__tests__/converters/transactions/filterDuplicates.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/filterDuplicates.test.js
@@ -182,6 +182,80 @@ describe('filterDuplicates', () => {
           comment: 'Покупка SOU Sber Bank'
         }
       ]
+    ],
+    [
+      [
+        {
+          sourceSystem: 8,
+          eventId: '-696460788586#7#25',
+          contractId: '20301567',
+          contractCurrency: '933',
+          cardPAN: '',
+          eventDate: 1779901343000,
+          processingDate: 1779829200000,
+          transactionType: 1,
+          transactionCode: 'TRAN_ERIP',
+          transactionName: 'Пополнение счета через ЕРИП онлайн',
+          transactionSum: 20,
+          transactionCurrency: '933',
+          eventStatus: 1,
+          payAvailable: false
+        },
+        {
+          sourceSystem: 8,
+          eventId: '-696460788586#7#26',
+          contractId: '20301567',
+          contractCurrency: '933',
+          cardPAN: '',
+          eventDate: 1779901343000,
+          processingDate: 1779829200000,
+          transactionType: 1,
+          transactionCode: 'TRAN_ERIP',
+          transactionName: 'Пополнение счета через ЕРИП онлайн',
+          transactionSum: 20,
+          transactionCurrency: '933',
+          eventStatus: 1,
+          payAvailable: false
+        }
+      ],
+      {
+        20301567: {
+          id: 'account-1',
+          instrument: 'BYN'
+        }
+      },
+      [
+        {
+          hold: false,
+          date: new Date('2026-05-27T17:02:23.000Z'),
+          movements: [
+            {
+              id: '-696460788586#7#25',
+              account: { id: 'account-1' },
+              invoice: null,
+              sum: 20,
+              fee: 0
+            }
+          ],
+          merchant: null,
+          comment: 'Пополнение счета через ЕРИП онлайн'
+        },
+        {
+          hold: false,
+          date: new Date('2026-05-27T17:02:23.000Z'),
+          movements: [
+            {
+              id: '-696460788586#7#26',
+              account: { id: 'account-1' },
+              invoice: null,
+              sum: 20,
+              fee: 0
+            }
+          ],
+          merchant: null,
+          comment: 'Пополнение счета через ЕРИП онлайн'
+        }
+      ]
     ]
   ])('converts filter duplicates transactions', (apiTransactions, accountsByContractNumber, transactions) => {
     expect(convertTransactions(apiTransactions, accountsByContractNumber)).toEqual(transactions)

--- a/src/plugins/sberbank-by/__tests__/converters/transactions/filterDuplicates.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/filterDuplicates.test.js
@@ -109,6 +109,79 @@ describe('filterDuplicates', () => {
           comment: 'Открытие'
         }
       ]
+    ],
+    [
+      [
+        {
+          sourceSystem: 4,
+          eventId: 'hold-event',
+          contractId: '10957794',
+          cardPAN: '911238******4812',
+          cardId: '1771310095',
+          eventDate: 1712911020000,
+          transactionCode: '01000R',
+          transactionName: 'SOU Sber Bank > Minsk BLR Терминал: WWL90902 RRN:410383389811 AuthCode:602242',
+          merchantId: '0802082',
+          merchantPlace: 'SOU Sber Bank > Minsk BLR',
+          transactionSum: -50,
+          transactionCurrency: '933',
+          commissionSum: 0,
+          commissionCurrency: '933',
+          rnnCode: '410383389811',
+          authorizationCode: '602242',
+          eventStatus: 0,
+          payAvailable: false
+        },
+        {
+          sourceSystem: 1,
+          eventId: 'posted-event',
+          contractId: '10957794',
+          contractCurrency: '933',
+          cardPAN: '911238******4812',
+          cardId: '1771310095',
+          eventDate: 1712911022000,
+          processingDate: 1712914622000,
+          transactionType: -1,
+          transactionCode: '205',
+          transactionName: 'Покупка SOU Sber Bank',
+          operationCode: null,
+          merchantId: '0802082',
+          merchantName: 'SOU Sber Bank',
+          merchantPlace: 'Minsk',
+          transactionSum: 50,
+          transactionCurrency: '933',
+          accountSum: 50,
+          commissionSum: 0,
+          commissionCurrency: '933',
+          rnnCode: '410383389811',
+          authorizationCode: '602242',
+          eventStatus: 1,
+          payAvailable: false
+        }
+      ],
+      {
+        10957794: {
+          id: 'account-1',
+          instrument: 'BYN'
+        }
+      },
+      [
+        {
+          hold: false,
+          date: new Date('2024-04-12T08:37:02.000Z'),
+          movements: [
+            {
+              id: 'posted-event',
+              account: { id: 'account-1' },
+              invoice: null,
+              sum: -50,
+              fee: 0
+            }
+          ],
+          merchant: null,
+          comment: 'Покупка SOU Sber Bank'
+        }
+      ]
     ]
   ])('converts filter duplicates transactions', (apiTransactions, accountsByContractNumber, transactions) => {
     expect(convertTransactions(apiTransactions, accountsByContractNumber)).toEqual(transactions)

--- a/src/plugins/sberbank-by/__tests__/converters/transactions/filterDuplicates.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/filterDuplicates.test.js
@@ -186,6 +186,152 @@ describe('filterDuplicates', () => {
     [
       [
         {
+          sourceSystem: 4,
+          eventId: 'hold-event',
+          contractId: '10957794',
+          cardPAN: '911238******4812',
+          cardId: '1771310095',
+          eventDate: 1712911020000,
+          transactionCode: '01000R',
+          transactionName: 'SOU Sber Bank > Minsk BLR Терминал: WWL90902 RRN:410383389811 AuthCode:602242',
+          merchantId: '0802082',
+          merchantPlace: 'SOU Sber Bank > Minsk BLR',
+          transactionSum: -50,
+          transactionCurrency: '933',
+          commissionSum: 0,
+          commissionCurrency: '933',
+          rnnCode: '410383389811',
+          authorizationCode: '602242',
+          eventStatus: 0,
+          payAvailable: false
+        },
+        {
+          sourceSystem: 1,
+          eventId: 'posted-event',
+          contractId: '10957794',
+          contractCurrency: '933',
+          cardPAN: '911238******4812',
+          cardId: '1771310095',
+          eventDate: 1712911022000,
+          processingDate: 1712914622000,
+          transactionType: -1,
+          transactionCode: '205',
+          transactionName: 'Покупка SOU Sber Bank',
+          operationCode: null,
+          merchantId: '0802082',
+          merchantName: 'SOU Sber Bank',
+          merchantPlace: 'Minsk',
+          transactionSum: 50,
+          transactionCurrency: '933',
+          accountSum: 50,
+          commissionSum: 0,
+          commissionCurrency: '933',
+          rnnCode: '410383389811',
+          authorizationCode: '000000',
+          eventStatus: 1,
+          payAvailable: false
+        }
+      ],
+      {
+        10957794: {
+          id: 'account-1',
+          instrument: 'BYN'
+        }
+      },
+      [
+        {
+          hold: false,
+          date: new Date('2024-04-12T08:37:02.000Z'),
+          movements: [
+            {
+              id: 'posted-event',
+              account: { id: 'account-1' },
+              invoice: null,
+              sum: -50,
+              fee: 0
+            }
+          ],
+          merchant: null,
+          comment: 'Покупка SOU Sber Bank'
+        }
+      ]
+    ],
+    [
+      [
+        {
+          sourceSystem: 4,
+          eventId: 'hold-event',
+          contractId: '10957794',
+          cardPAN: '911238******4812',
+          cardId: '1771310095',
+          eventDate: 1712911020000,
+          transactionCode: '01000R',
+          transactionName: 'SOU Sber Bank > Minsk BLR Терминал: WWL90902 RRN:410383389811 AuthCode:602242',
+          merchantId: '0802082',
+          merchantPlace: 'SOU Sber Bank > Minsk BLR',
+          transactionSum: -50,
+          transactionCurrency: '933',
+          commissionSum: 0,
+          commissionCurrency: '933',
+          rnnCode: '410383389811',
+          authorizationCode: '602242',
+          eventStatus: 0,
+          payAvailable: false
+        },
+        {
+          sourceSystem: 1,
+          eventId: 'posted-event',
+          contractId: '10957794',
+          contractCurrency: '933',
+          cardPAN: '911238******4812',
+          cardId: '',
+          eventDate: 1712911022000,
+          processingDate: 1712914622000,
+          transactionType: -1,
+          transactionCode: '205',
+          transactionName: 'Покупка SOU Sber Bank',
+          operationCode: null,
+          merchantId: '0802082',
+          merchantName: 'SOU Sber Bank',
+          merchantPlace: 'Minsk',
+          transactionSum: 50,
+          transactionCurrency: '933',
+          accountSum: 50,
+          commissionSum: 0,
+          commissionCurrency: '933',
+          rnnCode: '410383389811',
+          authorizationCode: '602242',
+          eventStatus: 1,
+          payAvailable: false
+        }
+      ],
+      {
+        10957794: {
+          id: 'account-1',
+          instrument: 'BYN'
+        }
+      },
+      [
+        {
+          hold: false,
+          date: new Date('2024-04-12T08:37:02.000Z'),
+          movements: [
+            {
+              id: 'posted-event',
+              account: { id: 'account-1' },
+              invoice: null,
+              sum: -50,
+              fee: 0
+            }
+          ],
+          merchant: null,
+          comment: 'Покупка SOU Sber Bank'
+        }
+      ]
+    ],
+    [
+      [
+        {
           sourceSystem: 8,
           eventId: '-696460788586#7#25',
           contractId: '20301567',

--- a/src/plugins/sberbank-by/__tests__/converters/transactions/income.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/income.test.js
@@ -8,6 +8,69 @@ describe('convertTransaction', () => {
   it.each([
     [
       {
+        sourceSystem: 3,
+        eventId: 'incoming-p2p-event',
+        contractId: 'account-contract',
+        contractCurrency: '933',
+        cardPAN: '111111******2222',
+        cardExpiryDate: null,
+        cardId: 'card-id',
+        eventDate: 1778918001000,
+        processingDate: 1778965200000,
+        transactionType: 1,
+        transactionCode: '206',
+        transactionName: 'Зачисление по услуге Перевод BYN на "чужие" карты в пределах Сбер Банка 111111******2222',
+        operationCode: null,
+        merchantId: '0822061',
+        merchantName: 'P2P SOU Sber Bank',
+        merchantPlace: 'Minsk',
+        transactionSum: 30.0,
+        transactionCurrency: '933',
+        accountSum: 30.0,
+        commissionSum: null,
+        commissionCurrency: '933',
+        rnnCode: '600000000001',
+        authorizationCode: '111111',
+        eventStatus: 1,
+        mccCode: '6012',
+        errorDescription: null,
+        souServiceCode: 656,
+        souServiceType: null,
+        souServiceName: null,
+        souRnnCode: null,
+        souAuthorizationCode: null,
+        souTransactionSum: null,
+        souTransactionCurrency: null,
+        souEventId: 'incoming-sou-event',
+        qrPaymentId: null,
+        fileId: null,
+        printDocs: null,
+        payAvailable: false
+      },
+      {
+        hold: false,
+        date: new Date(1778918001000),
+        movements: [
+          {
+            id: 'incoming-p2p-event',
+            account: { id: 'account' },
+            invoice: null,
+            sum: 30.0,
+            fee: 0
+          }
+        ],
+        merchant: {
+          title: 'P2P SOU Sber Bank',
+          city: null,
+          country: null,
+          location: null,
+          mcc: 6012
+        },
+        comment: 'Зачисление по услуге Перевод BYN на "чужие" карты в пределах Сбер Банка 111111******2222'
+      }
+    ],
+    [
+      {
         sourceSystem: 2,
         eventId: '1842095258',
         contractId: '8013742',

--- a/src/plugins/sberbank-by/__tests__/converters/transactions/outerTransfer.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/outerTransfer.test.js
@@ -339,18 +339,6 @@ describe('convertTransaction', () => {
             invoice: null,
             sum: 110,
             fee: 0
-          },
-          {
-            id: null,
-            account: {
-              type: 'ccard',
-              instrument: 'BYN',
-              company: null,
-              syncIds: ['1474']
-            },
-            invoice: null,
-            sum: -110,
-            fee: 0
           }
         ],
         merchant: null,
@@ -407,18 +395,6 @@ describe('convertTransaction', () => {
             account: { id: 'account' },
             invoice: null,
             sum: 79,
-            fee: 0
-          },
-          {
-            id: null,
-            account: {
-              type: 'ccard',
-              instrument: 'BYN',
-              company: null,
-              syncIds: ['6492']
-            },
-            invoice: null,
-            sum: -79,
             fee: 0
           }
         ],

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -118,17 +118,18 @@ function getAccountLevelEventId (apiTransaction, rrn, authorizationCode) {
 function getApiTransactionDedupKey (apiTransaction) {
   const { rrn, authorizationCode } = getApiTransactionReferenceCodes(apiTransaction)
   const accountLevelEventId = getAccountLevelEventId(apiTransaction, rrn, authorizationCode)
+  const referenceKey = rrn || authorizationCode
+  const cardKey = referenceKey ? '' : apiTransaction.cardId || apiTransaction.cardPAN || ''
   const dateKey = rrn || authorizationCode
     ? toISODateString(new Date(apiTransaction.eventDate))
     : String(apiTransaction.eventDate)
   return [
     apiTransaction.contractId,
-    apiTransaction.cardId || apiTransaction.cardPAN || '',
+    cardKey,
     dateKey,
     Math.abs(apiTransaction.transactionSum),
     apiTransaction.transactionCurrency || '',
-    rrn,
-    authorizationCode,
+    referenceKey,
     accountLevelEventId
   ].join('_')
 }

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -101,11 +101,23 @@ function parseMetalInstrument (code) {
   }
 }
 
-function getApiTransactionDedupKey (apiTransaction) {
+function getApiTransactionReferenceCodes (apiTransaction) {
   const rrn = apiTransaction.rnnCode || apiTransaction.souRnnCode || ''
   const authorizationCode = apiTransaction.authorizationCode && apiTransaction.authorizationCode !== '000000'
     ? apiTransaction.authorizationCode
     : ''
+  return { rrn, authorizationCode }
+}
+
+function getAccountLevelEventId (apiTransaction, rrn, authorizationCode) {
+  return !rrn && !authorizationCode && !(apiTransaction.cardId || apiTransaction.cardPAN)
+    ? apiTransaction.eventId || ''
+    : ''
+}
+
+function getApiTransactionDedupKey (apiTransaction) {
+  const { rrn, authorizationCode } = getApiTransactionReferenceCodes(apiTransaction)
+  const accountLevelEventId = getAccountLevelEventId(apiTransaction, rrn, authorizationCode)
   const dateKey = rrn || authorizationCode
     ? toISODateString(new Date(apiTransaction.eventDate))
     : String(apiTransaction.eventDate)
@@ -116,7 +128,8 @@ function getApiTransactionDedupKey (apiTransaction) {
     Math.abs(apiTransaction.transactionSum),
     apiTransaction.transactionCurrency || '',
     rrn,
-    authorizationCode
+    authorizationCode,
+    accountLevelEventId
   ].join('_')
 }
 
@@ -152,6 +165,9 @@ function getTransactionDedupKey (transaction) {
   const movement = transaction.movements?.[0]
   if (!movement) {
     return null
+  }
+  if (transaction.dedupIdentity) {
+    return `${movement.account.id}_${transaction.dedupIdentity}`
   }
   return `${movement.account.id}_${transaction.date.getTime()}_${Math.abs(movement.sum)}`
 }
@@ -263,6 +279,7 @@ export function convertTransaction (apiTransaction, account) {
   if (apiTransaction.eventStatus === -1 || apiTransaction.transactionSum === 0) {
     return null
   }
+  const { rrn, authorizationCode } = getApiTransactionReferenceCodes(apiTransaction)
   const currency = apiTransaction.transactionCurrency.length === 3
     ? apiTransaction.transactionCurrency
     : apiTransaction.transactionCurrency.length === 2 ? `0${apiTransaction.transactionCurrency}` : `00${apiTransaction.transactionCurrency}`
@@ -295,6 +312,15 @@ export function convertTransaction (apiTransaction, account) {
     parsePayee
   ]
   parsers.some(parser => parser(transaction, apiTransaction, account, invoice))
+
+  const accountLevelEventId = getAccountLevelEventId(apiTransaction, rrn, authorizationCode)
+  if (accountLevelEventId) {
+    Object.defineProperty(transaction, 'dedupIdentity', {
+      value: accountLevelEventId,
+      enumerable: false,
+      configurable: true
+    })
+  }
 
   return transaction
 }

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -1,4 +1,4 @@
-import { keyBy, sortBy, uniqBy } from 'lodash'
+import { keyBy, sortBy } from 'lodash'
 import codeToCurrency from '../../common/codeToCurrencyLookup'
 import { toISODateString } from '../../common/dateUtils'
 import { getIntervalBetweenDates } from '../../common/momentDateUtils'
@@ -101,21 +101,82 @@ function parseMetalInstrument (code) {
   }
 }
 
+function getApiTransactionDedupKey (apiTransaction) {
+  const rrn = apiTransaction.rnnCode || apiTransaction.souRnnCode || ''
+  const authorizationCode = apiTransaction.authorizationCode && apiTransaction.authorizationCode !== '000000'
+    ? apiTransaction.authorizationCode
+    : ''
+  if (rrn || authorizationCode) {
+    return [
+      apiTransaction.contractId,
+      apiTransaction.cardId || apiTransaction.cardPAN || '',
+      toISODateString(new Date(apiTransaction.eventDate)),
+      Math.abs(apiTransaction.transactionSum),
+      apiTransaction.transactionCurrency || '',
+      rrn,
+      authorizationCode
+    ].join('_')
+  }
+  return [
+    apiTransaction.contractId,
+    apiTransaction.eventDate,
+    Math.abs(apiTransaction.transactionSum),
+    rrn,
+    apiTransaction.authorizationCode || ''
+  ].join('_')
+}
+
+function shouldReplaceApiTransaction (currentTransaction, nextTransaction) {
+  if (currentTransaction.eventStatus === 0 && nextTransaction.eventStatus !== 0) {
+    return true
+  }
+  if (!currentTransaction.processingDate && nextTransaction.processingDate) {
+    return true
+  }
+  return false
+}
+
+function deduplicateApiTransactions (apiTransactions) {
+  const uniqueTransactions = []
+  const transactionIndexesByKey = {}
+  for (const apiTransaction of sortBy(apiTransactions, transaction => transaction.transactionName?.match(/Перевод/))) {
+    const key = getApiTransactionDedupKey(apiTransaction)
+    const index = transactionIndexesByKey[key]
+    if (index === undefined) {
+      transactionIndexesByKey[key] = uniqueTransactions.length
+      uniqueTransactions.push(apiTransaction)
+      continue
+    }
+    if (shouldReplaceApiTransaction(uniqueTransactions[index], apiTransaction)) {
+      uniqueTransactions[index] = apiTransaction
+    }
+  }
+  return uniqueTransactions
+}
+
+function getTransactionDedupKey (transaction) {
+  return `${transaction.movements[0].account.id}_${transaction.date.getTime()}_${Math.abs(transaction.movements[0].sum)}`
+}
+
+function shouldReplaceTransaction (currentTransaction, nextTransaction) {
+  return currentTransaction.hold && !nextTransaction.hold
+}
+
 export function convertTransactions (apiTransactions, accountsByContractNumber) {
-  const adjustedApiTransactions = uniqBy(
-    sortBy(apiTransactions, apiTransaction => apiTransaction.transactionName?.match(/Перевод/)),
-    apiTransaction => `${apiTransaction.contractId}_${apiTransaction.eventDate}_${Math.abs(apiTransaction.transactionSum)}_${apiTransaction.rnnCode}_${apiTransaction.authorizationCode}`)
+  const adjustedApiTransactions = deduplicateApiTransactions(apiTransactions)
   const transactions = []
-  const transactionIds = {}
+  const transactionIndexes = {}
   for (const transaction of adjustedApiTransactions) {
     if (accountsByContractNumber[transaction.contractId]) {
       const answer = convertTransaction(transaction, accountsByContractNumber[transaction.contractId])
       if (answer !== null) {
-        const key = answer.movements[0].account.id + '_' + answer.date + '_' + Math.abs(answer.movements[0].sum)
-        if (transactionIds[key]) { //
-        } else {
-          transactionIds[key] = true
+        const key = getTransactionDedupKey(answer)
+        const index = transactionIndexes[key]
+        if (index === undefined) {
+          transactionIndexes[key] = transactions.length
           transactions.push(answer)
+        } else if (shouldReplaceTransaction(transactions[index], answer)) {
+          transactions[index] = answer
         }
       }
     }

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -376,10 +376,14 @@ function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
     return true
   }
   if ([
-    /Дополнительный взнос/i,
-    /P2P SOU Sber/i
+    /Дополнительный взнос/i
   ].some(regexp => regexp.test(apiTransaction.transactionName))) {
     transaction.groupKeys = [toISODateString(transaction.date) + '_' + invoice.instrument + '_' + Math.abs(invoice.sum)]
+    return true
+  }
+  if ([
+    /P2P SOU Sber/i
+  ].some(regexp => regexp.test(apiTransaction.transactionName))) {
     return true
   }
   if ([

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -106,23 +106,17 @@ function getApiTransactionDedupKey (apiTransaction) {
   const authorizationCode = apiTransaction.authorizationCode && apiTransaction.authorizationCode !== '000000'
     ? apiTransaction.authorizationCode
     : ''
-  if (rrn || authorizationCode) {
-    return [
-      apiTransaction.contractId,
-      apiTransaction.cardId || apiTransaction.cardPAN || '',
-      toISODateString(new Date(apiTransaction.eventDate)),
-      Math.abs(apiTransaction.transactionSum),
-      apiTransaction.transactionCurrency || '',
-      rrn,
-      authorizationCode
-    ].join('_')
-  }
+  const dateKey = rrn || authorizationCode
+    ? toISODateString(new Date(apiTransaction.eventDate))
+    : String(apiTransaction.eventDate)
   return [
     apiTransaction.contractId,
-    apiTransaction.eventDate,
+    apiTransaction.cardId || apiTransaction.cardPAN || '',
+    dateKey,
     Math.abs(apiTransaction.transactionSum),
+    apiTransaction.transactionCurrency || '',
     rrn,
-    apiTransaction.authorizationCode || ''
+    authorizationCode
   ].join('_')
 }
 
@@ -139,7 +133,7 @@ function shouldReplaceApiTransaction (currentTransaction, nextTransaction) {
 function deduplicateApiTransactions (apiTransactions) {
   const uniqueTransactions = []
   const transactionIndexesByKey = {}
-  for (const apiTransaction of sortBy(apiTransactions, transaction => transaction.transactionName?.match(/Перевод/))) {
+  for (const apiTransaction of sortBy(apiTransactions, apiTransaction => apiTransaction.transactionName?.match(/Перевод/))) {
     const key = getApiTransactionDedupKey(apiTransaction)
     const index = transactionIndexesByKey[key]
     if (index === undefined) {
@@ -155,7 +149,11 @@ function deduplicateApiTransactions (apiTransactions) {
 }
 
 function getTransactionDedupKey (transaction) {
-  return `${transaction.movements[0].account.id}_${transaction.date.getTime()}_${Math.abs(transaction.movements[0].sum)}`
+  const movement = transaction.movements?.[0]
+  if (!movement) {
+    return null
+  }
+  return `${movement.account.id}_${transaction.date.getTime()}_${Math.abs(movement.sum)}`
 }
 
 function shouldReplaceTransaction (currentTransaction, nextTransaction) {
@@ -171,6 +169,10 @@ export function convertTransactions (apiTransactions, accountsByContractNumber) 
       const answer = convertTransaction(transaction, accountsByContractNumber[transaction.contractId])
       if (answer !== null) {
         const key = getTransactionDedupKey(answer)
+        if (key === null) {
+          transactions.push(answer)
+          continue
+        }
         const index = transactionIndexes[key]
         if (index === undefined) {
           transactionIndexes[key] = transactions.length

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -409,6 +409,9 @@ function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
 }
 
 function parseOuterTransfer (transaction, apiTransaction, account, invoice) {
+  if (apiTransaction.transactionType > 0) {
+    return false
+  }
   if ([
     /^.*на "чужие" карты.*$/i,
     /^.*Пополнение вклада.*$/i,


### PR DESCRIPTION
Исправлена дедупликация и классификация операций в sberbank-by.

Что изменено:

 - перед конвертацией добавлена дедупликация API-операций по устойчивому ключу;
 - ключ строится с учётом rrnCode / souRnnCode, authorizationCode, account-level eventId, карты, даты, суммы, валюты и названия операции;
 - если bank API отдаёт hold и posted вариант одной операции, posted получает приоритет;
 - после конвертации добавлена дополнительная дедупликация по movement id / account / сумме / дате;
 - сохранены отдельные операции, которые банк действительно отдаёт разными eventId — например два одинаковых ERIP-зачисления;
 - входящие P2P-зачисления больше не получают transfer groupKeys;
 - входящие операции Зачисление ... на "чужие" карты и Перевод ... на "чужие" карты больше не превращаются в -N +N transfer;
 - исходящие внешние переводы и снятие наличных остаются transfer/cash сценариями.

Тесты добавлены/обновлены для:

 - hold → posted replacement;
 - matching cleared rows by reference;
 - сохранения двух отдельных ERIP credits;
 - входящего P2P, который не должен склеиваться с matching debit;
 - входящих P2P-зачислений как обычного income.