### PR TITLE
[raiffeisen-business-rs] переиспользование сессии, чтобы не запрашивать 2FA при каждой синхронизации

### DIFF
--- a/src/plugins/raiffeisen-business-rs/index.ts
+++ b/src/plugins/raiffeisen-business-rs/index.ts
@@ -7,18 +7,45 @@ import {
   setLegalEntity
 } from './fetchApi'
 import { convertAccounts, convertTransactions } from './converters'
-import { Auth, GetAccountTransactionsResponse, LegalEntitiesResponse, Preferences, RaiffAccount } from './models'
+import {
+  Auth,
+  AccountBalanceResponse,
+  GetAccountTransactionsResponse,
+  LegalEntity,
+  LegalEntitiesResponse,
+  LegalEntitySession,
+  Preferences,
+  RaiffAccount
+} from './models'
 
-export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
-  toDate = toDate ?? new Date()
+const STORED_SESSIONS_KEY = 'sessions'
+
+async function tryRestoreSessions (
+  sessions: LegalEntitySession[]
+): Promise<Array<{ legalEntity: LegalEntity, auth: Auth, fetchedAccounts: AccountBalanceResponse[] }> | null> {
+  if (sessions.length === 0) {
+    return null
+  }
+  const restored: Array<{ legalEntity: LegalEntity, auth: Auth, fetchedAccounts: AccountBalanceResponse[] }> = []
+  for (const session of sessions) {
+    try {
+      const fetchedAccounts = await fetchAllAccounts(session.auth)
+      restored.push({ legalEntity: session.legalEntity, auth: session.auth, fetchedAccounts })
+    } catch (_) {
+      return null
+    }
+  }
+  return restored
+}
+
+async function performFullLogin (
+  preferences: Preferences
+): Promise<Array<{ legalEntity: LegalEntity, auth: Auth, fetchedAccounts: AccountBalanceResponse[] }>> {
   const authTicket = await getTicket(preferences)
   const legalEntitiesResponse: LegalEntitiesResponse = await getLegalEntities(authTicket, preferences.login)
-  const legalEntities = legalEntitiesResponse.PrincipalData
-  const activeEntities = legalEntities.filter(legalEntity => legalEntity.IsActive)
+  const activeEntities = legalEntitiesResponse.PrincipalData.filter(legalEntity => legalEntity.IsActive)
 
-  const accounts: RaiffAccount[] = []
-  const transactions: Transaction[] = []
-
+  const sessions: Array<{ legalEntity: LegalEntity, auth: Auth, fetchedAccounts: AccountBalanceResponse[] }> = []
   for (const legalEntity of activeEntities) {
     const auth: Auth = await setLegalEntity(
       legalEntity.LegalEntityID.toString(),
@@ -26,6 +53,30 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
       legalEntitiesResponse.Ticket
     )
     const fetchedAccounts = await fetchAllAccounts(auth)
+    sessions.push({ legalEntity, auth, fetchedAccounts })
+  }
+  return sessions
+}
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  toDate = toDate ?? new Date()
+
+  const storedSessions = (ZenMoney.getData(STORED_SESSIONS_KEY, []) as LegalEntitySession[]) ?? []
+  let entitySessions = await tryRestoreSessions(storedSessions)
+  if (entitySessions === null) {
+    entitySessions = await performFullLogin(preferences)
+  }
+
+  ZenMoney.setData(
+    STORED_SESSIONS_KEY,
+    entitySessions.map(({ legalEntity, auth }) => ({ legalEntity, auth }))
+  )
+  ZenMoney.saveData()
+
+  const accounts: RaiffAccount[] = []
+  const transactions: Transaction[] = []
+
+  for (const { auth, fetchedAccounts } of entitySessions) {
     accounts.push(...convertAccounts(fetchedAccounts))
 
     const apiTransactions: GetAccountTransactionsResponse[] = []

--- a/src/plugins/raiffeisen-business-rs/models.ts
+++ b/src/plugins/raiffeisen-business-rs/models.ts
@@ -5,6 +5,11 @@ export interface Auth {
   cookie: string
 }
 
+export interface LegalEntitySession {
+  legalEntity: LegalEntity
+  auth: Auth
+}
+
 // Input preferences from schema in preferences.xml
 export interface Preferences {
   login: string


### PR DESCRIPTION
После того как #1009 был замёржен, плагин работает, но банк требует подтверждение push 2FA в мобильном приложении при **каждой** синхронизации, потому что `GetLegalEntities` всегда возвращает `ForceSecondLogin: true` и плагин каждый раз заново проходит полный логин.

Closes #1039.

## Что сделано

- **index.ts** — после успешного логина cookies каждой legal entity сохраняются через `ZenMoney.setData('sessions', ...)`. В начале следующей синхронизации плагин пробует сразу вызвать `fetchAllAccounts` с сохранёнными cookies; если запрос проходит — весь логин (`getTicket → getLegalEntities → push 2FA → setLegalEntity`) пропускается. Если сохранённая сессия истекла — откат к обычному полному логину (одно подтверждение 2FA), и новые cookies сохраняются.
- **models.ts** — добавлен тип `LegalEntitySession` для сохраняемой структуры.

Cookies сессии у банка живут достаточно долго, так что обычные синхронизации в течение дня не должны вообще требовать подтверждения в приложении.

## Тестирование

- `ts-standard` — без ошибок
- `tsc --noEmit` — без ошибок
- Существующие unit-тесты `raiffeisen-business-rs` проходят
- Боевой тест с реальным банком:
  - Фаза 1 (полный логин): получен ticket, прошла push 2FA, `SetLegalEntityWeb` вернул cookies, `fetchAllAccounts` успешно получил счета
  - Фаза 2 (имитация следующей синхронизации с сохранёнными cookies, без новых credentials): `fetchAllAccounts` успешно получил те же 2 счёта **без** запроса 2FA в мобильном приложении