### PR TITLE
[priorbank] fix: add maintenance mode to known bank errors; guard null salt

### DIFF
--- a/src/plugins/priorbank/__tests__/index.login.test.js
+++ b/src/plugins/priorbank/__tests__/index.login.test.js
@@ -1,9 +1,10 @@
 import fetchMock from 'fetch-mock'
-import { InvalidLoginOrPasswordError } from '../../../errors'
+import { BankMessageError, InvalidLoginOrPasswordError } from '../../../errors'
 import { installFetchMockDeveloperFriendlyFallback } from '../../../testUtils'
 import { makePluginDataApi } from '../../../ZPAPI.pluginData'
 import { scrape } from '../index'
 import { mockGetSalt, mockLogin, mockMobileToken } from '../mocks'
+import { calculatePasswordHash, calculatePassword2Hash } from '../prior'
 
 installFetchMockDeveloperFriendlyFallback(fetchMock)
 
@@ -70,4 +71,117 @@ test('throws credentials mismatch as InvalidPreferencesError', async () => {
     toDate: new Date('2018-12-07T12:00:00Z')
   })
   await expect(result).rejects.toBeInstanceOf(InvalidLoginOrPasswordError)
+})
+
+test('throws BankMessageError for unknown maintenance error message', async () => {
+  const login = 'test(login)'
+  const password = 'test(password)'
+  const accessToken = 'test(access_token)'
+  const tokenType = 'bearer'
+  const clientSecret = 'test(client_secret)'
+  const salt = 'saltsaltsaltsaltsaltsaltsaltsalt'
+
+  global.ZenMoney = {
+    isAccountSkipped: () => false,
+    ...makePluginDataApi({}).methods
+  }
+
+  mockMobileToken({
+    response: {
+      access_token: accessToken,
+      token_type: tokenType,
+      client_secret: clientSecret
+    }
+  })
+
+  mockGetSalt({
+    tokenType,
+    accessToken,
+    clientSecret,
+    login,
+    response: {
+      success: true,
+      errorMessage: '',
+      internalErrorCode: 0,
+      externalErrorCode: '',
+      token: false,
+      tokenFields: null,
+      result: { salt }
+    }
+  })
+
+  const hash = calculatePasswordHash({ loginSalt: salt, password })
+  const hash2 = calculatePassword2Hash({ loginSalt: salt, password })
+
+  mockLogin({
+    tokenType,
+    accessToken,
+    clientSecret,
+    login,
+    hash,
+    hash2,
+    response: {
+      status: 200,
+      body: {
+        success: false,
+        errorMessage: 'Подключение к системе в данный момент запрещено. На сайте ведутся технические работы',
+        internalErrorCode: 0,
+        externalErrorCode: '-20900',
+        token: false,
+        tokenFields: null,
+        result: null
+      }
+    }
+  })
+
+  const result = scrape({
+    preferences: { login, password },
+    fromDate: new Date('2018-12-01T12:00:00Z'),
+    toDate: new Date('2018-12-07T12:00:00Z')
+  })
+  await expect(result).rejects.toBeInstanceOf(BankMessageError)
+})
+
+test('throws BankMessageError when GetSalt returns no salt', async () => {
+  const login = 'test(login)'
+  const password = 'test(password)'
+  const accessToken = 'test(access_token)'
+  const tokenType = 'bearer'
+  const clientSecret = 'test(client_secret)'
+
+  global.ZenMoney = {
+    isAccountSkipped: () => false,
+    ...makePluginDataApi({}).methods
+  }
+
+  mockMobileToken({
+    response: {
+      access_token: accessToken,
+      token_type: tokenType,
+      client_secret: clientSecret
+    }
+  })
+
+  mockGetSalt({
+    tokenType,
+    accessToken,
+    clientSecret,
+    login,
+    response: {
+      success: true,
+      errorMessage: '',
+      internalErrorCode: 0,
+      externalErrorCode: '',
+      token: false,
+      tokenFields: null,
+      result: {}
+    }
+  })
+
+  const result = scrape({
+    preferences: { login, password },
+    fromDate: new Date('2018-12-01T12:00:00Z'),
+    toDate: new Date('2018-12-07T12:00:00Z')
+  })
+  await expect(result).rejects.toBeInstanceOf(BankMessageError)
 })

--- a/src/plugins/priorbank/__tests__/index.login.test.js
+++ b/src/plugins/priorbank/__tests__/index.login.test.js
@@ -73,7 +73,7 @@ test('throws credentials mismatch as InvalidPreferencesError', async () => {
   await expect(result).rejects.toBeInstanceOf(InvalidLoginOrPasswordError)
 })
 
-test('throws BankMessageError for unknown maintenance error message', async () => {
+test('throws BankMessageError for maintenance mode error message', async () => {
   const login = 'test(login)'
   const password = 'test(password)'
   const accessToken = 'test(access_token)'

--- a/src/plugins/priorbank/prior.js
+++ b/src/plugins/priorbank/prior.js
@@ -16,7 +16,8 @@ export function assertResponseSuccess (response) {
     if ([
       'Услуга временно заблокирована',
       'Услуга заблокирована до активации',
-      'Ошибка на сервере'
+      'Ошибка на сервере',
+      'технические работы'
     ].some(pattern => message.indexOf(pattern) >= 0)) {
       throw new BankMessageError(message)
     }
@@ -54,7 +55,11 @@ export async function getSalt ({ authAccessToken, clientSecret, login }) {
   })
   assertResponseSuccess(response)
 
-  return response.body.result.salt
+  const salt = response.body.result && response.body.result.salt
+  if (!salt) {
+    throw new BankMessageError('GetSalt: salt value not returned by server')
+  }
+  return salt
 }
 
 export const calculatePasswordHash = ({ loginSalt, password }) => {


### PR DESCRIPTION
## Problem

Two bugs that cause crashes instead of user-friendly error messages:

**1. `assertResponseSuccess` missing maintenance mode in known-message list**

The function has an allowlist of known bank messages that get shown to the user as `BankMessageError`. When the bank enters maintenance mode, it returns:

```
{ success: false, errorMessage: "Подключение к системе в данный момент запрещено. На сайте ведутся технические работы", externalErrorCode: "-20900" }
```

This message wasn't in the list, so the function fell through to `console.assert`, which **does not throw** in Node.js/Bun. Execution continued with `success: false` and crashed downstream with `TypeError: Cannot read property 'access_token' of null`.

**Why the allowlist (not a catch-all):** `BankMessageError extends TemporaryError` with `logIsNotImportant=true`, which hides the "Send log" button in ZenMoney UI. The list is a semantic gate: only curated, user-friendly bank messages should suppress log reporting. A catch-all would silently promote any unknown `errorMessage` (including internal error codes or stack traces) to a "safe bank message", hiding real bugs.

**2. `getSalt` returns `undefined` when `result` has no `salt` field**

`return response.body.result.salt` passes `undefined` to `calculatePassword2Hash`, which crashes:
> `The 'data' argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received undefined`

## Fix

- `assertResponseSuccess`: add `'технические работы'` to the known-message allowlist (substring match)
- `getSalt`: null-guard `result.salt` before returning, throw `BankMessageError` if missing

## Tests

Two regression tests in `__tests__/index.login.test.js`:
- maintenance mode error on Login → throws `BankMessageError`
- empty `result` from GetSalt → throws `BankMessageError`