### PR TITLE
[belinvestbank]: Стабильные ID и корректные интервалы истории

### DIFF
--- a/src/plugins/belinvestbank/__tests__/api.test.js
+++ b/src/plugins/belinvestbank/__tests__/api.test.js
@@ -1,16 +1,31 @@
 import { createDateIntervals } from '../api'
 
+function toDateRange (intervals) {
+  return intervals.map(([fromDate, toDate]) => ([
+    [fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate(), fromDate.getHours(), fromDate.getMinutes(), fromDate.getSeconds(), fromDate.getMilliseconds()],
+    [toDate.getFullYear(), toDate.getMonth(), toDate.getDate(), toDate.getHours(), toDate.getMinutes(), toDate.getSeconds(), toDate.getMilliseconds()]
+  ]))
+}
+
 describe('createDateIntervals', () => {
-  it('should convert date period', () => {
-    expect(
+  it('should split date period by whole days without overlap', () => {
+    expect(toDateRange(
       createDateIntervals(new Date('2018-01-01T20:45+03:00'), new Date('2018-02-05T09:00+03:00'))
-    ).toEqual(
-      [
-        [new Date('2018-01-01T20:45:00+03:00'), new Date('2018-01-11T20:44:59.999+03:00')],
-        [new Date('2018-01-11T20:45:00+03:00'), new Date('2018-01-21T20:44:59.999+03:00')],
-        [new Date('2018-01-21T20:45:00+03:00'), new Date('2018-01-31T20:44:59.999+03:00')],
-        [new Date('2018-01-31T20:45:00+03:00'), new Date('2018-02-05T09:00:00.000+03:00')]
-      ]
-    )
+    )).toEqual([
+      [[2018, 0, 1, 0, 0, 0, 0], [2018, 0, 10, 23, 59, 59, 999]],
+      [[2018, 0, 11, 0, 0, 0, 0], [2018, 0, 20, 23, 59, 59, 999]],
+      [[2018, 0, 21, 0, 0, 0, 0], [2018, 0, 30, 23, 59, 59, 999]],
+      [[2018, 0, 31, 0, 0, 0, 0], [2018, 1, 5, 23, 59, 59, 999]]
+    ])
+  })
+
+  it('should not reuse the same formatted day for adjacent UTC-based intervals', () => {
+    expect(toDateRange(
+      createDateIntervals(new Date('2026-01-01T00:00:00Z'), new Date('2026-01-25T00:00:00Z'))
+    )).toEqual([
+      [[2026, 0, 1, 0, 0, 0, 0], [2026, 0, 10, 23, 59, 59, 999]],
+      [[2026, 0, 11, 0, 0, 0, 0], [2026, 0, 20, 23, 59, 59, 999]],
+      [[2026, 0, 21, 0, 0, 0, 0], [2026, 0, 25, 23, 59, 59, 999]]
+    ])
   })
 })

--- a/src/plugins/belinvestbank/__tests__/converters/transactions.test.js
+++ b/src/plugins/belinvestbank/__tests__/converters/transactions.test.js
@@ -502,6 +502,62 @@ describe('convertTransaction', () => {
     expect(updatedTransaction.movements[0].id).toBe(transaction.movements[0].id)
   })
 
+  it('keeps movement id stable when bank history key changes for the same app id', () => {
+    const apiTransaction = {
+      date: '2021-07-15 12:35:13',
+      type: 'Оплата',
+      cardAcceptor: 'GOOGLE*CLOUDMOSA INC>INTERNET US',
+      transactionAmt: '1',
+      transactionAmtCurrency: 'USD',
+      accountAmt: '2,57',
+      accountAmtCurrency: 'BYN',
+      status: 'ПРОВЕДЕНО',
+      sign: '-',
+      mcc: '7372',
+      cardNum: '**** 2272',
+      appId: '332785',
+      historyKey: 9
+    }
+
+    const transaction = convertTransaction(apiTransaction, account)
+    const updatedTransaction = convertTransaction({
+      ...apiTransaction,
+      historyKey: 10
+    }, account)
+
+    expect(updatedTransaction.movements[0].id).toBe(transaction.movements[0].id)
+  })
+
+  it('keeps movement id stable when a blocked transaction clears', () => {
+    const apiTransaction = {
+      date: '2021-07-15 12:35:13',
+      type: 'Оплата',
+      cardAcceptor: 'GOOGLE*CLOUDMOSA INC>INTERNET US',
+      transactionAmt: '1',
+      transactionAmtCurrency: 'USD',
+      accountAmt: '2,57',
+      accountAmtCurrency: 'BYN',
+      status: 'ЗАБЛОКИРОВАНО',
+      sign: '-',
+      mcc: '7372',
+      cardNum: '**** 2272',
+      appId: '332785',
+      historyKey: 9
+    }
+
+    const holdTransaction = convertTransaction(apiTransaction, account)
+    const postedTransaction = convertTransaction({
+      ...apiTransaction,
+      status: 'ПРОВЕДЕНО',
+      reflectedAccountAmt: '2,57',
+      historyKey: 10
+    }, account)
+
+    expect(holdTransaction.hold).toBe(true)
+    expect(postedTransaction.hold).toBe(false)
+    expect(postedTransaction.movements[0].id).toBe(holdTransaction.movements[0].id)
+  })
+
   it('uses different movement ids for different bank history keys', () => {
     const apiTransaction = {
       date: '2021-07-15 12:35:13',

--- a/src/plugins/belinvestbank/__tests__/converters/transactions.test.js
+++ b/src/plugins/belinvestbank/__tests__/converters/transactions.test.js
@@ -63,7 +63,7 @@ describe('convertTransaction', () => {
         date: new Date('2019-01-01T10:12:13+03:00'),
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             invoice: null,
             account: { id: '30848200' },
             sum: -10.13,
@@ -77,7 +77,7 @@ describe('convertTransaction', () => {
               type: 'cash'
             },
             fee: 0,
-            id: null,
+            id: expect.any(String),
             invoice: null,
             sum: 10.13
           }
@@ -120,7 +120,7 @@ describe('convertTransaction', () => {
         date: new Date('2019-01-01T10:12:13+03:00'),
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             invoice: null,
             account: { id: '30848200' },
             sum: -2.8,
@@ -161,7 +161,7 @@ describe('convertTransaction', () => {
         date: new Date('2019-07-19T11:35:17+03:00'),
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             invoice: null,
             account: { id: '30848200' },
             sum: -0.06,
@@ -211,7 +211,7 @@ describe('convertTransaction', () => {
         movements:
           [
             {
-              id: null,
+              id: expect.any(String),
               account: { id: '30848200' },
               invoice: null,
               sum: 50,
@@ -225,7 +225,7 @@ describe('convertTransaction', () => {
                 type: 'ccard'
               },
               fee: 0,
-              id: null,
+              id: expect.any(String),
               invoice: null,
               sum: -50
             }
@@ -268,7 +268,7 @@ describe('convertTransaction', () => {
         movements:
           [
             {
-              id: null,
+              id: expect.any(String),
               account: { id: '30848200' },
               invoice: null,
               sum: -79.23,
@@ -282,7 +282,7 @@ describe('convertTransaction', () => {
                 type: 'ccard'
               },
               fee: 0,
-              id: null,
+              id: expect.any(String),
               invoice: null,
               sum: 79.23
             }
@@ -330,7 +330,7 @@ describe('convertTransaction', () => {
         movements:
           [
             {
-              id: null,
+              id: expect.any(String),
               account: { id: '30848200' },
               invoice: null,
               sum: -15.73,
@@ -387,7 +387,7 @@ describe('convertTransaction', () => {
         movements:
           [
             {
-              id: null,
+              id: expect.any(String),
               account: { id: '30848200' },
               invoice: null,
               sum: -113.7,
@@ -443,7 +443,7 @@ describe('convertTransaction', () => {
         movements:
           [
             {
-              id: null,
+              id: expect.any(String),
               account: { id: '30848200' },
               invoice: null,
               sum: -2.57,
@@ -472,6 +472,60 @@ describe('convertTransaction', () => {
       expect(transaction).toEqual(tc.expectedTransaction)
     })
   }
+
+  it('keeps movement id stable when bank-provided text changes', () => {
+    const apiTransaction = {
+      date: '2021-07-15 12:35:13',
+      type: 'Оплата',
+      cardAcceptor: 'GOOGLE*CLOUDMOSA INC>INTERNET US',
+      transactionAmt: '1',
+      transactionAmtCurrency: 'USD',
+      accountAmt: '0.00',
+      accountAmtCurrency: 'BYN',
+      reflectedAccountAmt: '2,57',
+      status: 'ПРОВЕДЕНО',
+      sign: '-',
+      mcc: '7372',
+      cardNum: '**** 2272',
+      appId: '332785',
+      historyKey: 9
+    }
+
+    const transaction = convertTransaction(apiTransaction, account)
+    const updatedTransaction = convertTransaction({
+      ...apiTransaction,
+      cardAcceptor: 'GOOGLE*UPDATED NAME>INTERNET US',
+      mcc: '5812'
+    }, account)
+
+    expect(updatedTransaction.merchant).not.toEqual(transaction.merchant)
+    expect(updatedTransaction.movements[0].id).toBe(transaction.movements[0].id)
+  })
+
+  it('uses different movement ids for different bank history keys', () => {
+    const apiTransaction = {
+      date: '2021-07-15 12:35:13',
+      type: 'Оплата',
+      cardAcceptor: 'GOOGLE*CLOUDMOSA INC>INTERNET US',
+      transactionAmt: '1',
+      transactionAmtCurrency: 'USD',
+      accountAmt: '2,57',
+      accountAmtCurrency: 'BYN',
+      status: 'ПРОВЕДЕНО',
+      sign: '-',
+      mcc: '7372',
+      cardNum: '**** 2272',
+      historyKey: 9
+    }
+
+    const transaction = convertTransaction(apiTransaction, account)
+    const anotherTransaction = convertTransaction({
+      ...apiTransaction,
+      historyKey: 10
+    }, account)
+
+    expect(anotherTransaction.movements[0].id).not.toBe(transaction.movements[0].id)
+  })
 
   it.each([
     [
@@ -511,7 +565,7 @@ describe('convertTransaction', () => {
         movements:
           [
             {
-              id: null,
+              id: expect.any(String),
               account: { id: 'account1' },
               invoice: null,
               sum: 288.2,

--- a/src/plugins/belinvestbank/__tests__/index.test.js
+++ b/src/plugins/belinvestbank/__tests__/index.test.js
@@ -41,7 +41,7 @@ describe('scrape', () => {
         date: new Date('2026-01-01T10:12:13+03:00'),
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             invoice: null,
             account: { id: '30848200' },
             sum: 10.13,

--- a/src/plugins/belinvestbank/api.js
+++ b/src/plugins/belinvestbank/api.js
@@ -305,13 +305,28 @@ function formatDate (date) {
   return ('0' + date.getDate()).slice(-2) + '.' + ('0' + (date.getMonth() + 1)).slice(-2) + '.' + date.getFullYear()
 }
 
+function getStartOfDay (date) {
+  const normalizedDate = new Date(date)
+  normalizedDate.setHours(0, 0, 0, 0)
+  return normalizedDate
+}
+
+function getEndOfDay (date) {
+  const normalizedDate = getStartOfDay(date)
+  normalizedDate.setDate(normalizedDate.getDate() + 1)
+  normalizedDate.setMilliseconds(-1)
+  return normalizedDate
+}
+
 export function createDateIntervals (fromDate, toDate) {
-  const interval = 10 * 24 * 60 * 60 * 1000 // 10 days interval for fetching data
+  const firstDay = getStartOfDay(fromDate)
+  const lastDay = getEndOfDay(toDate)
+  const intervalDays = 10
   const gapMs = 1
   return commonCreateDateIntervals({
-    fromDate,
-    toDate,
-    addIntervalToDate: date => new Date(date.getTime() + interval - gapMs),
+    fromDate: firstDay,
+    toDate: lastDay,
+    addIntervalToDate: date => getEndOfDay(new Date(date.getFullYear(), date.getMonth(), date.getDate() + intervalDays - 1)),
     gapMs
   })
 }

--- a/src/plugins/belinvestbank/converters.js
+++ b/src/plugins/belinvestbank/converters.js
@@ -220,12 +220,12 @@ function getMovementId (account, transactionKey, movementType) {
 }
 
 function getTransactionKey (json) {
-  if (json.historyKey !== undefined && json.historyKey !== null && String(json.historyKey).trim() !== '') {
-    return joinIdParts(['history', json.cardNum, json.date, json.historyKey])
-  }
-
   if (json.appId !== undefined && json.appId !== null && String(json.appId).trim() !== '' && String(json.appId).trim() !== '—') {
     return joinIdParts(['app', json.appId])
+  }
+
+  if (json.historyKey !== undefined && json.historyKey !== null && String(json.historyKey).trim() !== '') {
+    return joinIdParts(['history', json.cardNum, json.date, json.historyKey])
   }
 
   return joinIdParts([

--- a/src/plugins/belinvestbank/converters.js
+++ b/src/plugins/belinvestbank/converters.js
@@ -61,12 +61,13 @@ export function convertTransaction (json, account) {
 
   const sum = getSumAmount(json)
   if (sum === 0) return null
+  const transactionKey = getTransactionKey(json)
 
   const transaction = {
     date: getDate(json.date),
     movements: [
       {
-        id: null,
+        id: getMovementId(account, transactionKey, 'card'),
         account: { id: account.id },
         invoice: null,
         sum,
@@ -118,7 +119,7 @@ function parseCash (transaction, json) {
   if (json.type === 'Выдача наличных') {
     // добавим вторую часть перевода
     transaction.movements.push({
-      id: null,
+      id: getMovementId(transaction.movements[0].account, getTransactionKey(json), 'cash'),
       account: {
         company: null,
         type: 'cash',
@@ -196,7 +197,7 @@ function getSumAmount (json) {
 function makeOuterTransfer (transaction, json) {
   transaction.merchant = null
   transaction.movements.push({
-    id: null,
+    id: getMovementId(transaction.movements[0].account, getTransactionKey(json), 'ccard'),
     account: {
       company: null,
       type: 'ccard',
@@ -212,4 +213,38 @@ function makeOuterTransfer (transaction, json) {
 export function getDate (str) {
   const [year, month, day, hour, minute, second] = str.match(/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/).slice(1)
   return new Date(`${year}-${month}-${day}T${hour}:${minute}:${second}+03:00`)
+}
+
+function getMovementId (account, transactionKey, movementType) {
+  return ['belinvestbank', account.id, movementType, transactionKey].join(':')
+}
+
+function getTransactionKey (json) {
+  if (json.historyKey !== undefined && json.historyKey !== null && String(json.historyKey).trim() !== '') {
+    return joinIdParts(['history', json.cardNum, json.date, json.historyKey])
+  }
+
+  if (json.appId !== undefined && json.appId !== null && String(json.appId).trim() !== '' && String(json.appId).trim() !== '—') {
+    return joinIdParts(['app', json.appId])
+  }
+
+  return joinIdParts([
+    'fallback',
+    json.cardNum,
+    json.date,
+    json.type,
+    json.sign,
+    json.accountAmt,
+    json.accountAmtCurrency,
+    json.transactionAmt,
+    json.transactionAmtCurrency
+  ])
+}
+
+function joinIdParts (parts) {
+  return parts.map(normalizeIdPart).join(':')
+}
+
+function normalizeIdPart (part) {
+  return String(part ?? '').trim().replace(/\s+/g, ' ')
 }


### PR DESCRIPTION
Исправлена стабильность ID и разбиение истории в belinvestbank.

Что изменено:

 - интервалы загрузки истории теперь нормализуются на полные календарные дни;
 - соседние интервалы больше не переиспользуют одну и ту же дату при форматировании для bank API;
 - у движений появились stable movement IDs вместо null;
 - ID строится от appId, если он есть;
 - если appId нет, используется fallback через historyKey, карту, дату и параметры операции;
 - для cash/outer-transfer вторых движений тоже формируются отдельные стабильные IDs;
 - текст мерчанта и MCC не участвуют в primary ID, чтобы изменение банковского текста не создавало новую операцию;
 - при одинаковом appId изменение historyKey не меняет ID;
 - при отсутствии appId разные historyKey остаются разными операциями.

Тесты добавлены/обновлены для:

 - whole-day interval splitting без overlap;
 - UTC-based соседних интервалов без повторного дня;
 - стабильности ID при изменении банковского текста;
 - стабильности ID при изменении historyKey для того же appId;
 - hold/blocked → posted сценария;
 - различения операций с разными historyKey.