### PR TITLE
[bgpb]: Поддержка депозитов, истории и стабильных ID

### DIFF
--- a/src/plugins/bgpb/__tests__/converters/accounts.test.js
+++ b/src/plugins/bgpb/__tests__/converters/accounts.test.js
@@ -1,4 +1,5 @@
 import { convertAccount } from '../../converters'
+import { ZPAPI } from '../../../../ZPAPI'
 
 describe('convertAccount', () => {
   beforeEach(() => {
@@ -21,6 +22,7 @@ describe('convertAccount', () => {
     expect(convertAccount(bankCard)).toEqual({
       id: '11161311',
       transactionsAccId: null,
+      conditionsAccId: null,
       type: 'card',
       title: 'Расчетная карточка*1111',
       currencyCode: '840',
@@ -28,9 +30,60 @@ describe('convertAccount', () => {
       instrument: 'USD',
       balance: 0,
       syncID: ['1111'],
+      bankId: 'cb727d83-2d8a-4c54-898f-6d45f0eba713',
       productId: '11161311-117d11',
       productType: 'MS'
     })
+  })
+
+  it('maps deposit to zenmoney one', () => {
+    const deposit = {
+      Id: '28180546-ad468b',
+      No: 'BY44OLMP34140000000800598636',
+      ProductType: 'DEPOSIT',
+      ProductTypeName: 'Номер счёта',
+      Currency: '933',
+      CustomName: 'мой депозит',
+      Opened: '20260130',
+      Expired: '20290228',
+      Balance: '3 085,85',
+      Extra: {
+        InterestRate: '15.1% годовых'
+      },
+      Group: {
+        Name: 'Ещё',
+        Action: [
+          { Id: 'statement-action', Type: 'itwg:OperationTxt3', Name: 'Выписка' },
+          { Id: 'conditions-action', Type: 'itwg:Conditions2', Name: 'Условия обслуживания' }
+        ]
+      }
+    }
+
+    expect(convertAccount(deposit)).toEqual({
+      id: '28180546',
+      transactionsAccId: 'statement-action',
+      conditionsAccId: 'conditions-action',
+      type: 'deposit',
+      title: 'мой депозит*8636',
+      currencyCode: '933',
+      cardNumber: 'BY44OLMP34140000000800598636',
+      instrument: 'BYN',
+      balance: 3085.85,
+      syncID: ['BY44OLMP34140000000800598636'],
+      startDate: new Date('2026-01-30T00:00:00.000Z'),
+      startBalance: 3085.85,
+      percent: 15.1,
+      capitalization: true,
+      payoffInterval: 'month',
+      payoffStep: 1,
+      endDateOffset: 1125,
+      endDateOffsetInterval: 'day',
+      productId: '28180546-ad468b',
+      productType: 'DEPOSIT'
+    })
+
+    const api = new ZPAPI({ manifest: {}, preferences: {}, data: {} })
+    expect(() => api.addAccount(convertAccount(deposit))).not.toThrow()
   })
 
   it('maps skipped card to nothing', () => {

--- a/src/plugins/bgpb/__tests__/converters/transactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions.test.js
@@ -202,6 +202,35 @@ describe('convertTransaction', () => {
       expect(transaction).toEqual(tc.expectedTransaction)
     })
   }
+
+  it('deposit statement row', () => {
+    expect(convertTransaction({
+      statementType: 'deposit',
+      date: '03.02.2026',
+      description: 'Пополнение вклада',
+      income: '400,00',
+      outcome: '',
+      balance: '900,00',
+      currency: 'BYN'
+    }, {
+      id: 'deposit-account',
+      instrument: 'BYN'
+    })).toEqual({
+      date: new Date('2026-02-02T21:00:00.000Z'),
+      movements: [
+        {
+          id: null,
+          account: { id: 'deposit-account' },
+          invoice: null,
+          sum: 400,
+          fee: 0
+        }
+      ],
+      merchant: null,
+      comment: 'Пополнение вклада',
+      hold: false
+    })
+  })
 })
 
 describe('convertLastTransaction', () => {

--- a/src/plugins/bgpb/__tests__/converters/transactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions.test.js
@@ -13,7 +13,7 @@ function withNullMovementIds (transaction) {
   }
 }
 
-function expectMovementIds(transaction) {
+function expectMovementIds (transaction) {
   expect(transaction.movements.every(movement => typeof movement.id === 'string' && movement.id.length > 0)).toBe(true)
 }
 

--- a/src/plugins/bgpb/__tests__/converters/transactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions.test.js
@@ -712,4 +712,126 @@ describe('convertLastTransaction', () => {
 
     expect(statementTransaction.movements[0].id).toBe(historyTransaction.movements[0].id)
   })
+
+  it('keeps movement id stable when matching statement and history text differs', () => {
+    const account = {
+      id: 'account',
+      instrument: 'BYN',
+      bankId: '4026868',
+      syncID: ['1111']
+    }
+
+    const statementTransaction = convertTransaction({
+      amount: '250,00',
+      amountReal: '250,00',
+      authCode: '185665',
+      cardNum: '1111',
+      currency: 'BYN',
+      currencyReal: 'BYN',
+      date: '15.05.2026 10:55',
+      description: 'PEREVOD (SPISANIE)',
+      mcc: '6012',
+      place: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)',
+      type: 'СПИСАНИЕ'
+    }, account)
+    const historyTransaction = convertLastTransaction({
+      orderNumber: '3289575665',
+      bankId: '4026868',
+      direction: 'outgoing',
+      date: '2026-05-15T10:55:51+0300',
+      totalAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      currencyAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      status: 'success',
+      terminal: 'ERIP MOBILE TRANSFER',
+      pan: '518597******1111',
+      transType: 781,
+      transTypeDesc: 'Card transfer',
+      authCode: '185665',
+      mcc: 6012,
+      reversal: 0
+    }, [account])
+
+    expect(statementTransaction.movements[0].id).toBe(historyTransaction.movements[0].id)
+  })
+
+  it('keeps movement id stable when a history operation clears', () => {
+    const account = {
+      id: 'account',
+      instrument: 'BYN',
+      bankId: '4026868',
+      syncID: ['1111']
+    }
+    const apiTransaction = {
+      orderNumber: '3289575665',
+      bankId: '4026868',
+      direction: 'outgoing',
+      date: '2026-05-15T10:55:51+0300',
+      totalAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      currencyAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      terminal: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)',
+      pan: '518597******1111',
+      transType: 781,
+      transTypeDesc: 'PEREVOD (SPISANIE)',
+      authCode: '185665',
+      mcc: 6012,
+      reversal: 0
+    }
+
+    const holdTransaction = convertLastTransaction({
+      ...apiTransaction,
+      status: 'pending'
+    }, [account])
+    const postedTransaction = convertLastTransaction({
+      ...apiTransaction,
+      status: 'success'
+    }, [account])
+
+    expect(holdTransaction.hold).toBe(true)
+    expect(postedTransaction.hold).toBe(false)
+    expect(holdTransaction.movements[0].id).toBe(postedTransaction.movements[0].id)
+  })
+
+  it('skips reversed history operations', () => {
+    const transaction = convertLastTransaction({
+      orderNumber: '3289575665',
+      bankId: '4026868',
+      direction: 'outgoing',
+      date: '2026-05-15T10:55:51+0300',
+      totalAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      currencyAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      status: 'success',
+      terminal: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)',
+      pan: '518597******1111',
+      transType: 781,
+      transTypeDesc: 'PEREVOD (SPISANIE)',
+      authCode: '185665',
+      mcc: 6012,
+      reversal: 1
+    }, [{
+      id: 'account',
+      instrument: 'BYN',
+      bankId: '4026868',
+      syncID: ['1111']
+    }])
+
+    expect(transaction).toBeNull()
+  })
 })

--- a/src/plugins/bgpb/__tests__/converters/transactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions.test.js
@@ -1,5 +1,22 @@
 import { convertLastTransaction, convertTransaction } from '../../converters'
 
+function withNullMovementIds (transaction) {
+  if (!transaction) {
+    return transaction
+  }
+  return {
+    ...transaction,
+    movements: transaction.movements.map(movement => ({
+      ...movement,
+      id: null
+    }))
+  }
+}
+
+function expectMovementIds(transaction) {
+  expect(transaction.movements.every(movement => typeof movement.id === 'string' && movement.id.length > 0)).toBe(true)
+}
+
 describe('convertTransaction', () => {
   const account = {
     id: '11161311-117d11',
@@ -199,12 +216,13 @@ describe('convertTransaction', () => {
     it(tc.name, () => {
       const transaction = convertTransaction(tc.transaction, account)
 
-      expect(transaction).toEqual(tc.expectedTransaction)
+      expectMovementIds(transaction)
+      expect(withNullMovementIds(transaction)).toEqual(tc.expectedTransaction)
     })
   }
 
   it('deposit statement row', () => {
-    expect(convertTransaction({
+    const transaction = convertTransaction({
       statementType: 'deposit',
       date: '03.02.2026',
       description: 'Пополнение вклада',
@@ -215,7 +233,10 @@ describe('convertTransaction', () => {
     }, {
       id: 'deposit-account',
       instrument: 'BYN'
-    })).toEqual({
+    })
+
+    expectMovementIds(transaction)
+    expect(withNullMovementIds(transaction)).toEqual({
       date: new Date('2026-02-02T21:00:00.000Z'),
       movements: [
         {
@@ -638,7 +659,57 @@ describe('convertLastTransaction', () => {
     it(tc.name, () => {
       const transaction = convertLastTransaction(tc.transaction, accounts)
 
-      expect(transaction).toEqual(tc.expectedTransaction)
+      if (transaction) {
+        expectMovementIds(transaction)
+      }
+      expect(withNullMovementIds(transaction)).toEqual(tc.expectedTransaction)
     })
   }
+
+  it('uses the same movement id for matching statement and history transactions', () => {
+    const account = {
+      id: 'account',
+      instrument: 'BYN',
+      bankId: '4026868',
+      syncID: ['1111']
+    }
+
+    const statementTransaction = convertTransaction({
+      amount: '250,00',
+      amountReal: '250,00',
+      authCode: '185665',
+      cardNum: '1111',
+      currency: 'BYN',
+      currencyReal: 'BYN',
+      date: '15.05.2026 10:55',
+      description: 'PEREVOD (SPISANIE)',
+      mcc: '6012',
+      place: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)',
+      type: 'СПИСАНИЕ'
+    }, account)
+    const historyTransaction = convertLastTransaction({
+      orderNumber: '3289575665',
+      bankId: '4026868',
+      direction: 'outgoing',
+      date: '2026-05-15T10:55:51+0300',
+      totalAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      currencyAmount: {
+        currency: 933,
+        amount: 25000
+      },
+      status: 'success',
+      terminal: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)',
+      pan: '518597******1111',
+      transType: 781,
+      transTypeDesc: 'PEREVOD (SPISANIE)',
+      authCode: '185665',
+      mcc: 6012,
+      reversal: 0
+    }, [account])
+
+    expect(statementTransaction.movements[0].id).toBe(historyTransaction.movements[0].id)
+  })
 })

--- a/src/plugins/bgpb/__tests__/converters/transactions/innerTransfer.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions/innerTransfer.test.js
@@ -1,5 +1,15 @@
 import { convertTransaction } from '../../../converters'
 
+function withNullMovementIds (transaction) {
+  return {
+    ...transaction,
+    movements: transaction.movements.map(movement => ({
+      ...movement,
+      id: null
+    }))
+  }
+}
+
 describe('convertTransaction', () => {
   it.each([
     [
@@ -81,6 +91,8 @@ describe('convertTransaction', () => {
       }
     ]
   ])('converts inner transfer', (apiTransaction, account, transaction) => {
-    expect(convertTransaction(apiTransaction, account)).toEqual(transaction)
+    const convertedTransaction = convertTransaction(apiTransaction, account)
+    expect(convertedTransaction.movements.every(movement => typeof movement.id === 'string' && movement.id.length > 0)).toBe(true)
+    expect(withNullMovementIds(convertedTransaction)).toEqual(transaction)
   })
 })

--- a/src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js
@@ -197,6 +197,59 @@ describe('convertLastTransaction', () => {
         }
       ],
       null
+    ],
+    [
+      {
+        orderNumber: '3289575665',
+        bankId: '4026868',
+        direction: 'outgoing',
+        date: '2026-05-15T10:55:51+0300',
+        totalAmount: {
+          currency: 933,
+          amount: 25000
+        },
+        currencyAmount: {
+          currency: 933,
+          amount: 25000
+        },
+        status: 'success',
+        terminal: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)',
+        pan: '518597******1111',
+        transType: 781,
+        transTypeDesc: 'PEREVOD (SPISANIE)',
+        authCode: '185665',
+        mcc: 6012,
+        reversal: 0
+      },
+      [
+        {
+          id: 'account',
+          instrument: 'BYN',
+          bankId: '4026868',
+          syncID: ['1111']
+        }
+      ],
+      {
+        date: new Date('2026-05-15T10:55:51+0300'),
+        movements:
+          [
+            {
+              id: null,
+              account: { id: 'account' },
+              invoice: null,
+              sum: -250,
+              fee: 0
+            }
+          ],
+        merchant:
+          {
+            mcc: 6012,
+            location: null,
+            fullTitle: 'ERIP_MOB.APP, EPOS, PEREVOD (SPISANIE)'
+          },
+        comment: 'PEREVOD (SPISANIE)',
+        hold: false
+      }
     ]
   ])('converts last transactions', (apiTransaction, accounts, transaction) => {
     expect(convertLastTransaction(apiTransaction, accounts)).toEqual(transaction)

--- a/src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js
@@ -1,5 +1,18 @@
 import { convertLastTransaction, convertTestLastTransactions } from '../../../converters'
 
+function withNullMovementIds (transaction) {
+  if (!transaction) {
+    return transaction
+  }
+  return {
+    ...transaction,
+    movements: transaction.movements.map(movement => ({
+      ...movement,
+      id: null
+    }))
+  }
+}
+
 describe('convertLastTransaction', () => {
   it.each([
     [
@@ -252,7 +265,11 @@ describe('convertLastTransaction', () => {
       }
     ]
   ])('converts last transactions', (apiTransaction, accounts, transaction) => {
-    expect(convertLastTransaction(apiTransaction, accounts)).toEqual(transaction)
+    const convertedTransaction = convertLastTransaction(apiTransaction, accounts)
+    if (convertedTransaction) {
+      expect(convertedTransaction.movements.every(movement => typeof movement.id === 'string' && movement.id.length > 0)).toBe(true)
+    }
+    expect(withNullMovementIds(convertedTransaction)).toEqual(transaction)
   })
 })
 
@@ -363,12 +380,14 @@ describe('convertLastTransactions', () => {
       []
     ]
   ])('converts last transactions', (apiTransactions, transactions) => {
-    expect(convertTestLastTransactions(apiTransactions, [
+    const convertedTransactions = convertTestLastTransactions(apiTransactions, [
       {
         id: 'account',
         instrument: 'BYN',
         syncID: ['1111']
       }
-    ])).toEqual(transactions)
+    ])
+    expect(convertedTransactions.every(transaction => transaction.movements.every(movement => typeof movement.id === 'string' && movement.id.length > 0))).toBe(true)
+    expect(convertedTransactions.map(withNullMovementIds)).toEqual(transactions)
   })
 })

--- a/src/plugins/bgpb/__tests__/parseTransactionAndOverdraft.test.js
+++ b/src/plugins/bgpb/__tests__/parseTransactionAndOverdraft.test.js
@@ -517,4 +517,80 @@ describe('parseTransactionAndOverdraft', () => {
   ])('parses transactions and overdraft', (mails, result) => {
     expect(parseTransactionsAndOverdraft(mails)).toEqual(result)
   })
+
+  it('parses deposit statement rows', () => {
+    const mails = [
+      `<?xml version="1.0" encoding="utf-8" ?>
+<BS_Response>
+  <MailAttachment>
+    <Attachment>
+      <Body Mimetype="text/html" xml:space="preserve"><![CDATA[
+        <html>
+          <head>
+            <title>Выписка по счету за период</title>
+          </head>
+          <body>
+            <table>
+              <tr>
+                <td>Дата</td>
+                <td>Операция</td>
+                <td>Приход</td>
+                <td>Расход</td>
+                <td>Остаток</td>
+                <td>Валюта</td>
+              </tr>
+              <tr>
+                <td align="left" colspan="4">Входящий остаток на 01.01.2026</td>
+                <td align="right">0,00</td>
+                <td align="center">BYN</td>
+              </tr>
+              <tr>
+                <td align="center">03.02.2026</td>
+                <td align="left">Пополнение вклада</td>
+                <td align="right">400,00</td>
+                <td align="right"></td>
+                <td align="right">900,00</td>
+                <td align="center">BYN</td>
+              </tr>
+              <tr>
+                <td align="center">28.02.2026</td>
+                <td align="left">Выплата накопленных процентов</td>
+                <td align="right">19,55</td>
+                <td align="right"></td>
+                <td align="right">919,55</td>
+                <td align="center">BYN</td>
+              </tr>
+            </table>
+          </body>
+        </html>
+      ]]></Body>
+    </Attachment>
+  </MailAttachment>
+</BS_Response>`
+    ]
+
+    expect(parseTransactionsAndOverdraft(mails, { type: 'deposit' })).toEqual({
+      overdraft: null,
+      transactions: [
+        {
+          statementType: 'deposit',
+          date: '03.02.2026',
+          description: 'Пополнение вклада',
+          income: '400,00',
+          outcome: '',
+          balance: '900,00',
+          currency: 'BYN'
+        },
+        {
+          statementType: 'deposit',
+          date: '28.02.2026',
+          description: 'Выплата накопленных процентов',
+          income: '19,55',
+          outcome: '',
+          balance: '919,55',
+          currency: 'BYN'
+        }
+      ]
+    })
+  })
 })

--- a/src/plugins/bgpb/api.js
+++ b/src/plugins/bgpb/api.js
@@ -17,6 +17,17 @@ const EXTRA_AUTH_REQUIRED_ERROR = 'Для выполнения действия 
 
 const SOU_ADMIN_ENDPOINT = 'sou2/xml_online.admin'
 const SOU_REQUEST_ENDPOINT = 'sou2/xml_online.request'
+const TERMINAL_CAPABILITIES_XML =
+  '   <TerminalCapabilities>\r\n' +
+  '       <LongParameter>Y</LongParameter>\r\n' +
+  '       <ScreenWidth>99</ScreenWidth>\r\n' +
+  '       <AnyAmount>Y</AnyAmount>\r\n' +
+  '       <BooleanParameter>Y</BooleanParameter>\r\n' +
+  '       <CheckWidth>39</CheckWidth>\r\n' +
+  '       <InputDataSources>\r\n' +
+  '           <InputDataSource>Lookup</InputDataSource>\r\n' +
+  '       </InputDataSources>\r\n' +
+  '   </TerminalCapabilities>\r\n'
 
 export function generateBoundary () {
   return generateRandomString(8) + '-' + generateRandomString(4) + '-' + generateRandomString(4) + '-' + generateRandomString(4) + '-' + generateRandomString(12)
@@ -25,6 +36,34 @@ export function generateBoundary () {
 export function terminalTime () {
   const now = new Date()
   return String(now.getFullYear()) + ('0' + (now.getMonth() + 1)).slice(-2) + ('0' + now.getDate()).slice(-2) + ('0' + now.getHours()).slice(-2) + ('0' + now.getMinutes()).slice(-2) + ('0' + now.getSeconds()).slice(-2)
+}
+
+function buildTerminalInfoXml () {
+  return `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
+    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n'
+}
+
+function buildSessionXml (sid) {
+  return '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n'
+}
+
+function buildMailAttachmentRequest (sid, mailId) {
+  return '<BS_Request>\r\n' +
+    '   <MailAttachment Id="' + mailId + '" No="0"/>\r\n' +
+    '   <RequestType>MailAttachment</RequestType>\r\n' +
+    buildSessionXml(sid) +
+    buildTerminalInfoXml() +
+    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+    TERMINAL_CAPABILITIES_XML +
+    '</BS_Request>\r\n'
+}
+
+async function fetchMailAttachment (sid, mailId) {
+  return await fetchApi(SOU_ADMIN_ENDPOINT,
+    buildMailAttachmentRequest(sid, mailId),
+    {},
+    response => true,
+    message => new InvalidPreferencesError(message))
 }
 
 async function fetchApi (url, xml, options, predicate = () => true, error = (message) => console.assert(false, message)) {
@@ -144,9 +183,8 @@ async function fetchProducts (sid, {
     '<BS_Request>\r\n' +
     `   <GetProducts ProductType="${productType}" GetActions="${getActions}" GetBalance="${getBalance}" IncludeHidden="${includeHidden}" GetGroupedActions="${getGroupedActions}" SortByGroups="${sortByGroups}"/>\r\n` +
     '   <RequestType>GetProducts</RequestType>\r\n' +
-    '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    buildSessionXml(sid) +
+    buildTerminalInfoXml() +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError(message))
 }
@@ -320,8 +358,7 @@ export async function login (login, password) {
     '      <Parameter Id="AppVersion">' + APP_VERSION + '</Parameter>\r\n' +
     '   </Login>\r\n' +
     '   <RequestType>Login</RequestType>\r\n' +
-    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    buildTerminalInfoXml() +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>\r\n', { sanitizeRequestLog: { body: true } }, response => true, message => new InvalidPreferencesError('Неверный логин или пароль'))
   if (res.BS_Response.Login && res.BS_Response.Login.SID) {
@@ -363,20 +400,10 @@ export async function fetchBalance (sid, account) {
     '<BS_Request>\r\n' +
     '   <Balance Currency="' + account.currencyCode + '"/>\r\n' +
     '   <RequestType>Balance</RequestType>\r\n' +
-    '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    buildSessionXml(sid) +
+    buildTerminalInfoXml() +
     '   <ClientId IdType="' + account.productType + '">' + account.cardNumber + '</ClientId>\r\n' +
-    '   <TerminalCapabilities>\r\n' +
-    '      <LongParameter>Y</LongParameter>\r\n' +
-    '      <ScreenWidth>99</ScreenWidth>\r\n' +
-    '      <AnyAmount>Y</AnyAmount>\r\n' +
-    '      <BooleanParameter>Y</BooleanParameter>\r\n' +
-    '      <CheckWidth>39</CheckWidth>\r\n' +
-    '      <InputDataSources>\r\n' +
-    '         <InputDataSource>Lookup</InputDataSource>\r\n' +
-    '      </InputDataSources>\r\n' +
-    '   </TerminalCapabilities>\r\n' +
+    TERMINAL_CAPABILITIES_XML +
     '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
   if (res === null) {
     return null
@@ -401,9 +428,8 @@ export async function fetchTransactionsAccId (sid, account) {
     '<BS_Request>\r\n' +
     '   <GetActions ProductId="' + account.productId + '"/>\r\n' +
     '   <RequestType>GetActions</RequestType>\r\n' +
-    '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    buildSessionXml(sid) +
+    buildTerminalInfoXml() +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
   if (res.BS_Response.GetActions && res.BS_Response.GetActions.Action) {
@@ -431,33 +457,13 @@ export async function fetchAccountConditions (sid, account) {
     '<BS_Request>\r\n' +
     '<ExecuteAction Id="' + account.conditionsAccId + '"/>\r\n' +
     '<RequestType>ExecuteAction</RequestType>\r\n' +
-    '<Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `<TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-    '<TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    buildSessionXml(sid) +
+    buildTerminalInfoXml() +
     '<Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>', {}, response => true, message => new InvalidPreferencesError('bad request'))
   const mailID = response.BS_Response.ExecuteAction.MailId
 
-  const mail = await fetchApi(SOU_ADMIN_ENDPOINT,
-    '<BS_Request>\r\n' +
-    '   <MailAttachment Id="' + mailID + '" No="0"/>\r\n' +
-    '   <RequestType>MailAttachment</RequestType>\r\n' +
-    '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
-    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-    '   <TerminalCapabilities>\r\n' +
-    '       <LongParameter>Y</LongParameter>\r\n' +
-    '       <ScreenWidth>99</ScreenWidth>\r\n' +
-    '       <AnyAmount>Y</AnyAmount>\r\n' +
-    '       <BooleanParameter>Y</BooleanParameter>\r\n' +
-    '       <CheckWidth>39</CheckWidth>\r\n' +
-    '       <InputDataSources>\r\n' +
-    '           <InputDataSource>Lookup</InputDataSource>\r\n' +
-    '       </InputDataSources>\r\n' +
-    '   </TerminalCapabilities>\r\n' +
-    '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
-
+  const mail = await fetchMailAttachment(sid, mailID)
   const data = mail.BS_Response.MailAttachment.Attachment
   return parseConditionsMail(data)
 }
@@ -570,9 +576,8 @@ export async function fetchFullTransactions (sid, account, fromDate, toDate = ne
         '      <Parameter Id="DateTill">' + transactionDate(date[1]) + '</Parameter>\r\n' +
         '   </ExecuteAction>\r\n' +
         '   <RequestType>ExecuteAction</RequestType>\r\n' +
-        '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-        `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-        '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+        buildSessionXml(sid) +
+        buildTerminalInfoXml() +
         '   <Subsystem>ClientAuth</Subsystem>\r\n' +
         '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
 
@@ -596,25 +601,7 @@ export async function fetchFullTransactions (sid, account, fromDate, toDate = ne
   const mails = []
   for (const mailId of mailIDs) {
     try {
-      mails.push(await fetchApi(SOU_ADMIN_ENDPOINT,
-        '<BS_Request>\r\n' +
-        '   <MailAttachment Id="' + mailId + '" No="0"/>\r\n' +
-        '   <RequestType>MailAttachment</RequestType>\r\n' +
-        '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-        `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
-        '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
-        '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-        '   <TerminalCapabilities>\r\n' +
-        '       <LongParameter>Y</LongParameter>\r\n' +
-        '       <ScreenWidth>99</ScreenWidth>\r\n' +
-        '       <AnyAmount>Y</AnyAmount>\r\n' +
-        '       <BooleanParameter>Y</BooleanParameter>\r\n' +
-        '       <CheckWidth>39</CheckWidth>\r\n' +
-        '       <InputDataSources>\r\n' +
-        '           <InputDataSource>Lookup</InputDataSource>\r\n' +
-        '       </InputDataSources>\r\n' +
-        '   </TerminalCapabilities>\r\n' +
-        '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request')))
+      mails.push(await fetchMailAttachment(sid, mailId))
     } catch (_error) {
       console.log(`>>> Не удалось загрузить вложение выписки для "${account.title}", пропускаем один интервал.`)
     }

--- a/src/plugins/bgpb/api.js
+++ b/src/plugins/bgpb/api.js
@@ -6,8 +6,14 @@ import { generateRandomString } from '../../common/utils'
 import { parseXml } from '../../common/xmlUtils'
 
 const BASE_URL = 'https://mobapp-frontend.bgpb.by/'
-const TERMINAL_ID = 41742969
-const APP_VERSION = '9.1.0'
+const TERMINAL_ID = 41742962
+const APP_VERSION = '1.5.0'
+const DEVICE_PLATFORM = 'Android 11'
+const PUSH_HISTORY_ENDPOINT = `push-history/api/android_${APP_VERSION}/v2/getHistory`
+const HISTORY_BASE_PATH = 'history/client/2/1/'
+const HISTORY_CONFIG_ENDPOINT = `${HISTORY_BASE_PATH}getConfig`
+const HISTORY_EXT_OPERATIONS_ENDPOINT = `${HISTORY_BASE_PATH}ext-operations`
+const EXTRA_AUTH_REQUIRED_ERROR = 'Для выполнения действия требуется дополнительная аутентификация'
 
 const SOU_ADMIN_ENDPOINT = 'sou2/xml_online.admin'
 const SOU_REQUEST_ENDPOINT = 'sou2/xml_online.request'
@@ -28,13 +34,13 @@ async function fetchApi (url, xml, options, predicate = () => true, error = (mes
 
   options.method = options.method ? options.method : 'POST'
   options.headers = {
-    'User-Agent': `BGPB mobile/${APP_VERSION} (Android; unknownAndroidSDKbuiltforx86; Android 10)`,
+    'User-Agent': `BGPB mobile/${APP_VERSION} (Android; unknownAndroidSDKbuiltforx86; ${DEVICE_PLATFORM})`,
     'Content-Type': 'multipart/form-data; boundary=' + boundary
   }
   options.body = boundaryStart +
     'Content-Disposition: form-data; name="XML"\r\n' +
     'Content-Transfer-Encoding: binary\r\n' +
-    'Content-Type: application/xml; charset=windows-1251\r\n' +
+    'Content-Type: application/xml; charset=UTF-8\r\n' +
     'Content-Length: ' + xml.length + '\r\n\r\n' +
     xml +
     boundaryLast
@@ -44,6 +50,10 @@ async function fetchApi (url, xml, options, predicate = () => true, error = (mes
     validateResponse(response, response => predicate(response), error)
   }
   const res = parseXml(response.body)
+
+  if (!res || !res.BS_Response) {
+    throw new TemporaryError('Ответ банка: получен некорректный ответ сервера')
+  }
 
   if (res.BS_Response.Error && res.BS_Response.Error.ErrorLine) {
     if (res.BS_Response.Error.ErrorLine === 'Ошибка авторизации: Баланс недоступен') {
@@ -76,9 +86,74 @@ function validateResponse (response, predicate, error) {
   }
 }
 
+function normalizeItems (item) {
+  if (!item) {
+    return []
+  }
+  return Array.isArray(item) ? item.filter(Boolean) : [item]
+}
+
+function normalizeProductsResponse (response) {
+  if (!response || !response.BS_Response || !response.BS_Response.GetProducts) {
+    return []
+  }
+  return normalizeItems(response.BS_Response.GetProducts.Product)
+}
+
+function getAttachmentHtml (attachment) {
+  if (!attachment) {
+    return ''
+  }
+  if (typeof attachment === 'string') {
+    return attachment
+  }
+  if (typeof attachment.Body === 'string') {
+    return attachment.Body
+  }
+  const $ = cheerio.load(attachment)
+  const root = $().children()[0]
+  const body = root && root.children && root.children[0] && root.children[0].Body
+  return typeof body === 'string' ? body : ''
+}
+
+function parseAmount (amount) {
+  if (amount === null || amount === undefined || amount === '') {
+    return null
+  }
+  const normalized = Number.parseFloat(String(amount).replace(',', '.').replace(/\s/g, ''))
+  return isNaN(normalized) ? null : normalized
+}
+
+function isStatementAction (action) {
+  return /operationtxt/i.test(action.Type || '') || /statement/i.test(action.Type || '') || action.Name === 'Выписка'
+}
+
+function isConditionsAction (action) {
+  return /conditions/i.test(action.Type || '') || action.Name === 'Условия обслуживания'
+}
+
+async function fetchProducts (sid, {
+  productType,
+  getActions = 'N',
+  getBalance = 'N',
+  includeHidden = 'N',
+  getGroupedActions = 'N',
+  sortByGroups = 'N'
+}) {
+  return await fetchApi(SOU_ADMIN_ENDPOINT,
+    '<BS_Request>\r\n' +
+    `   <GetProducts ProductType="${productType}" GetActions="${getActions}" GetBalance="${getBalance}" IncludeHidden="${includeHidden}" GetGroupedActions="${getGroupedActions}" SortByGroups="${sortByGroups}"/>\r\n` +
+    '   <RequestType>GetProducts</RequestType>\r\n' +
+    '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
+    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
+    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+    '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError(message))
+}
+
 export function parseFullTransactionsMail (html) {
-  let $ = cheerio.load(html)
-  $ = cheerio.load($().children()[0].children[0].Body)
+  const body = getAttachmentHtml(html)
+  const $ = cheerio.load(body)
   const tdObjects = $('table tr td[style="border: none;width:17cm;"]').toArray()
   if (tdObjects.length < 3) {
     return []
@@ -152,8 +227,8 @@ export function parseFullTransactionsMail (html) {
 }
 
 export function parseFullTransactionsMailCardLimit (html) {
-  let $ = cheerio.load(html)
-  $ = cheerio.load($().children()[0].children[0].Body)
+  const body = getAttachmentHtml(html)
+  const $ = cheerio.load(body)
 
   let isLimit = false
   let overdraft = null
@@ -176,8 +251,8 @@ export function parseFullTransactionsMailCardLimit (html) {
 }
 
 export function parseConditionsMail (html) {
-  let $ = cheerio.load(html)
-  $ = cheerio.load($().children()[0].children[0].Body)
+  const body = getAttachmentHtml(html)
+  const $ = cheerio.load(body)
 
   let isNumber = false
   let accountNumber = null
@@ -199,15 +274,53 @@ export function parseConditionsMail (html) {
   return accountNumber
 }
 
+export function parseDepositTransactionsMail (html) {
+  const body = getAttachmentHtml(html)
+  const $ = cheerio.load(body)
+  const table = $('table').toArray().find(node => {
+    const headers = $(node).find('tr').first().find('td,th').toArray().map(cell => $(cell).text().replace(/\s+/g, ' ').trim())
+    return ['Дата', 'Операция', 'Приход', 'Расход', 'Остаток', 'Валюта'].every(header => headers.includes(header))
+  })
+
+  if (!table) {
+    return []
+  }
+
+  return $(table).find('tr').toArray().slice(1).map(row => {
+    const cells = $(row).find('td').toArray().map(cell => $(cell).text().replace(/\s+/g, ' ').trim())
+    if (cells.length !== 6) {
+      return null
+    }
+
+    const [date, description, income, outcome, balance, currency] = cells
+    if (!/\d{2}\.\d{2}\.\d{4}/.test(date) ||
+      /Входящий остаток|Обороты за период|Исходящий остаток/i.test(description)) {
+      return null
+    }
+
+    return {
+      statementType: 'deposit',
+      date,
+      description,
+      income,
+      outcome,
+      balance,
+      currency
+    }
+  }).filter(Boolean)
+}
+
 export async function login (login, password) {
   const res = await fetchApi(SOU_ADMIN_ENDPOINT,
     '<BS_Request>\r\n' +
     '   <Login Biometric="N" IpAddress="10.0.2.15" Type="PWD">\r\n' +
     '      <Parameter Id="Login">' + login + '</Parameter>\r\n' +
     '      <Parameter Id="Password">' + password + '</Parameter>\r\n' +
+    '      <Parameter Id="DevicePlatform">' + DEVICE_PLATFORM + '</Parameter>\r\n' +
+    '      <Parameter Id="AppVersion">' + APP_VERSION + '</Parameter>\r\n' +
     '   </Login>\r\n' +
     '   <RequestType>Login</RequestType>\r\n' +
-    `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
+    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
     '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>\r\n', { sanitizeRequestLog: { body: true } }, response => true, message => new InvalidPreferencesError('Неверный логин или пароль'))
@@ -220,34 +333,38 @@ export async function login (login, password) {
 
 export async function fetchAccounts (sid) {
   console.log('>>> Загрузка списка счетов...')
+  const [cards, deposits] = await Promise.all([
+    fetchProducts(sid, {
+      productType: 'MS',
+      getActions: 'Y',
+      getGroupedActions: 'Y',
+      sortByGroups: 'Y'
+    }),
+    fetchProducts(sid, {
+      productType: 'DEPOSIT',
+      getActions: 'Y',
+      getBalance: 'Y',
+      getGroupedActions: 'Y',
+      sortByGroups: 'Y'
+    })
+  ])
 
-  const res = await fetchApi(SOU_ADMIN_ENDPOINT,
-    '<BS_Request>\r\n' +
-    '   <GetProducts GetActions="N" ProductType="MS"/>\r\n' +
-    '   <RequestType>GetProducts</RequestType>\r\n' +
-    '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
-    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-    '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
-  if (res.BS_Response.GetProducts && res.BS_Response.GetProducts.Product && !Array.isArray(res.BS_Response.GetProducts.Product)) {
-    // Обрабатываем особенность парсинга xml.
-    return [res.BS_Response.GetProducts.Product]
-  } else if (res.BS_Response.GetProducts && res.BS_Response.GetProducts.Product && res.BS_Response.GetProducts.Product.length > 0) {
-    return res.BS_Response.GetProducts.Product
-  }
-  return []
+  return normalizeProductsResponse(cards).concat(normalizeProductsResponse(deposits))
 }
 
 export async function fetchBalance (sid, account) {
   console.log('>>> Загрузка баланса для ' + account.title)
+
+  if (account.productType === 'DEPOSIT') {
+    return parseAmount(account.balance) || 0
+  }
 
   const res = await fetchApi(SOU_REQUEST_ENDPOINT,
     '<BS_Request>\r\n' +
     '   <Balance Currency="' + account.currencyCode + '"/>\r\n' +
     '   <RequestType>Balance</RequestType>\r\n' +
     '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
+    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
     '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
     '   <ClientId IdType="' + account.productType + '">' + account.cardNumber + '</ClientId>\r\n' +
     '   <TerminalCapabilities>\r\n' +
@@ -273,31 +390,33 @@ export async function fetchBalance (sid, account) {
 export async function fetchTransactionsAccId (sid, account) {
   console.log('>>> Загрузка id аккаунта для транзакций для ' + account.title)
 
+  if (account.transactionsAccId || account.conditionsAccId) {
+    return {
+      transactionsAccId: account.transactionsAccId || null,
+      conditionsAccId: account.conditionsAccId || null
+    }
+  }
+
   const res = await fetchApi(SOU_ADMIN_ENDPOINT,
     '<BS_Request>\r\n' +
     '   <GetActions ProductId="' + account.productId + '"/>\r\n' +
     '   <RequestType>GetActions</RequestType>\r\n' +
     '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
+    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
     '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
-  if (res.BS_Response.GetActions && res.BS_Response.GetActions.Action && res.BS_Response.GetActions.Action.length > 2) {
-    const actions = res.BS_Response.GetActions.Action.filter((action) => action !== null)
+  if (res.BS_Response.GetActions && res.BS_Response.GetActions.Action) {
+    const actions = normalizeItems(res.BS_Response.GetActions.Action)
     const resp = {
       transactionsAccId: null,
       conditionsAccId: null
     }
     for (let i = 0; i < actions.length; i++) {
-      switch (actions[i].Type) {
-        case 'itwg:OperationTxt':
-          // нашли action id для выписки за период
-          resp.transactionsAccId = actions[i].Id
-          break
-        case 'itwg:Conditions':
-          // нашли action id для выписки за период
-          resp.conditionsAccId = actions[i].Id
-          break
+      if (!resp.transactionsAccId && isStatementAction(actions[i])) {
+        resp.transactionsAccId = actions[i].Id
+      } else if (!resp.conditionsAccId && isConditionsAction(actions[i])) {
+        resp.conditionsAccId = actions[i].Id
       }
     }
     return resp
@@ -313,7 +432,7 @@ export async function fetchAccountConditions (sid, account) {
     '<ExecuteAction Id="' + account.conditionsAccId + '"/>\r\n' +
     '<RequestType>ExecuteAction</RequestType>\r\n' +
     '<Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `<TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
+    `<TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
     '<TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
     '<Subsystem>ClientAuth</Subsystem>\r\n' +
     '</BS_Request>', {}, response => true, message => new InvalidPreferencesError('bad request'))
@@ -324,7 +443,7 @@ export async function fetchAccountConditions (sid, account) {
     '   <MailAttachment Id="' + mailID + '" No="0"/>\r\n' +
     '   <RequestType>MailAttachment</RequestType>\r\n' +
     '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-    `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
+    `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
     '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
     '   <TerminalCapabilities>\r\n' +
@@ -358,56 +477,160 @@ function transactionDate (date) {
   return String(date.getDate() + '.' + ('0' + (date.getMonth() + 1)).slice(-2) + '.' + String(date.getFullYear()))
 }
 
+function padNumber (value) {
+  return String(value).padStart(2, '0')
+}
+
+function formatHistoryDate (date, endOfDay = false) {
+  const historyDate = new Date(date)
+  if (endOfDay) {
+    historyDate.setHours(23, 59, 59, 0)
+  } else {
+    historyDate.setHours(0, 0, 0, 0)
+  }
+  return `${historyDate.getFullYear()}-${padNumber(historyDate.getMonth() + 1)}-${padNumber(historyDate.getDate())}T${padNumber(historyDate.getHours())}:${padNumber(historyDate.getMinutes())}:${padNumber(historyDate.getSeconds())}+0300`
+}
+
+function parseHistoryConfigDate (value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null
+  }
+  const [year, month, day] = value.split('-').map(Number)
+  return new Date(year, month - 1, day)
+}
+
+function clampHistoryFromDate (fromDate, toDate, historyConfig) {
+  const effectiveToDate = new Date(toDate)
+  const clampedDates = [new Date(fromDate)]
+  const minDate = parseHistoryConfigDate(historyConfig?.minDate)
+  if (minDate) {
+    clampedDates.push(minDate)
+  }
+  const extOperationsHistoryInDays = Number(historyConfig?.extOperationsHistoryInDays)
+  if (Number.isFinite(extOperationsHistoryInDays) && extOperationsHistoryInDays > 0) {
+    const extHistoryStartDate = new Date(effectiveToDate)
+    extHistoryStartDate.setDate(extHistoryStartDate.getDate() - (extOperationsHistoryInDays - 1))
+    clampedDates.push(extHistoryStartDate)
+  }
+  return new Date(Math.max(...clampedDates.map(date => date.getTime())))
+}
+
+async function fetchHistoryConfig () {
+  return (await fetchApiJson(HISTORY_CONFIG_ENDPOINT, {
+    method: 'GET'
+  }, response => response.body && response.body.errorCode === 0 && response.body.config, message => new TemporaryError(message))).body.config
+}
+
+async function fetchCardLastTransactions (sid, account, fromDate, toDate, historyConfig) {
+  if (!account.bankId) {
+    return []
+  }
+  const effectiveToDate = toDate || new Date()
+  const effectiveFromDate = clampHistoryFromDate(fromDate, effectiveToDate, historyConfig)
+  if (effectiveFromDate.getTime() > effectiveToDate.getTime()) {
+    return []
+  }
+
+  const response = await fetchApiJson(HISTORY_EXT_OPERATIONS_ENDPOINT, {
+    method: 'POST',
+    body: {
+      filter: {
+        startDate: formatHistoryDate(effectiveFromDate),
+        endDate: formatHistoryDate(effectiveToDate, true),
+        bankId: String(account.bankId)
+      },
+      session: {
+        sessionId: sid
+      },
+      page: {
+        count: Math.max(Number(historyConfig?.pageSize) || 20, 100)
+      }
+    }
+  }, response => response.body && response.body.errorCode === 0 && response.body.result && Array.isArray(response.body.result.items), message => new TemporaryError(message))
+
+  return response.body.result.items.map(transaction => ({
+    ...transaction,
+    bankId: String(account.bankId)
+  }))
+}
+
 export async function fetchFullTransactions (sid, account, fromDate, toDate = new Date()) {
   console.log('>>> Загрузка списка транзакций...')
   toDate = toDate || new Date()
 
   const dates = createDateIntervals(fromDate, toDate)
-  const responses = await Promise.all(dates.map(async date => {
-    return fetchApi(SOU_ADMIN_ENDPOINT,
-      '<BS_Request>\r\n' +
-      '   <ExecuteAction Id="' + account.transactionsAccId + '">\r\n' +
-      '      <Parameter Id="DateFrom">' + transactionDate(date[0]) + '</Parameter>\r\n' +
-      '      <Parameter Id="DateTill">' + transactionDate(date[1]) + '</Parameter>\r\n' +
-      '   </ExecuteAction>\r\n' +
-      '   <RequestType>ExecuteAction</RequestType>\r\n' +
-      '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-      `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
-      '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
-      '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-      '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
-  }))
-  const mailIDs = responses.map(response => {
-    return response.BS_Response.ExecuteAction.MailId
-  })
-  return await Promise.all(flatMap(mailIDs, (mailId) => {
-    return fetchApi(SOU_ADMIN_ENDPOINT,
-      '<BS_Request>\r\n' +
-      '   <MailAttachment Id="' + mailId + '" No="0"/>\r\n' +
-      '   <RequestType>MailAttachment</RequestType>\r\n' +
-      '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
-      `   <TerminalId>${TERMINAL_ID}</TerminalId>\r\n` +
-      '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
-      '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-      '   <TerminalCapabilities>\r\n' +
-      '       <LongParameter>Y</LongParameter>\r\n' +
-      '       <ScreenWidth>99</ScreenWidth>\r\n' +
-      '       <AnyAmount>Y</AnyAmount>\r\n' +
-      '       <BooleanParameter>Y</BooleanParameter>\r\n' +
-      '       <CheckWidth>39</CheckWidth>\r\n' +
-      '       <InputDataSources>\r\n' +
-      '           <InputDataSource>Lookup</InputDataSource>\r\n' +
-      '       </InputDataSources>\r\n' +
-      '   </TerminalCapabilities>\r\n' +
-      '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
-  }))
+  const mailIDs = []
+
+  for (const date of dates) {
+    try {
+      const response = await fetchApi(SOU_ADMIN_ENDPOINT,
+        '<BS_Request>\r\n' +
+        '   <ExecuteAction Id="' + account.transactionsAccId + '" Button="OK">\r\n' +
+        '      <Parameter Id="DateFrom">' + transactionDate(date[0]) + '</Parameter>\r\n' +
+        '      <Parameter Id="DateTill">' + transactionDate(date[1]) + '</Parameter>\r\n' +
+        '   </ExecuteAction>\r\n' +
+        '   <RequestType>ExecuteAction</RequestType>\r\n' +
+        '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
+        `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
+        '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+        '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+        '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
+
+      const mailId = response?.BS_Response?.ExecuteAction?.MailId
+      if (mailId) {
+        mailIDs.push(mailId)
+      }
+    } catch (error) {
+      if (error.message && error.message.includes(EXTRA_AUTH_REQUIRED_ERROR)) {
+        console.log(`>>> Полная выписка для "${account.title}" требует device-bound аутентификацию приложения, пропускаем.`)
+        return []
+      }
+      if (error instanceof TemporaryError) {
+        console.log(`>>> Не удалось запросить выписку для "${account.title}" за ${transactionDate(date[0])}-${transactionDate(date[1])}, пропускаем интервал.`)
+        continue
+      }
+      throw error
+    }
+  }
+
+  const mails = []
+  for (const mailId of mailIDs) {
+    try {
+      mails.push(await fetchApi(SOU_ADMIN_ENDPOINT,
+        '<BS_Request>\r\n' +
+        '   <MailAttachment Id="' + mailId + '" No="0"/>\r\n' +
+        '   <RequestType>MailAttachment</RequestType>\r\n' +
+        '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n' +
+        `   <TerminalId Version="${APP_VERSION}">${TERMINAL_ID}</TerminalId>\r\n` +
+        '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+        '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+        '   <TerminalCapabilities>\r\n' +
+        '       <LongParameter>Y</LongParameter>\r\n' +
+        '       <ScreenWidth>99</ScreenWidth>\r\n' +
+        '       <AnyAmount>Y</AnyAmount>\r\n' +
+        '       <BooleanParameter>Y</BooleanParameter>\r\n' +
+        '       <CheckWidth>39</CheckWidth>\r\n' +
+        '       <InputDataSources>\r\n' +
+        '           <InputDataSource>Lookup</InputDataSource>\r\n' +
+        '       </InputDataSources>\r\n' +
+        '   </TerminalCapabilities>\r\n' +
+        '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request')))
+    } catch (_error) {
+      console.log(`>>> Не удалось загрузить вложение выписки для "${account.title}", пропускаем один интервал.`)
+    }
+  }
+
+  return mails
 }
 
-export function parseTransactionsAndOverdraft (mails) {
+export function parseTransactionsAndOverdraft (mails, account = null) {
   let overdraft = null
   const transactions = flatMap(mails, mail => {
     const mailObj = typeof mail === 'string' ? parseXml(mail) : mail
     const data = mailObj.BS_Response.MailAttachment.Attachment
+    if (account && account.type === 'deposit') {
+      return parseDepositTransactionsMail(data)
+    }
     overdraft = parseFullTransactionsMailCardLimit(data) || overdraft
     return parseFullTransactionsMail(data)
   })
@@ -418,9 +641,8 @@ export function parseTransactionsAndOverdraft (mails) {
   }
 }
 
-export async function fetchLastTransactions (sid) {
-  console.log('>>> Загрузка списка последних транзакций...')
-  const transactions = (await fetchApiJson('push-history/api/andorid_5.17.1/v1/getHistory', {
+async function fetchPushHistoryTransactions (sid) {
+  return (await fetchApiJson(PUSH_HISTORY_ENDPOINT, {
     method: 'POST',
     body: {
       eventTypes: [
@@ -431,8 +653,34 @@ export async function fetchLastTransactions (sid) {
       offset: 0,
       sessionId: sid
     }
-  }, response => response.body.errorCode && response.body.errorCode === 0 && response.body.historyRecords && response.body.historyRecords.length > 0, message => new TemporaryError(message))).body.historyRecords
+  }, response => response.body && response.body.errorCode === 0 && Array.isArray(response.body.historyRecords), message => new TemporaryError(message))).body.historyRecords
+}
 
-  console.log(`>>> Загружено ${transactions.length} последних операций.`)
-  return transactions
+export async function fetchLastTransactions (sid, accounts = [], fromDate = new Date(), toDate = new Date()) {
+  console.log('>>> Загрузка списка последних транзакций...')
+  const cardAccounts = accounts.filter(account => account.type === 'card' && account.bankId)
+  if (cardAccounts.length === 0) {
+    const transactions = await fetchPushHistoryTransactions(sid)
+    console.log(`>>> Загружено ${transactions.length} последних операций.`)
+    return transactions
+  }
+
+  try {
+    const historyConfig = await fetchHistoryConfig()
+    const transactions = flatMap(await Promise.all(cardAccounts.map(async account => {
+      try {
+        return await fetchCardLastTransactions(sid, account, fromDate, toDate, historyConfig)
+      } catch (error) {
+        console.log(`>>> Не удалось загрузить последние операции по карте "${account.title}", пропускаем.`)
+        return []
+      }
+    })), item => item)
+    console.log(`>>> Загружено ${transactions.length} последних операций через HistoryApi.`)
+    return transactions
+  } catch (error) {
+    console.log('>>> Не удалось получить карточную историю через HistoryApi, пробуем push-history.')
+    const transactions = await fetchPushHistoryTransactions(sid)
+    console.log(`>>> Загружено ${transactions.length} последних операций.`)
+    return transactions
+  }
 }

--- a/src/plugins/bgpb/converters.js
+++ b/src/plugins/bgpb/converters.js
@@ -114,20 +114,34 @@ function getMerchantKeyParts (merchant) {
   return [merchant.title, merchant.city, merchant.mcc]
 }
 
+function createStableSourceKey (apiTransaction) {
+  if (apiTransaction.authCode) {
+    return `auth:${apiTransaction.authCode}`
+  }
+  if (apiTransaction.orderNumber) {
+    return `order:${apiTransaction.orderNumber}`
+  }
+  if (apiTransaction.id && !isHistoryApiTransaction(apiTransaction)) {
+    return `event:${apiTransaction.id}`
+  }
+  return null
+}
+
 function createTransactionKey (account, transaction, apiTransaction = {}) {
   const primaryMovement = transaction.movements[0]
-  const sourceSpecificKey = apiTransaction.authCode
-    ? null
-    : apiTransaction.orderNumber
-      ? `order:${apiTransaction.orderNumber}`
-      : apiTransaction.id && !isHistoryApiTransaction(apiTransaction)
-        ? `event:${apiTransaction.id}`
-        : null
+  const stableSourceKey = createStableSourceKey(apiTransaction)
+  if (stableSourceKey) {
+    return joinIdParts([
+      'bgpb',
+      account.id,
+      stableSourceKey,
+      transaction.date.toISOString().slice(0, 16)
+    ])
+  }
+
   return joinIdParts([
     'bgpb',
     account.id,
-    apiTransaction.authCode && `auth:${apiTransaction.authCode}`,
-    sourceSpecificKey,
     transaction.date.toISOString().slice(0, 16),
     transaction.hold ? 'hold' : 'posted',
     primaryMovement.sum,
@@ -160,6 +174,9 @@ function convertHistoryLastTransaction (apiTransaction, accounts) {
   const invoiceAmount = parseMinorAmount(apiTransaction.currencyAmount?.amount)
 
   if (totalAmount === null && invoiceAmount === null) {
+    return null
+  }
+  if (apiTransaction.reversal === 1 || apiTransaction.reversal === true || apiTransaction.status === 'reversed' || apiTransaction.status === 'declined') {
     return null
   }
 

--- a/src/plugins/bgpb/converters.js
+++ b/src/plugins/bgpb/converters.js
@@ -1,15 +1,148 @@
 import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
 
+function normalizeItems (item) {
+  if (!item) {
+    return []
+  }
+  return Array.isArray(item) ? item.filter(Boolean) : [item]
+}
+
+function findActionId (product, predicate) {
+  for (const group of normalizeItems(product.Group)) {
+    for (const action of normalizeItems(group.Action)) {
+      if (predicate(action)) {
+        return action.Id
+      }
+    }
+  }
+  return null
+}
+
+function parseAmount (amount) {
+  if (amount === null || amount === undefined || amount === '') {
+    return null
+  }
+  const normalized = Number.parseFloat(String(amount).replace(',', '.').replace(/\s/g, ''))
+  return isNaN(normalized) ? null : normalized
+}
+
+function parseBankDate (value) {
+  if (typeof value !== 'string' || !/^\d{8}$/.test(value)) {
+    return null
+  }
+  const year = Number(value.slice(0, 4))
+  const month = Number(value.slice(4, 6)) - 1
+  const day = Number(value.slice(6, 8))
+  return new Date(Date.UTC(year, month, day))
+}
+
+function parsePercent (value) {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const match = value.replace(',', '.').match(/-?\d+(?:\.\d+)?/)
+  return match ? Number(match[0]) : null
+}
+
+function getDateDiffInDays (startDate, endDate) {
+  if (!(startDate instanceof Date) || isNaN(startDate) || !(endDate instanceof Date) || isNaN(endDate)) {
+    return null
+  }
+  return Math.round((endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000))
+}
+
+function parseMinorAmount (amount) {
+  const normalized = Number(amount)
+  return Number.isFinite(normalized) ? normalized / 100 : null
+}
+
+function isHistoryApiTransaction (apiTransaction) {
+  return Boolean(apiTransaction && typeof apiTransaction === 'object' && typeof apiTransaction.date === 'string' && typeof apiTransaction.pan === 'string')
+}
+
+function findHistoryTransactionAccount (apiTransaction, accounts) {
+  const last4 = apiTransaction.pan.slice(-4)
+  return accounts.find(account => {
+    if (apiTransaction.bankId && account.bankId && String(account.bankId) === String(apiTransaction.bankId)) {
+      return true
+    }
+    return account.syncID.indexOf(last4) !== -1
+  }) || null
+}
+
+function createHistoryMerchant (apiTransaction) {
+  const mcc = Number(apiTransaction.mcc)
+  const terminal = typeof apiTransaction.terminal === 'string' ? apiTransaction.terminal.trim() : ''
+  if (!terminal && (isNaN(mcc) || mcc === 0)) {
+    return null
+  }
+
+  const merchant = {
+    mcc: isNaN(mcc) || mcc === 0 ? null : mcc,
+    location: null
+  }
+  const parts = terminal.split(/\s*,\s*/).filter(Boolean)
+  if (parts.length >= 3 && /^[A-Z]{2,3}$/.test(parts[parts.length - 1])) {
+    merchant.title = parts[0]
+    merchant.city = parts[1] || null
+    merchant.country = parts[2] || null
+  } else if (terminal) {
+    merchant.fullTitle = terminal
+  }
+  return merchant
+}
+
+function convertHistoryLastTransaction (apiTransaction, accounts) {
+  const account = findHistoryTransactionAccount(apiTransaction, accounts)
+  if (!account) {
+    return null
+  }
+
+  const totalInstrument = codeToCurrencyLookup[apiTransaction.totalAmount?.currency] || account.instrument
+  const invoiceInstrument = codeToCurrencyLookup[apiTransaction.currencyAmount?.currency] || totalInstrument
+  const sign = apiTransaction.direction === 'incoming' ? 1 : -1
+  const totalAmount = parseMinorAmount(apiTransaction.totalAmount?.amount)
+  const invoiceAmount = parseMinorAmount(apiTransaction.currencyAmount?.amount)
+
+  if (totalAmount === null && invoiceAmount === null) {
+    return null
+  }
+
+  return {
+    date: new Date(apiTransaction.date),
+    movements: [
+      {
+        id: null,
+        account: { id: account.id },
+        invoice: invoiceInstrument !== account.instrument && invoiceAmount !== null
+          ? {
+              instrument: invoiceInstrument,
+              sum: sign * invoiceAmount
+            }
+          : null,
+        sum: totalInstrument === account.instrument && totalAmount !== null ? sign * totalAmount : null,
+        fee: 0
+      }
+    ],
+    merchant: createHistoryMerchant(apiTransaction),
+    comment: apiTransaction.transTypeDesc || null,
+    hold: apiTransaction.status !== 'success'
+  }
+}
+
 export function convertAccount (ob) {
   if ((ob.Enabled && ob.Enabled === 'N') || (ob.Blocked && ob.Blocked === 'Y')) {
     return null
   }
   const id = ob.Id.split('-')[0]
-  if (ob.ProductType !== 'NON_ONUS' && !ZenMoney.isAccountSkipped(id)) {
-    // eslint-disable-next-line no-debugger
+  const transactionsAccId = findActionId(ob, action => /operationtxt/i.test(action.Type || '') || /statement/i.test(action.Type || '') || action.Name === 'Выписка')
+  const conditionsAccId = findActionId(ob, action => /conditions/i.test(action.Type || '') || action.Name === 'Условия обслуживания')
+
+  if (ob.ProductType === 'MS' && !ZenMoney.isAccountSkipped(id)) {
     return {
       id,
-      transactionsAccId: null,
+      transactionsAccId,
+      conditionsAccId,
       type: 'card',
       title: ob.CustomName + '*' + ob.No.slice(-4),
       currencyCode: ob.Currency,
@@ -17,6 +150,36 @@ export function convertAccount (ob) {
       instrument: codeToCurrencyLookup[ob.Currency],
       balance: 0,
       syncID: [ob.No.slice(-4)],
+      bankId: ob.BankId || ob.ExtraData || null,
+      productId: ob.Id,
+      productType: ob.ProductType
+    }
+  }
+  if (ob.ProductType === 'DEPOSIT' && !ZenMoney.isAccountSkipped(id)) {
+    const startDate = parseBankDate(ob.Opened)
+    const endDate = parseBankDate(ob.Expired)
+    const endDateOffset = getDateDiffInDays(startDate, endDate)
+    const percent = parsePercent(ob.Extra?.InterestRate)
+
+    return {
+      id,
+      transactionsAccId,
+      conditionsAccId,
+      type: 'deposit',
+      title: (ob.CustomName || ob.ProductTypeName || 'Вклад') + '*' + ob.No.slice(-4),
+      currencyCode: ob.Currency,
+      cardNumber: ob.No,
+      instrument: codeToCurrencyLookup[ob.Currency],
+      balance: parseAmount(ob.Balance) || 0,
+      syncID: [ob.No],
+      startDate,
+      startBalance: parseAmount(ob.Balance) || 0,
+      percent: percent || 0,
+      capitalization: true,
+      payoffInterval: 'month',
+      payoffStep: 1,
+      endDateOffset,
+      endDateOffsetInterval: 'day',
       productId: ob.Id,
       productType: ob.ProductType
     }
@@ -36,6 +199,9 @@ export function addOverdraftInfo (account, overdraft) {
 }
 
 export function convertTransaction (apiTransaction, account) {
+  if (apiTransaction.statementType === 'deposit') {
+    return convertDepositTransaction(apiTransaction, account)
+  }
   const invoice = {
     sum: getSumAmount(apiTransaction.type, apiTransaction.amountReal),
     instrument: apiTransaction.currencyReal
@@ -65,6 +231,26 @@ export function convertTransaction (apiTransaction, account) {
   return transaction
 }
 
+function convertDepositTransaction (apiTransaction, account) {
+  const income = parseAmount(apiTransaction.income)
+  const outcome = parseAmount(apiTransaction.outcome)
+  return {
+    date: new Date(getDate(apiTransaction.date)),
+    movements: [
+      {
+        id: null,
+        account: { id: account.id },
+        invoice: null,
+        sum: income !== null ? income : -(outcome || 0),
+        fee: 0
+      }
+    ],
+    merchant: null,
+    comment: apiTransaction.description || null,
+    hold: false
+  }
+}
+
 function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
   if (apiTransaction?.description.match('Перевод с карты на карту')) {
     transaction.groupKeys = [`${getDate(apiTransaction.date).slice(0, 16)}_${invoice.instrument}_${Math.abs(invoice.sum).toString()}`]
@@ -85,6 +271,9 @@ export function convertTestLastTransactions (apiTransactions, accounts) {
 }
 
 export function convertLastTransaction (apiTransaction, accounts) {
+  if (isHistoryApiTransaction(apiTransaction)) {
+    return convertHistoryLastTransaction(apiTransaction, accounts)
+  }
   const rawData = apiTransaction.pushMessageText.split('; ')
 
   if (rawData[0].slice(0, 4) !== 'Card' || [
@@ -299,17 +488,18 @@ function getSumAmount (debitFlag, strAmount) {
 }
 
 function getDate (str) {
-  const [day, month, year, hour, minute] = str.match(/(\d{2}).(\d{2}).(\d{4}) (\d{2}):(\d{2})/).slice(1)
+  const match = str.match(/(\d{2})\.(\d{2})\.(\d{4})(?: (\d{2}):(\d{2}))?/)
+  const [day, month, year, hour = '00', minute = '00'] = match.slice(1)
   return `${year}-${month}-${day}T${hour}:${minute}:00+03:00`
 }
 
 function getDateFromJSON (str) {
-  const [day, month, year, hour, minute] = str.match(/(\d{2}).(\d{2}).(\d{2}) (\d{2}):(\d{2}):\d{2}/).slice(1)
+  const [day, month, year, hour, minute] = str.match(/(\d{2})\.(\d{2})\.(\d{2}) (\d{2}):(\d{2}):\d{2}/).slice(1)
   return new Date(`20${year}-${month}-${day}T${hour}:${minute}:00+03:00`)
 }
 
 function getDateJSON (str) {
-  const [day, month, year] = str.match(/(\d{2}).(\d{2}).(\d{2})/).slice(1)
+  const [day, month, year] = str.match(/(\d{2})\.(\d{2})\.(\d{2})/).slice(1)
   return (`20${year}-${month}-${day}`)
 }
 

--- a/src/plugins/bgpb/converters.js
+++ b/src/plugins/bgpb/converters.js
@@ -92,6 +92,61 @@ function createHistoryMerchant (apiTransaction) {
   return merchant
 }
 
+function normalizeIdPart (value) {
+  return String(value ?? '').trim().replace(/\s+/g, ' ')
+}
+
+function joinIdParts (parts) {
+  return parts
+    .map(normalizeIdPart)
+    .filter(part => part !== '')
+    .join(':')
+}
+
+function getMerchantKeyParts (merchant) {
+  if (!merchant) {
+    return []
+  }
+  if (merchant.fullTitle) {
+    const [title = merchant.fullTitle, city = ''] = merchant.fullTitle.split(/\s*,\s*/)
+    return [title, city, merchant.mcc]
+  }
+  return [merchant.title, merchant.city, merchant.mcc]
+}
+
+function createTransactionKey (account, transaction, apiTransaction = {}) {
+  const primaryMovement = transaction.movements[0]
+  const sourceSpecificKey = apiTransaction.authCode
+    ? null
+    : apiTransaction.orderNumber
+      ? `order:${apiTransaction.orderNumber}`
+      : apiTransaction.id && !isHistoryApiTransaction(apiTransaction)
+        ? `event:${apiTransaction.id}`
+        : null
+  return joinIdParts([
+    'bgpb',
+    account.id,
+    apiTransaction.authCode && `auth:${apiTransaction.authCode}`,
+    sourceSpecificKey,
+    transaction.date.toISOString().slice(0, 16),
+    transaction.hold ? 'hold' : 'posted',
+    primaryMovement.sum,
+    primaryMovement.invoice?.instrument,
+    primaryMovement.invoice?.sum,
+    transaction.comment,
+    ...getMerchantKeyParts(transaction.merchant)
+  ])
+}
+
+function assignMovementIds (transaction, account, apiTransaction) {
+  const transactionKey = createTransactionKey(account, transaction, apiTransaction)
+  transaction.movements[0].id = joinIdParts([transactionKey, 'card'])
+  if (transaction.movements[1]) {
+    transaction.movements[1].id = joinIdParts([transactionKey, transaction.movements[1].account?.type || 'transfer'])
+  }
+  return transaction
+}
+
 function convertHistoryLastTransaction (apiTransaction, accounts) {
   const account = findHistoryTransactionAccount(apiTransaction, accounts)
   if (!account) {
@@ -112,7 +167,7 @@ function convertHistoryLastTransaction (apiTransaction, accounts) {
     date: new Date(apiTransaction.date),
     movements: [
       {
-        id: null,
+        id: '',
         account: { id: account.id },
         invoice: invoiceInstrument !== account.instrument && invoiceAmount !== null
           ? {
@@ -128,6 +183,15 @@ function convertHistoryLastTransaction (apiTransaction, accounts) {
     comment: apiTransaction.transTypeDesc || null,
     hold: apiTransaction.status !== 'success'
   }
+}
+
+function convertHistoryLastTransactionWithIds (apiTransaction, accounts) {
+  const transaction = convertHistoryLastTransaction(apiTransaction, accounts)
+  if (!transaction) {
+    return null
+  }
+  const account = findHistoryTransactionAccount(apiTransaction, accounts)
+  return assignMovementIds(transaction, account, apiTransaction)
 }
 
 export function convertAccount (ob) {
@@ -210,7 +274,7 @@ export function convertTransaction (apiTransaction, account) {
     date: new Date(getDate(apiTransaction.date)),
     movements: [
       {
-        id: null,
+        id: '',
         account: { id: account.id },
         invoice: invoice.instrument === account.instrument ? null : invoice,
         sum: invoice.instrument === account.instrument ? invoice.sum : getSumAmount(apiTransaction.type, apiTransaction.amount),
@@ -228,17 +292,17 @@ export function convertTransaction (apiTransaction, account) {
     parseComment
   ].some(parser => parser(transaction, apiTransaction, account, invoice))
 
-  return transaction
+  return assignMovementIds(transaction, account, apiTransaction)
 }
 
 function convertDepositTransaction (apiTransaction, account) {
   const income = parseAmount(apiTransaction.income)
   const outcome = parseAmount(apiTransaction.outcome)
-  return {
+  const transaction = {
     date: new Date(getDate(apiTransaction.date)),
     movements: [
       {
-        id: null,
+        id: '',
         account: { id: account.id },
         invoice: null,
         sum: income !== null ? income : -(outcome || 0),
@@ -249,6 +313,7 @@ function convertDepositTransaction (apiTransaction, account) {
     comment: apiTransaction.description || null,
     hold: false
   }
+  return assignMovementIds(transaction, account, apiTransaction)
 }
 
 function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
@@ -272,7 +337,7 @@ export function convertTestLastTransactions (apiTransactions, accounts) {
 
 export function convertLastTransaction (apiTransaction, accounts) {
   if (isHistoryApiTransaction(apiTransaction)) {
-    return convertHistoryLastTransaction(apiTransaction, accounts)
+    return convertHistoryLastTransactionWithIds(apiTransaction, accounts)
   }
   const rawData = apiTransaction.pushMessageText.split('; ')
 
@@ -327,7 +392,7 @@ export function convertLastTransaction (apiTransaction, accounts) {
     date,
     movements: [
       {
-        id: null,
+        id: '',
         account: { id: account.id },
         invoice: invoice.instrument === account.instrument ? null : invoice,
         sum: invoice.instrument === account.instrument ? invoice.sum : null,
@@ -345,7 +410,7 @@ export function convertLastTransaction (apiTransaction, accounts) {
     parsePayee
   ].some(parser => parser(transaction, apiTransaction))
 
-  return transaction
+  return assignMovementIds(transaction, account, apiTransaction)
 }
 
 function parseCash (transaction, apiTransaction) {
@@ -504,16 +569,29 @@ function getDateJSON (str) {
 }
 
 export function transactionsUnique (array) {
-  const a = array.concat()
-  for (let i = 0; i < a.length; ++i) {
-    for (let j = i + 1; j < a.length; ++j) {
-      if (a[i].date.getTime() === a[j].date.getTime() &&
-        a[i].movements.length === a[j].movements.length &&
-        a[i].movements[0].account.id === a[j].movements[0].account.id &&
-        a[i].movements[0].sum === a[j].movements[0].sum) {
-        a.splice(j--, 1)
-      }
+  const uniqueTransactions = []
+  const seen = new Set()
+  for (const transaction of array) {
+    const firstMovement = transaction.movements[0]
+    const key = firstMovement.id || joinIdParts([
+      transaction.date.getTime(),
+      transaction.movements.length,
+      firstMovement.account.id,
+      firstMovement.sum,
+      firstMovement.invoice?.instrument,
+      firstMovement.invoice?.sum,
+      transaction.comment,
+      transaction.merchant?.fullTitle,
+      transaction.merchant?.title,
+      transaction.merchant?.city,
+      transaction.merchant?.country,
+      transaction.merchant?.mcc
+    ])
+    if (seen.has(key)) {
+      continue
     }
+    seen.add(key)
+    uniqueTransactions.push(transaction)
   }
-  return a
+  return uniqueTransactions
 }

--- a/src/plugins/bgpb/index.js
+++ b/src/plugins/bgpb/index.js
@@ -1,7 +1,6 @@
 import _ from 'lodash'
 import { adjustTransactions } from '../../common/transactionGroupHandler'
 import {
-  fetchAccountConditions,
   fetchAccounts,
   fetchBalance,
   fetchFullTransactions,
@@ -28,7 +27,7 @@ export async function scrape ({ preferences, fromDate, toDate }) {
   accounts = await Promise.all(accounts.map(async account => {
     if (account.transactionsAccId) {
       const mails = await fetchFullTransactions(token, account, fromDate, toDate)
-      const { overdraft, transactions } = parseTransactionsAndOverdraft(mails)
+      const { overdraft, transactions } = parseTransactionsAndOverdraft(mails, account)
       account = addOverdraftInfo(account, overdraft)
       for (const apiTransaction of transactions) {
         const transaction = convertTransaction(apiTransaction, account)
@@ -40,7 +39,7 @@ export async function scrape ({ preferences, fromDate, toDate }) {
     return account
   }))
 
-  const transactionsLast = (await fetchLastTransactions(token))
+  const transactionsLast = (await fetchLastTransactions(token, accounts, fromDate, toDate))
     .map(transaction => convertLastTransaction(transaction, accounts))
     .filter(function (op) {
       if (op === null) {
@@ -65,18 +64,16 @@ async function allAccounts (token) {
     .map(convertAccount)
     .filter(account => account !== null)
   for (let i = 0; i < accounts.length; i++) {
-    accounts[i].balance = await fetchBalance(token, accounts[i])
-    if (accounts[i].balance === null) {
-      continue
+    if (accounts[i].productType !== 'DEPOSIT') {
+      accounts[i].balance = await fetchBalance(token, accounts[i])
+      if (accounts[i].balance === null) {
+        continue
+      }
     }
-    const accIDs = await fetchTransactionsAccId(token, accounts[i])
-    accounts[i].transactionsAccId = accIDs.transactionsAccId
-    accounts[i].conditionsAccId = accIDs.conditionsAccId
-  }
-
-  for (let i = 0; i < accounts.length; i++) {
-    if (accounts[i].balance !== null && accounts[i].conditionsAccId !== null) {
-      accounts[i].accountID = await fetchAccountConditions(token, accounts[i])
+    if (!accounts[i].transactionsAccId || !accounts[i].conditionsAccId) {
+      const accIDs = await fetchTransactionsAccId(token, accounts[i])
+      accounts[i].transactionsAccId = accounts[i].transactionsAccId || accIDs.transactionsAccId
+      accounts[i].conditionsAccId = accounts[i].conditionsAccId || accIDs.conditionsAccId
     }
   }
 


### PR DESCRIPTION
Расширена и стабилизирована интеграция bgpb.

Что изменено по счетам:

 - добавлена нормализация одиночных/массивных XML-узлов;
 - account actions теперь ищутся по типу/названию действия, а не по позиции в массиве;
 - в аккаунты добавлены transactionsAccId, conditionsAccId, bankId, productId;
 - добавлена конвертация депозитных продуктов в ZenMoney deposit account;
 - для депозитов парсятся даты открытия/закрытия, процент, баланс, syncID и параметры капитализации.

Что изменено по транзакциям:

 - добавлена загрузка и парсинг deposit statement rows из mail attachment;
 - добавлена работа с history API (getConfig, ext-operations) и ограничение дат по доступному диапазону истории;
 - добавлена конвертация last/history операций в ZenMoney transactions;
 - reversed history operations пропускаются;
 - для statement/history/deposit операций назначаются stable movement IDs;
 - одинаковая операция из statement и history получает одинаковый ID даже при различии текста;
 - hold/history операция при клиринге сохраняет стабильный ID;
 - даты в парсерах стали устойчивее к форматам без времени.

Что изменено в scrape flow:

 - overdraft/statement парсинг получает контекст аккаунта;
 - last transactions загружаются с учётом accounts/fromDate/toDate;
 - баланс не запрашивается для депозитов тем же способом, что для карточных счетов;
 - missing action IDs дозапрашиваются только если их нет в данных продукта.