### PR TITLE
fix(tbc-ge): guard non-array apiAccounts in convertCardsV2

### DIFF
--- a/src/plugins/tbc-ge/__tests__/convertersV2/accounts/cardsV2Guard.test.ts
+++ b/src/plugins/tbc-ge/__tests__/convertersV2/accounts/cardsV2Guard.test.ts
@@ -1,0 +1,14 @@
+import { convertCardsV2 } from '../../../converters'
+import { CardProductV2 } from '../../../models'
+
+it('returns empty array when apiAccounts is null', () => {
+  expect(convertCardsV2(null as unknown as CardProductV2[])).toEqual([])
+})
+
+it('returns empty array when apiAccounts is undefined', () => {
+  expect(convertCardsV2(undefined as unknown as CardProductV2[])).toEqual([])
+})
+
+it('returns empty array when apiAccounts is not an array', () => {
+  expect(convertCardsV2({} as unknown as CardProductV2[])).toEqual([])
+})

--- a/src/plugins/tbc-ge/converters.ts
+++ b/src/plugins/tbc-ge/converters.ts
@@ -109,6 +109,9 @@ export function convertDepositV2 (apiAccount: DepositDataV2): PreparedLoanV2 {
 }
 
 export function convertCardsV2 (apiAccounts: CardProductV2[]): PreparedCardV2[] {
+  if (!Array.isArray(apiAccounts)) {
+    return []
+  }
   const accounts: PreparedCardV2[] = []
   for (const apiAccount of apiAccounts) {
     // Handle accounts without cards as regular bank accounts


### PR DESCRIPTION
## Problem

TBC-GE plugin crashes at midnight UTC when the API returns a non-array for `apiAccounts` (session boundary reset):

```
TypeError: undefined is not a function (near '...apiAccount of apiAccounts...')
  at convertCardsV2 (tbc-ge/converters.ts:113:14)
```

Observed on 2026-05-19 and 2026-05-20 at 00:00 UTC, same connection, `failures:1`.

## Fix

Added `Array.isArray()` guard at the top of `convertCardsV2` before the `for...of` loop.

## Tests

New: `__tests__/convertersV2/accounts/cardsV2Guard.test.ts` — 3 cases: null, undefined, non-array object.

- `jest --testPathPattern="plugins/tbc-ge"` — 22 suites, 61 tests pass
- `ts-standard` clean