### PR TITLE
fix(priorbank): guard non-array apiAccountDetails in convertAccounts

### DIFF
--- a/src/plugins/priorbank/__tests__/converters/accounts/convertAccountsGuard.test.js
+++ b/src/plugins/priorbank/__tests__/converters/accounts/convertAccountsGuard.test.js
@@ -1,0 +1,27 @@
+import { convertAccounts } from '../../../converters'
+
+const minimalApiAccount = {
+  clientObject: {
+    id: 1,
+    cardContractNumber: '1234',
+    cardMaskedNumber: 'XXXX1234',
+    currIso: 'BYN',
+    customSynonym: 'My card',
+    defaultSynonym: 'My card'
+  },
+  balance: { available: 100 }
+}
+
+describe('convertAccounts guard — non-array apiAccountDetails', () => {
+  it('returns empty array when apiAccountDetails is null', () => {
+    expect(convertAccounts([minimalApiAccount], null)).toEqual([])
+  })
+
+  it('returns empty array when apiAccountDetails is undefined', () => {
+    expect(convertAccounts([minimalApiAccount], undefined)).toEqual([])
+  })
+
+  it('returns empty array when apiAccountDetails is an object (not an array)', () => {
+    expect(convertAccounts([minimalApiAccount], {})).toEqual([])
+  })
+})

--- a/src/plugins/priorbank/converters.js
+++ b/src/plugins/priorbank/converters.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { formatCommentFeeLine, joinCommentLines } from '../../common/converters'
 
 export function convertAccounts (apiAccounts, apiAccountDetails) {
+  if (!Array.isArray(apiAccountDetails)) { return [] }
   const accounts = []
   for (const apiAccount of apiAccounts) {
     if (apiAccount.status?.respCode === -9999) { continue } // Card of another bank


### PR DESCRIPTION
## Problem

PriorBank plugin crashes at midnight UTC when the API returns a non-array for `apiAccountDetails`:

```
TypeError: apiAccountDetails.find is not a function
  at convertAccounts (priorbank/converters.js:17:39)
```

Observed at 00:00 UTC, `failures:1`, self-heals in 30 min.

## Fix

Added `Array.isArray()` guard at the top of `convertAccounts` before any iteration.

## Tests

New: `__tests__/converters/accounts/convertAccountsGuard.test.js` — 3 cases: null, undefined, non-array object (with real `apiAccounts` entry that reaches line 17).

- `jest --testPathPattern="plugins/priorbank"` — 12 suites, 36 tests pass
- `ts-standard` clean