### PR TITLE
fix(kapitalbank-uz): add missing TemporaryError import, remove stray takePicture call

### DIFF
--- a/src/plugins/kapitalbank-uz/__tests__/accounts/account.test.js
+++ b/src/plugins/kapitalbank-uz/__tests__/accounts/account.test.js
@@ -1,0 +1,37 @@
+import {
+  convertAccount
+} from '../../converters'
+
+describe('convertAccount', () => {
+  it('converts USD account', () => {
+    expect(convertAccount({
+      guid: 'AC-abcd1234-0000-0000-0000-000000000001',
+      accountNumber: 'UZ12345678901234567890',
+      currency: { name: 'USD', scale: 2 },
+      balance: 150075
+    })).toEqual({
+      id: 'AC-abcd1234-0000-0000-0000-000000000001',
+      title: 'Счёт USD *0001',
+      syncIds: ['UZ12345678901234567890'],
+      instrument: 'USD',
+      type: 'checking',
+      balance: 1500.75
+    })
+  })
+
+  it('converts UZS account', () => {
+    expect(convertAccount({
+      guid: 'AC-abcd1234-0000-0000-0000-000000000002',
+      accountNumber: 'UZ98765432109876543210',
+      currency: { name: 'UZS', scale: 2 },
+      balance: 5000000000
+    })).toEqual({
+      id: 'AC-abcd1234-0000-0000-0000-000000000002',
+      title: 'Счёт UZS *0002',
+      syncIds: ['UZ98765432109876543210'],
+      instrument: 'UZS',
+      type: 'checking',
+      balance: 50000000
+    })
+  })
+})

--- a/src/plugins/kapitalbank-uz/__tests__/transactions/deposit-tx.test.js
+++ b/src/plugins/kapitalbank-uz/__tests__/transactions/deposit-tx.test.js
@@ -1,0 +1,32 @@
+import {
+  convertDepositTransaction
+} from '../../converters'
+
+describe('convertDepositTransaction', () => {
+  it('returns null for INTEREST activity', () => {
+    const deposit = { id: 'DP-001' }
+    const rawTx = {
+      activity: { type: 'INTEREST', description: 'Interest payment' },
+      amount: 50000,
+      currency: { name: 'UZS', scale: 2 },
+      paymentDate: '2025-03-01 10:00:00.+0000'
+    }
+    expect(convertDepositTransaction(deposit, rawTx)).toBeNull()
+  })
+
+  it('converts PARTIAL_REPLENISHMENT as credit', () => {
+    const deposit = { id: 'DP-002' }
+    const rawTx = {
+      activity: { type: 'PARTIAL_REPLENISHMENT', description: 'Пополнение вклада' },
+      amount: 1000000,
+      currency: { name: 'UZS', scale: 2 },
+      paymentDate: '2025-03-15 12:30:00.+0000'
+    }
+    const result = convertDepositTransaction(deposit, rawTx)
+    expect(result).not.toBeNull()
+    expect(result.movements[0].account.id).toBe('DP-002')
+    expect(result.movements[0].sum).toBe(10000)
+    expect(result.comment).toBe('Пополнение вклада')
+    expect(result.hold).toBe(false)
+  })
+})

--- a/src/plugins/kapitalbank-uz/__tests__/transactions/outcome.test.js
+++ b/src/plugins/kapitalbank-uz/__tests__/transactions/outcome.test.js
@@ -49,4 +49,134 @@ describe('convertTransaction', () => {
     }
     expect(convertCardOrAccountTransaction(card, rawTransaction)).toEqual(transaction)
   })
+
+  it.each([
+    [
+      {
+        group: { title: 'Конвертация', type: 'CONVERSION' },
+        module: 'CONVERSION',
+        transactionDate: '2025-03-01 10:00:00.+0000',
+        transactionGuid: 'CNV-abc12345',
+        transactionType: 'DEBIT',
+        status: 'SUCCESS',
+        name: 'Обмен валюты USD/UZS',
+        amount: 10000,
+        currency: { name: 'UZS', scale: 2 }
+      },
+      {
+        date: new Date('2025-03-01T10:00:00.000Z'),
+        hold: false,
+        comment: 'Обмен валюты',
+        merchant: null,
+        movements: [
+          {
+            id: 'CNV-abc12345',
+            account: { id: 'card' },
+            invoice: null,
+            sum: -100,
+            fee: 0
+          }
+        ]
+      }
+    ]
+  ])('converts CONVERSION module transaction', (rawTransaction, transaction) => {
+    const card = { id: 'card', instrument: 'UZS' }
+    expect(convertCardOrAccountTransaction(card, rawTransaction)).toEqual(transaction)
+  })
+
+  it.each([
+    [
+      {
+        group: { title: 'Вклады', type: 'DEPOSITS' },
+        module: 'DEPOSITS_TRANSACTION',
+        transactionDate: '2025-04-10 08:00:00.+0000',
+        transactionGuid: 'DEP-xyz999',
+        transactionType: 'DEBIT',
+        status: 'SUCCESS',
+        name: 'Копилка',
+        amount: 500000,
+        currency: { name: 'UZS', scale: 2 }
+      },
+      {
+        date: new Date('2025-04-10T08:00:00.000Z'),
+        hold: false,
+        comment: 'Пополнение вклада Копилка',
+        merchant: null,
+        movements: [
+          {
+            id: 'DEP-xyz999',
+            account: { id: 'card' },
+            invoice: null,
+            sum: -5000,
+            fee: 0
+          }
+        ]
+      }
+    ]
+  ])('converts DEPOSITS_TRANSACTION module transaction', (rawTransaction, transaction) => {
+    const card = { id: 'card', instrument: 'UZS' }
+    expect(convertCardOrAccountTransaction(card, rawTransaction)).toEqual(transaction)
+  })
+
+  it.each([
+    [
+      {
+        group: { title: 'Вклады', type: 'DEPOSITS' },
+        module: 'ACCOUNTS',
+        transactionDate: '2025-05-01 00:00:00.+0000',
+        transactionGuid: 'ACC-interest-001',
+        transactionType: 'CREDIT',
+        status: 'SUCCESS',
+        name: 'Выплата процентов',
+        amount: 25000,
+        currency: { name: 'UZS', scale: 2 }
+      },
+      {
+        date: new Date('2025-05-01T00:00:00.000Z'),
+        hold: false,
+        comment: 'Выплата процентов по вкладу',
+        merchant: null,
+        movements: [
+          {
+            id: 'ACC-interest-001',
+            account: { id: 'card' },
+            invoice: null,
+            sum: 250,
+            fee: 0
+          }
+        ]
+      }
+    ],
+    [
+      {
+        group: { title: 'Переводы', type: 'OTHER' },
+        module: 'ACCOUNTS',
+        transactionDate: '2025-05-02 12:00:00.+0000',
+        transactionGuid: 'ACC-transfer-002',
+        transactionType: 'DEBIT',
+        status: 'SUCCESS',
+        name: 'Перевод на счёт',
+        amount: 100000,
+        currency: { name: 'UZS', scale: 2 }
+      },
+      {
+        date: new Date('2025-05-02T12:00:00.000Z'),
+        hold: false,
+        comment: null,
+        merchant: null,
+        movements: [
+          {
+            id: 'ACC-transfer-002',
+            account: { id: 'card' },
+            invoice: null,
+            sum: -1000,
+            fee: 0
+          }
+        ]
+      }
+    ]
+  ])('converts ACCOUNTS module transaction', (rawTransaction, transaction) => {
+    const card = { id: 'card', instrument: 'UZS' }
+    expect(convertCardOrAccountTransaction(card, rawTransaction)).toEqual(transaction)
+  })
 })

--- a/src/plugins/kapitalbank-uz/index.js
+++ b/src/plugins/kapitalbank-uz/index.js
@@ -1,6 +1,6 @@
 import { Jimp } from 'jimp'
 import { delay, generateRandomString } from '../../common/utils'
-import { InvalidLoginOrPasswordError } from '../../errors'
+import { InvalidLoginOrPasswordError, TemporaryError } from '../../errors'
 import {
   authByPhoneNumber,
   authByPassword,
@@ -14,11 +14,6 @@ import {
 } from './api'
 
 export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
-  const photoFromCamera = await ZenMoney.takePicture('jpeg')
-  console.log(typeof photoFromCamera)
-  console.log(photoFromCamera)
-  await blobToBase64WithResolution(photoFromCamera, 480, 640)
-  console.log('toBase64 complete')
   // FIRST RUN STEPS
   if (isFirstRun) {
     const deviceId = generateRandomString(16)
@@ -83,7 +78,7 @@ async function updateToken (phone, password, isResident, pinfl, birthDate) {
       const smsCode = await ZenMoney.readLine('Введите код из СМС сообщения')
       await verifySmsCode(verificationCode, smsCode)
     } else {
-      throw new TemporaryError('Problems with identification')
+      throw e
     }
   }
 }


### PR DESCRIPTION
## Problem

Three bugs in `kapitalbank-uz/index.js`:

1. **`TemporaryError` not imported** — used in `updateToken()` but only imported in `api.js`, not in `index.js`. Causes `ReferenceError` on any 403 response from the bank.

2. **Stray `takePicture` debug call in `scrape()`** — `ZenMoney.takePicture('jpeg')` was called at the top of every `scrape()` invocation (not just on first run), result discarded. Leftover debug code that blocks all syncs.

3. **Wrong error re-thrown in `updateToken` else branch** — `throw new TemporaryError('Problems with identification')` hid the original error. Changed to `throw e`.

## Changes

- `index.js`: add `TemporaryError` to import from `../../errors`
- `index.js`: remove 5 debug lines from top of `scrape()` (takePicture + console.logs + blobToBase64 call)
- `index.js`: fix else branch to `throw e`

## Tests

Added:
- `__tests__/accounts/account.test.js` — `convertAccount` (USD + UZS)
- `__tests__/transactions/deposit-tx.test.js` — `convertDepositTransaction` (INTEREST null + PARTIAL_REPLENISHMENT)
- Coverage for CONVERSION, DEPOSITS_TRANSACTION, ACCOUNTS module branches in `convertCardOrAccountTransaction`