### PR TITLE
fix(apelsin-uz): fix auth retry — inner catch checked outer error variable

### DIFF
--- a/src/plugins/apelsin-uz/__tests__/transactions/mastercard.test.js
+++ b/src/plugins/apelsin-uz/__tests__/transactions/mastercard.test.js
@@ -1,0 +1,49 @@
+import { convertMasterCardTransaction } from '../../converters'
+
+describe('convertMasterCardTransaction', () => {
+  it('converts regular outcome (back: false)', () => {
+    const card = { id: 'mc-card', instrument: 'USD' }
+    const rawTx = {
+      transDate: 1700000000000,
+      amount: '-1500',
+      fee: '0',
+      currency: { name: 'USD' },
+      merchantName: 'AMAZON',
+      back: false
+    }
+    const result = convertMasterCardTransaction(card, rawTx)
+    expect(result).not.toBeNull()
+    expect(result.movements[0].sum).toBe(-1500)
+    expect(result.merchant.title).toBe('AMAZON')
+    expect(result.hold).toBe(false)
+  })
+
+  it('converts refund (back: true) — no merchant', () => {
+    const card = { id: 'mc-card', instrument: 'USD' }
+    const rawTx = {
+      transDate: 1700000000000,
+      amount: '500',
+      fee: '0',
+      currency: { name: 'USD' },
+      merchantName: 'AMAZON',
+      back: true
+    }
+    const result = convertMasterCardTransaction(card, rawTx)
+    expect(result).not.toBeNull()
+    expect(result.movements[0].sum).toBe(500)
+    expect(result.merchant).toBeNull()
+  })
+
+  it('returns null for zero amount', () => {
+    const card = { id: 'mc-card', instrument: 'UZS' }
+    const rawTx = {
+      transDate: 1700000000000,
+      amount: '0',
+      fee: '0',
+      currency: { name: 'UZS' },
+      merchantName: 'TEST',
+      back: false
+    }
+    expect(convertMasterCardTransaction(card, rawTx)).toBeNull()
+  })
+})

--- a/src/plugins/apelsin-uz/auth.js
+++ b/src/plugins/apelsin-uz/auth.js
@@ -1,6 +1,6 @@
 import { fetchJson } from '../../common/network'
 import { generateRandomString } from '../../common/utils'
-import { InvalidPreferencesError } from '../../errors'
+import { InvalidPreferencesError, TemporaryError } from '../../errors'
 
 const baseUrl = 'https://id.uzum.uz/api'
 const apelsinApiBaseUrl = 'https://mobile.apelsin.uz/api'
@@ -32,6 +32,10 @@ export async function coldAuth (preferences) {
       console.error('SMS code validation failed', e)
     }
   } while (!smsVerified && smsCheckAttemps < maxSmsCheckAttempts)
+
+  if (!smsVerified) {
+    throw new TemporaryError('SMS code was not verified')
+  }
 
   await validatePassword(preferences.password)
 

--- a/src/plugins/apelsin-uz/index.js
+++ b/src/plugins/apelsin-uz/index.js
@@ -38,12 +38,12 @@ export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
         await refreshToken(ZenMoney.getData('authRefreshToken'))
         uzcardCards = await getUzcardCards()
       } catch (ex) {
-        if (e instanceof AuthError) {
+        if (ex instanceof AuthError) {
           console.info('try to do cold auth')
           await coldAuth(preferences)
           uzcardCards = await getUzcardCards()
         } else {
-          throw e
+          throw ex
         }
       }
     } else {


### PR DESCRIPTION
## Problem

Two bugs in `apelsin-uz`:

### 1. Auth retry — wrong variable in inner catch

In `index.js`, the `getUzcardCards` auth retry block checked the outer `e` instead of the inner `ex`:

```js
// Before (buggy):
} catch (ex) {
  if (e instanceof AuthError) {   // checks outer `e`, not `ex`
    await coldAuth(preferences)
    uzcardCards = await getUzcardCards()
  } else {
    throw e                        // throws outer error, loses refresh error
  }
}
```

**Effect:** When `refreshToken()` throws for any reason, the code always falls through to `coldAuth()` (because `e` — the original AuthError — is still AuthError). When it should propagate the refresh failure, it throws the wrong error.

### 2. `coldAuth` proceeds past failed SMS verification

In `auth.js`, after 3 failed SMS code attempts `smsVerified` stays `false`, but `validatePassword()` was called unconditionally. The API returns `403 otp_not_passed`, and the plugin continued with no auth tokens.

## Fixes

```js
// index.js — use ex throughout
} catch (ex) {
  if (ex instanceof AuthError) {
    await coldAuth(preferences)
    uzcardCards = await getUzcardCards()
  } else {
    throw ex
  }
}
```

```js
// auth.js — guard before validatePassword
if (!smsVerified) {
  throw new TemporaryError('SMS code was not verified')
}
await validatePassword(preferences.password)
```

## Tests

Added:
- `__tests__/transactions/mastercard.test.js` — `convertMasterCardTransaction` (outcome, refund, zero amount)