### PR TITLE
fix(kapitalbank-uz): fix header formats and missing auth fields

### DIFF
--- a/src/plugins/kapitalbank-uz/api.js
+++ b/src/plugins/kapitalbank-uz/api.js
@@ -8,8 +8,23 @@ import {
   convertDepositTransaction
 } from './converters'
 
-const appVersion = '3.1.1'
+const appVersionFull = '3.5.1-build.750release'
+// Server parses X-App-Version as "Android; X.Y.Z" — strip build suffix (substringBefore "-")
+const appVersion = appVersionFull.split('-')[0]
 const baseUrl = 'https://b2c-api.kapitalbank.uz/api/v1'
+
+function generateUuid () {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = Math.random() * 16 | 0
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16)
+  })
+}
+
+function assertVersionSupported (response) {
+  if (response.status === 426) {
+    throw new TemporaryError('Kapitalbank: ' + (response.body?.errorDetail || response.body?.message || 'Неподдерживаемая версия приложения'))
+  }
+}
 
 function getDefaultHeaders () {
   return {
@@ -19,11 +34,11 @@ function getDefaultHeaders () {
     Connection: 'Keep-Alive',
     DeviceId: ZenMoney.getData('deviceId'),
     Host: 'b2c-api.kapitalbank.uz',
-    'User-Agent': 'okhttp/4.12.0',
-    'X-App-Version': 'Android; ' + appVersion,
+    'User-Agent': 'okhttp/5.3.2',
+    'X-App-Version': appVersion,
     'X-Device-Info': 'Android; 13; samsung; o1s; ' + appVersion + '; XXHDPI; ' + ZenMoney.getData('deviceId'),
     'X-Device-OS': 'ANDROID',
-    'X-Trace-Info': 'sessionId=' + ZenMoney.getData('sessionId') + '; requestId=' + ZenMoney.getData('requestId')
+    'X-Trace-Info': 'sessionId=' + ZenMoney.getData('sessionId') + ' requestId=' + generateUuid()
   }
 }
 
@@ -43,6 +58,7 @@ export async function authByPhoneNumber (phone) {
     sanitizeRequestLog: { body: { phone: true, password: true } }
   })
 
+  assertVersionSupported(response)
   console.assert(response.ok, 'unexpected auth response', response)
 
   return response.body.exist
@@ -56,10 +72,14 @@ export async function authByPassword (phone, password) {
     headers: getDefaultHeaders(),
     body: {
       phoneNumber: phone,
-      password
+      password,
+      otpSendingSource: 'SMS',
+      applicationId: 'uz.kapitalbank.kbonline'
     },
     sanitizeRequestLog: { body: { phone: true, password: true } }
   })
+
+  assertVersionSupported(response)
 
   // нужно пройти процесс идентификации через myid.uz
   if (response.status === 403) {
@@ -108,8 +128,9 @@ export async function refreshToken () {
     sanitizeRequestLog: { body: { verificationCode: true, otpCode: true } }
   })
 
-  // todo обработать неверный код подтверждения
-  console.assert(response.ok, 'unexpected auth response', response)
+  if (!response.ok) {
+    throw new TemporaryError('Kapitalbank: ' + (response.body?.errorDetail || response.body?.message || 'Ошибка обновления токена'))
+  }
 
   ZenMoney.setData('guid', response.body.guid)
   ZenMoney.setData('accessToken', response.body.accessToken)
@@ -149,11 +170,11 @@ export async function myIdVerifyResult (jobId) {
     headers: getDefaultHeaders()
   })
 
-  console.assert(response.ok, 'unexpected myIdVerifyResult response', response)
   if (response.status === 400 || response.status === 404) {
-    return { success: false, ...response.body?.errorDetail }
+    return { success: false, errorDetail: response.body?.errorDetail }
   }
 
+  console.assert(response.ok, 'unexpected myIdVerifyResult response', response)
   return { success: true }
 }
 

--- a/src/plugins/kapitalbank-uz/index.js
+++ b/src/plugins/kapitalbank-uz/index.js
@@ -1,10 +1,11 @@
 import { Jimp } from 'jimp'
 import { delay, generateRandomString } from '../../common/utils'
-import { InvalidLoginOrPasswordError } from '../../errors'
+import { InvalidLoginOrPasswordError, TemporaryError } from '../../errors'
 import {
   authByPhoneNumber,
   authByPassword,
   verifySmsCode,
+  refreshToken,
   myIdIdentify,
   myIdVerifyResult,
   getCards,
@@ -14,11 +15,6 @@ import {
 } from './api'
 
 export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
-  const photoFromCamera = await ZenMoney.takePicture('jpeg')
-  console.log(typeof photoFromCamera)
-  console.log(photoFromCamera)
-  await blobToBase64WithResolution(photoFromCamera, 480, 640)
-  console.log('toBase64 complete')
   // FIRST RUN STEPS
   if (isFirstRun) {
     const deviceId = generateRandomString(16)
@@ -47,7 +43,11 @@ export async function scrape ({ preferences, fromDate, toDate, isFirstRun }) {
   try {
     return await doScrape(fromDate, toDate)
   } catch {
-    await updateToken(preferences.phone, preferences.password, preferences.isResident, preferences.pinfl, preferences.bday)
+    try {
+      await refreshToken()
+    } catch {
+      await updateToken(preferences.phone, preferences.password, preferences.isResident, preferences.pinfl, preferences.bday)
+    }
     return await doScrape(fromDate, toDate)
   }
 }
@@ -83,7 +83,7 @@ async function updateToken (phone, password, isResident, pinfl, birthDate) {
       const smsCode = await ZenMoney.readLine('Введите код из СМС сообщения')
       await verifySmsCode(verificationCode, smsCode)
     } else {
-      throw new TemporaryError('Problems with identification')
+      throw e
     }
   }
 }
@@ -91,7 +91,7 @@ async function updateToken (phone, password, isResident, pinfl, birthDate) {
 async function completeIdentificationOrThrow (isResident, pinfl, birthDate) {
   const photoFromCamera = await ZenMoney.takePicture('jpeg')
   const base64Image = await blobToBase64WithResolution(photoFromCamera, 480, 640)
-  const jobId = await myIdIdentify(isResident, pinfl, birthDate, base64Image)
+  const jobId = await myIdIdentify(isResident === 'true' || isResident === true, pinfl, birthDate, base64Image)
   await delay(2000)
   let verifyResult = await myIdVerifyResult(jobId)
   if (!verifyResult.success) {


### PR DESCRIPTION
## Problem

Users get HTTP 426 (Upgrade Required) from every API call. Error body: `{errorCode: 100015, errorDetail: "Неподдерживаемая версия приложения"}`. After 426 was fixed, access token expiry triggered a re-auth loop that silently set all tokens to `undefined` and crashed with `response.body.map is not a function`.

## Root cause

Five issues found by decompiling the official APK (v3.5.1) with jadx:

**1. `X-App-Version` wrong format** (`hy/p.java` — OkHttp client setup)

The app builds this header as `StringsKt.substringBefore(versionName, "-")`, giving `"3.5.1"` — not `"Android; 3.5.1-build.750release"` as the plugin was sending.

**2. `X-Trace-Info` wrong separator and stale `requestId`** (`yf0/a.java` — header interceptor)

Format is `"sessionId=<id> requestId=<uuid>"` (space-separated, fresh UUID per request). The plugin used `"; "` separator and reused a stored `requestId`.

**3. `/auth/by-password` missing required fields** (`AuthRequest.java`)

Server enforces `otpSendingSource` and `applicationId` as required fields, even though the Kotlin side has defaults. Missing fields → `VALIDATION_ERROR`.

**4. `refreshToken()` used `console.assert` instead of throwing**

`console.assert` doesn't throw in JS — on a 401 it silently set all ZenMoney state to `undefined` and returned normally. The retry `doScrape()` then ran with `Authorization: Bearer undefined`, received another 401, and crashed with `response.body.map is not a function`.

**5. `myIdVerifyResult()` spread a string instead of copying errorDetail**

`{ ...response.body?.errorDetail }` when `errorDetail` is a string produces `{0: 'П', 1: 'р', ...}`. Changed to `{ success: false, errorDetail: response.body?.errorDetail }`.

## Changes

**api.js:**
- `appVersion` strips build suffix via `split('-')[0]` → `"3.5.1"`
- `generateUuid()` added for per-request `requestId`  
- `X-App-Version` sends only the semver string (no `"Android; "` prefix)
- `X-Trace-Info` uses space separator with a fresh UUID each call
- User-Agent bumped to `okhttp/5.3.2` (matches APK)
- `/auth/by-password` body includes `otpSendingSource: 'SMS'` and `applicationId: 'uz.kapitalbank.kbonline'`
- `assertVersionSupported()` added for auth endpoints (426 → TemporaryError)
- `refreshToken()` throws `TemporaryError` on non-ok response
- `myIdVerifyResult()` error object fixed

**index.js:**
- `TemporaryError` was missing from imports (caused ReferenceError at runtime)
- Import `refreshToken`; retry with `refreshToken()` before full re-auth. Full `updateToken()` only if refresh fails
- `isResident` coerced to boolean (`preferences` delivers XML strings)

## Codex review findings

Codex flagged `X-App-Version` format and `X-Trace-Info` separator as potential regressions. Both are false positives — the correct formats were confirmed directly from APK source (`hy/p.java`, `yf0/a.java`).