### PR TITLE
[bybit] add Bybit Card plugin

### DIFF
--- a/src/plugins/bybit/README.md
+++ b/src/plugins/bybit/README.md
@@ -1,0 +1,42 @@
+# Bybit Card plugin for ZenMoney
+
+Synchronizes the **Bybit Card** with ZenMoney via the public Bybit V5 REST API, using a read-only API key + secret.
+
+## What it imports
+
+- One ZenMoney credit-card account (`ccard`): **Bybit Card**.
+  - Stable id: `bybit_card`.
+  - Instrument: `USD`.
+  - Balance: sum of the "one-click" USDT-worth (`uBalance`) returned by the [Convert coin list](https://bybit-exchange.github.io/docs/v5/asset/convert/convert-coin-list) for configured Funding coins (`USDT`, `USDC`) plus the Funding `USD` fiat balance (added automatically, 1:1).
+  - Skip in ZenMoney: `bybit_card`.
+- Card transactions from [`POST /v5/card/transaction/query-asset-records`](https://bybit-exchange.github.io/docs/v5/bybit-card/asset-records).
+  - `SIDE_QUERY_FINANCIAL_ALL` is used for posted card transactions.
+  - `SIDE_QUERY_AUTH` is queried for the requested date range and only in-progress authorizations (`tradeStatus=0`) are imported, so new card payments appear as ZenMoney holds before posting.
+  - Each transaction's movement `sum` is the **total USD amount including fees** (`basicAmount` in `basicCurrency`, expected to be `USD`).
+  - `invoice` is the merchant amount (`transactionAmount` in `transactionCurrency`) only when that currency differs from the USD card account; otherwise it is `null`.
+  - Merchant data is populated from `merchName` / `merchCity` / `merchCountry` / `mccCode`.
+  - Authorizations (`side=1`) and any in-progress transactions (`tradeStatus=0`) are marked as holds.
+  - Declined (`tradeStatus=2`), reversal (`tradeStatus=3`), authorization-reversal (`side=2`), unDeduct-refund (`side=4`), and various `*-reversal` / `*-request` sides are filtered out to avoid double-counting.
+
+## How to create the API key
+
+1. Sign in to [bybit.com](https://www.bybit.com) → click your avatar → **API**.
+2. Click **Create New Key** → **System-generated API Keys** → **API Transaction**.
+3. Set **API Key Permissions** to **Read-Only**.
+4. Enable:
+   - **Bybit Card** (this is the scope required by `/v5/card/transaction/query-asset-records`).
+   - **Wallet** → *Account Transfer* and *Subaccount Transfer* (so the funding-wallet balance probe works).
+   - **Exchange** → *Exchange History* (read-only; required by `/v5/asset/exchange/query-coin-list`, which provides the one-click `uBalance` used for the aggregated USD balance).
+5. **Do NOT** enable any trading, derivatives, or withdrawal permissions. Read-only "Exchange History" alone does not allow executing convert/exchange orders.
+6. Optionally restrict the key by IP for extra safety.
+7. Copy the **API Key** and **API Secret** (the secret is shown only once) and paste them into the plugin's preferences.
+
+## Limitations
+
+- The plugin imports the side codes listed above. If Bybit introduces new `side` values or renames the existing ones, the `SIDE_SIGN` whitelist in [`converters.ts`](converters.ts) needs to be updated.
+- Authorization reversals (`side=2`) are not imported — instead, the matching authorization (`side=1`, in-progress hold) is expected to disappear from the upstream feed or be superseded by a cleared transaction on a subsequent sync. ZenMoney's hold-reconciliation logic handles the difference.
+
+## Suggested ZenMoney workflow
+
+- `Bybit Card` is a single USD `ccard` account. Spending is imported as the final USD card charge, including Bybit's card fees.
+- Hide the card via «skip account» using `bybit_card` if needed. The plugin uses `ZenMoney.isAccountSkipped` and skips imports for skipped accounts.

--- a/src/plugins/bybit/ZenmoneyManifest.xml
+++ b/src/plugins/bybit/ZenmoneyManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>bybit</id>
+    <company>0</company>
+    <description>
+        Bybit Card synchronization via the public Bybit V5 REST API.
+        Requires a read-only API Key + Secret minted in Bybit Dashboard → API
+        with &quot;Bybit Card&quot;, &quot;Wallet&quot;, and &quot;Exchange History&quot; permissions enabled.
+        Imports one USD Bybit Card account from Funding balances and Convert uBalance,
+        plus card transactions from /v5/card/transaction/query-asset-records.
+    </description>
+
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+</provider>

--- a/src/plugins/bybit/__tests__/converters/convertAccounts.test.ts
+++ b/src/plugins/bybit/__tests__/converters/convertAccounts.test.ts
@@ -1,0 +1,88 @@
+import { InvalidPreferencesError } from '../../../../errors'
+import { AccountType } from '../../../../types/zenmoney'
+import {
+  BYBIT_CARD_AGGREGATE_ACCOUNT_ID,
+  createAggregatedAccount,
+  parseCardBalanceCoinsList
+} from '../../converters'
+import { CoinBalance } from '../../models'
+
+describe('parseCardBalanceCoinsList', () => {
+  it('parses, trims, and uppercases a comma-separated list', () => {
+    expect(parseCardBalanceCoinsList('usdt, USDC')).toEqual(new Set(['USDT', 'USDC']))
+  })
+
+  it('deduplicates coins', () => {
+    expect(parseCardBalanceCoinsList('USDT, usdt, USDC')).toEqual(new Set(['USDT', 'USDC']))
+  })
+
+  it('treats empty and whitespace-only items as no-ops', () => {
+    expect(parseCardBalanceCoinsList(', ,USDT,')).toEqual(new Set(['USDT']))
+  })
+
+  it('throws InvalidPreferencesError for unsupported coins', () => {
+    expect(() => parseCardBalanceCoinsList('USDT, BTC')).toThrow(InvalidPreferencesError)
+  })
+})
+
+describe('createAggregatedAccount', () => {
+  const cardCoins = new Set(['USDT', 'USDC', 'USD'])
+
+  it('sums uBalance for USDT and USDC and adds USD fiat 1:1', () => {
+    const balances: CoinBalance[] = [
+      { coin: 'USDT', walletBalance: 100, transferBalance: 95 },
+      { coin: 'USDC', walletBalance: 50, transferBalance: 50 },
+      { coin: 'USD', walletBalance: 12.34, transferBalance: 12.34 }
+    ]
+    const convertUsdtValues = new Map<string, number>([
+      ['USDT', 95.01],
+      ['USDC', 49.97]
+    ])
+    expect(createAggregatedAccount(balances, cardCoins, convertUsdtValues)).toEqual({
+      id: BYBIT_CARD_AGGREGATE_ACCOUNT_ID,
+      type: AccountType.ccard,
+      title: 'Bybit Card',
+      instrument: 'USD',
+      balance: 95.01 + 49.97 + 12.34,
+      creditLimit: 0,
+      syncIds: [BYBIT_CARD_AGGREGATE_ACCOUNT_ID]
+    })
+  })
+
+  it('ignores Funding coins that are not in cardBalanceCoins', () => {
+    const balances: CoinBalance[] = [
+      { coin: 'USDT', walletBalance: 10, transferBalance: 10 },
+      { coin: 'BTC', walletBalance: 999, transferBalance: 999 }
+    ]
+    const convertUsdtValues = new Map<string, number>([
+      ['USDT', 10],
+      ['BTC', 9_999_999]
+    ])
+    const account = createAggregatedAccount(balances, new Set(['USDT', 'USD']), convertUsdtValues)
+    expect(account.balance).toBe(10)
+  })
+
+  it('counts a card coin as 0 when it is missing from the Convert response', () => {
+    const balances: CoinBalance[] = [
+      { coin: 'USDT', walletBalance: 5, transferBalance: 5 },
+      { coin: 'USDC', walletBalance: 3, transferBalance: 3 }
+    ]
+    const convertUsdtValues = new Map<string, number>([['USDT', 5]])
+    const account = createAggregatedAccount(balances, cardCoins, convertUsdtValues)
+    expect(account.balance).toBe(5)
+  })
+
+  it('uses transferBalance (not walletBalance) for USD fiat', () => {
+    const balances: CoinBalance[] = [
+      { coin: 'USD', walletBalance: 100, transferBalance: 80 }
+    ]
+    const account = createAggregatedAccount(balances, cardCoins, new Map())
+    expect(account.balance).toBe(80)
+  })
+
+  it('returns a zero-balance account when there are no matching coins', () => {
+    const account = createAggregatedAccount([], cardCoins, new Map())
+    expect(account.balance).toBe(0)
+    expect(account.id).toBe(BYBIT_CARD_AGGREGATE_ACCOUNT_ID)
+  })
+})

--- a/src/plugins/bybit/__tests__/converters/convertTransaction.test.ts
+++ b/src/plugins/bybit/__tests__/converters/convertTransaction.test.ts
@@ -1,0 +1,204 @@
+import { convertTransaction, selectCardTransactionsForImport } from '../../converters'
+import { AccountOrCard, AccountType } from '../../../../types/zenmoney'
+import { CardTransaction } from '../../models'
+
+const bybitCardAccount: AccountOrCard = {
+  id: 'bybit_card',
+  type: AccountType.ccard,
+  title: 'Bybit Card',
+  instrument: 'USD',
+  balance: 100,
+  creditLimit: 0,
+  syncIds: ['bybit_card']
+}
+
+function baseEntry (overrides: Partial<CardTransaction> = {}): CardTransaction {
+  return {
+    txnId: 'TXN1',
+    orderNo: null,
+    side: '3',
+    tradeStatus: '1',
+    txnCreate: '1672211918471',
+    basicAmount: 101.5,
+    basicCurrency: 'USD',
+    baseAmount: 101.5,
+    paidAmount: 101.5,
+    paidCurrency: 'USDT',
+    transactionAmount: 100,
+    transactionCurrency: 'USD',
+    transactionCurrencyAmount: 100,
+    merchName: null,
+    merchCity: null,
+    merchCountry: null,
+    mccCode: null,
+    merchCategoryDesc: null,
+    pan4: null,
+    declinedReason: null,
+    ...overrides
+  }
+}
+
+describe('convertTransaction', () => {
+  it('converts the cleared-purchase example from the Bybit docs as a USD card charge with fees included', () => {
+    // Sample fields mirror
+    //   https://bybit-exchange.github.io/docs/v5/bybit-card/asset-records
+    const entry = baseEntry({
+      txnId: 'TXN20230101001',
+      orderNo: 'ORD20230101001',
+      side: '3',
+      tradeStatus: '1',
+      txnCreate: '1672211918471',
+      basicAmount: 101.5,
+      basicCurrency: 'USD',
+      paidAmount: 101.5,
+      paidCurrency: 'USDT',
+      transactionAmount: 100,
+      transactionCurrency: 'USD',
+      merchName: 'Amazon',
+      merchCity: 'New York',
+      merchCountry: 'US',
+      mccCode: 5411,
+      merchCategoryDesc: 'Grocery Stores',
+      pan4: '1234'
+    })
+    expect(convertTransaction(entry, bybitCardAccount)).toEqual({
+      hold: false,
+      date: new Date(1672211918471),
+      movements: [{
+        id: 'TXN20230101001',
+        account: { id: 'bybit_card' },
+        invoice: null,
+        sum: -101.5,
+        fee: 0
+      }],
+      merchant: {
+        title: 'Amazon',
+        country: 'US',
+        city: 'New York',
+        mcc: 5411,
+        location: null
+      },
+      comment: null
+    })
+  })
+
+  it('keeps a merchant-currency invoice when it differs from the USD card account currency', () => {
+    const entry = baseEntry({
+      basicAmount: 108,
+      basicCurrency: 'USD',
+      transactionAmount: 100,
+      transactionCurrency: 'EUR'
+    })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect(tx?.movements[0]).toEqual({
+      id: 'TXN1',
+      account: { id: 'bybit_card' },
+      invoice: { sum: -100, instrument: 'EUR' },
+      sum: -108,
+      fee: 0
+    })
+  })
+
+  it('marks an in-progress authorization (side=1, tradeStatus=0) as a hold', () => {
+    const entry = baseEntry({
+      side: '1',
+      tradeStatus: '0',
+      merchName: 'STARBUCKS',
+      mccCode: 5814
+    })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect(tx?.hold).toBe(true)
+    expect(tx?.movements[0].sum).toBe(-101.5)
+  })
+
+  it('converts a refund (side=5) into a positive USD movement', () => {
+    const entry = baseEntry({
+      txnId: 'REFUND-1',
+      side: '5',
+      tradeStatus: '1',
+      basicAmount: 12.34,
+      transactionAmount: 12.34,
+      merchName: 'AMAZON.DE',
+      mccCode: 5942
+    })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect(tx?.movements[0].sum).toBe(12.34)
+    expect(tx?.hold).toBe(false)
+  })
+
+  it('returns null for declined transactions (tradeStatus=2)', () => {
+    expect(convertTransaction(baseEntry({ tradeStatus: '2' }), bybitCardAccount)).toBeNull()
+  })
+
+  it('returns null for reversal entries (tradeStatus=3)', () => {
+    expect(convertTransaction(baseEntry({ tradeStatus: '3' }), bybitCardAccount)).toBeNull()
+  })
+
+  it('returns null for ambiguous sides (auth reversal, refund-request, etc.)', () => {
+    for (const side of ['2', '4', '8', '9', '10', '11']) {
+      expect(convertTransaction(baseEntry({ side }), bybitCardAccount)).toBeNull()
+    }
+  })
+
+  it('omits the invoice when transaction currency equals account currency', () => {
+    const entry = baseEntry({
+      transactionCurrency: 'USD',
+      transactionAmount: 50,
+      basicAmount: 51.25
+    })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect(tx?.movements[0].invoice).toBeNull()
+    expect(tx?.movements[0].sum).toBe(-51.25)
+  })
+
+  it('builds a generic merchant title when only an MCC is present', () => {
+    const entry = baseEntry({ merchName: null, merchCategoryDesc: null, mccCode: 5411 })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect(tx?.merchant).toEqual({
+      title: 'Bybit Card',
+      country: null,
+      city: null,
+      mcc: 5411,
+      location: null
+    })
+  })
+
+  it('uses the category description when there is no merchant name', () => {
+    const entry = baseEntry({ merchName: null, merchCategoryDesc: 'Grocery Stores' })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect((tx?.merchant as { title: string }).title).toBe('Grocery Stores')
+  })
+
+  it('emits null merchant when there is no merchant info at all', () => {
+    const entry = baseEntry({
+      side: '13',
+      merchName: null,
+      merchCategoryDesc: null,
+      merchCity: null,
+      merchCountry: null,
+      mccCode: null
+    })
+    const tx = convertTransaction(entry, bybitCardAccount)
+    expect(tx?.merchant).toBeNull()
+  })
+})
+
+describe('selectCardTransactionsForImport', () => {
+  it('keeps all financial entries and only in-progress authorization entries', () => {
+    const financial = [
+      baseEntry({ txnId: 'FIN-1', tradeStatus: '1' }),
+      baseEntry({ txnId: 'FIN-2', tradeStatus: '3' })
+    ]
+    const auth = [
+      baseEntry({ txnId: 'AUTH-PENDING', tradeStatus: '0' }),
+      baseEntry({ txnId: 'AUTH-COMPLETED', tradeStatus: '1' }),
+      baseEntry({ txnId: 'AUTH-DECLINED', tradeStatus: '2' })
+    ]
+
+    expect(selectCardTransactionsForImport(financial, auth).map(entry => entry.txnId)).toEqual([
+      'FIN-1',
+      'FIN-2',
+      'AUTH-PENDING'
+    ])
+  })
+})

--- a/src/plugins/bybit/__tests__/fetchApi/sign.test.ts
+++ b/src/plugins/bybit/__tests__/fetchApi/sign.test.ts
@@ -1,0 +1,44 @@
+import { buildQueryString, signRequest, stripEmpty } from '../../fetchApi'
+
+describe('Bybit V5 request signing', () => {
+  const apiSecret = 'secret'
+  const timestamp = '1700000000000'
+  const apiKey = 'api-key'
+  const recvWindow = '20000'
+
+  it('signs the exact POST JSON payload sent in the request body', () => {
+    const body = stripEmpty({
+      type: 'SIDE_QUERY_AUTH',
+      createBeginTime: 1,
+      createEndTime: 2,
+      page: 1,
+      limit: 100,
+      empty: '',
+      missing: undefined
+    })
+
+    expect(body).toEqual({
+      type: 'SIDE_QUERY_AUTH',
+      createBeginTime: 1,
+      createEndTime: 2,
+      page: 1,
+      limit: 100
+    })
+
+    const payload = JSON.stringify(body)
+    expect(signRequest(apiSecret, timestamp, apiKey, recvWindow, payload)).toBe('acc8916b5dc03d3f55f8353263a637d389c249687f428d367c28f76b39e1999f')
+  })
+
+  it('signs the exact GET query string sent in the request URL', () => {
+    const payload = buildQueryString({
+      accountType: 'eb_convert_funding',
+      side: 0,
+      coin: 'USDT/USDC',
+      empty: '',
+      missing: undefined
+    })
+
+    expect(payload).toBe('accountType=eb_convert_funding&side=0&coin=USDT%2FUSDC')
+    expect(signRequest(apiSecret, timestamp, apiKey, recvWindow, payload)).toBe('1ba2e324a0b1ceb2545e1466d81cdf654e78d31f154d7cc337da100f9b187674')
+  })
+})

--- a/src/plugins/bybit/api.ts
+++ b/src/plugins/bybit/api.ts
@@ -1,0 +1,77 @@
+import { InvalidPreferencesError } from '../../errors'
+import { parseCardBalanceCoinsList } from './converters'
+import {
+  fetchCardTransactionsPage,
+  fetchConvertCoinUsdtValues as fetchConvertCoinUsdtValuesApi,
+  fetchFundingBalances
+} from './fetchApi'
+import { Auth, CardTransaction, CardTransactionQueryType, CoinBalance, Credentials, Preferences } from './models'
+
+// if > 100, the API returns 10 only
+const PAGE_LIMIT = 100
+
+export async function login (preferences: Preferences): Promise<Auth> {
+  if (preferences.apiKey == null || preferences.apiKey === '' ||
+    preferences.apiSecret == null || preferences.apiSecret === '' ||
+    preferences.cardBalanceCoins == null || preferences.cardBalanceCoins.trim() === '') {
+    throw new InvalidPreferencesError('Bybit: API Key, API Secret, and Card funding coins are required')
+  }
+  // validate the coin list
+  const cardBalanceCoins = parseCardBalanceCoinsList(preferences.cardBalanceCoins)
+  // Always include fiat USD from the Funding wallet (1:1 to USD)
+  cardBalanceCoins.add('USD')
+  const credentials: Credentials = { apiKey: preferences.apiKey, apiSecret: preferences.apiSecret }
+  return { credentials, cardBalanceCoins }
+}
+
+export async function fetchAccounts (creds: Credentials): Promise<CoinBalance[]> {
+  return await fetchFundingBalances(creds)
+}
+
+export async function fetchConvertCoinUsdtValues (creds: Credentials): Promise<Map<string, number>> {
+  return await fetchConvertCoinUsdtValuesApi(creds)
+}
+
+export async function fetchTransactions (
+  creds: Credentials,
+  fromDate: Date,
+  toDate: Date,
+  type: CardTransactionQueryType
+): Promise<CardTransaction[]> {
+  const transactions: CardTransaction[] = []
+  const createBeginTime = fromDate.getTime()
+  const createEndTime = toDate.getTime()
+
+  for (let page = 1; ; page++) {
+    const result = await fetchCardTransactionsPage(creds, {
+      type,
+      createBeginTime,
+      createEndTime,
+      page,
+      limit: PAGE_LIMIT
+    })
+    result.transactions.forEach(txn => transactions.push(txn))
+    const fetchedSoFar = page * PAGE_LIMIT
+    if (result.transactions.length < PAGE_LIMIT || fetchedSoFar >= result.totalCount) {
+      break
+    }
+  }
+
+  return transactions
+}
+
+export async function fetchFinancialTransactions (
+  creds: Credentials,
+  fromDate: Date,
+  toDate: Date
+): Promise<CardTransaction[]> {
+  return await fetchTransactions(creds, fromDate, toDate, 'SIDE_QUERY_FINANCIAL_ALL')
+}
+
+export async function fetchAuthorizationTransactions (
+  creds: Credentials,
+  fromDate: Date,
+  toDate: Date
+): Promise<CardTransaction[]> {
+  return await fetchTransactions(creds, fromDate, toDate, 'SIDE_QUERY_AUTH')
+}

--- a/src/plugins/bybit/converters.ts
+++ b/src/plugins/bybit/converters.ts
@@ -1,0 +1,141 @@
+import { InvalidPreferencesError } from '../../errors'
+import { AccountOrCard, AccountType, Merchant, Transaction } from '../../types/zenmoney'
+import { CardTransaction, CoinBalance } from './models'
+
+/** Stable id of the single USD Bybit Card account. */
+export const BYBIT_CARD_AGGREGATE_ACCOUNT_ID = 'bybit_card'
+
+const AGGREGATE_COINS_SUPPORTED: ReadonlySet<string> = new Set(['USDT', 'USDC'])
+
+// Mapping of /v5/card/transaction/query-asset-records `side` codes to a sign for the amount.
+// The docs list 13 sides; we only emit transactions for unambiguous debits/credits.
+// Anything else (authorization reversals, refund-requests, refund reversals, etc.) is
+// suppressed because it is either redundant (gets superseded by a cleared entry) or
+// cancels an earlier entry, which ZenMoney handles better by simply not importing.
+const SIDE_SIGN: Readonly<Record<string, 1 | -1>> = {
+  1: -1, // Authorization (hold)
+  3: -1, // Transaction (cleared purchase)
+  5: 1, //  Refund (settled credit)
+  6: 1, //  Chargeback (credit via dispute)
+  7: -1, // Transaction (Direct)
+  12: -1, // Chargeback Fee
+  13: -1 // ATM Withdrawal
+}
+
+// Returned by /v5/card/transaction/query-asset-records `tradeStatus`:
+// 0 In_Progress, 1 Completed, 2 Declined, 3 Reversal.
+const SKIPPED_TRADE_STATUSES: ReadonlySet<string> = new Set(['2', '3'])
+
+export function parseCardBalanceCoinsList (raw: string): Set<string> {
+  const coins = new Set<string>()
+  for (const part of raw.split(',')) {
+    const coin = part.trim().toUpperCase()
+    if (coin === '' || coins.has(coin)) {
+      continue
+    }
+
+    if (!AGGREGATE_COINS_SUPPORTED.has(coin)) {
+      throw new InvalidPreferencesError(
+        `Bybit: aggregate card account supports only USDT and USDC in the coin list (got ${coin}).`
+      )
+    }
+    coins.add(coin)
+  }
+  return coins
+}
+
+export function createAggregatedAccount (
+  balances: CoinBalance[],
+  cardBalanceCoins: Set<string>,
+  convertUsdtValues: Map<string, number>
+): AccountOrCard {
+  // USD fiat in Funding is taken 1:1 (it has no entry in the Convert coin list).
+  // Every other allowed coin uses Bybit's own "one-click" USDT-worth value (`uBalance`)
+  // so the aggregated balance matches what the Bybit Card UI displays.
+  let usdSum = 0
+  for (const b of balances) {
+    if (!cardBalanceCoins.has(b.coin)) {
+      continue
+    }
+    if (b.coin === 'USD') {
+      usdSum += b.transferBalance
+    } else {
+      usdSum += convertUsdtValues.get(b.coin) ?? 0
+    }
+  }
+  return {
+    id: BYBIT_CARD_AGGREGATE_ACCOUNT_ID,
+    type: AccountType.ccard,
+    title: 'Bybit Card',
+    instrument: 'USD',
+    balance: usdSum,
+    creditLimit: 0,
+    syncIds: [BYBIT_CARD_AGGREGATE_ACCOUNT_ID]
+  }
+}
+
+export function selectCardTransactionsForImport (
+  financialEntries: CardTransaction[],
+  authorizationEntries: CardTransaction[]
+): CardTransaction[] {
+  return [
+    ...financialEntries,
+    ...authorizationEntries.filter(entry => entry.tradeStatus === '0')
+  ]
+}
+
+export function convertTransaction (
+  entry: CardTransaction,
+  account: AccountOrCard
+): Transaction | null {
+  if (SKIPPED_TRADE_STATUSES.has(entry.tradeStatus)) {
+    return null
+  }
+  const sign = SIDE_SIGN[entry.side]
+  if (sign === undefined) {
+    return null
+  }
+  if (entry.basicAmount === 0 && entry.transactionAmount === 0) {
+    return null
+  }
+
+  const accountCurrency = account.instrument.toUpperCase()
+  const transactionCurrency = entry.transactionCurrency.toUpperCase()
+  const sum = sign * Math.abs(entry.basicAmount)
+  const sameCurrency = transactionCurrency === accountCurrency || entry.transactionAmount === 0
+  const invoice = sameCurrency
+    ? null
+    : { sum: sign * Math.abs(entry.transactionAmount), instrument: transactionCurrency }
+
+  const hold = entry.tradeStatus === '0' || entry.side === '1'
+
+  const merchant = buildMerchant(entry)
+
+  return {
+    hold,
+    date: new Date(Number(entry.txnCreate)),
+    movements: [{
+      id: entry.txnId,
+      account: { id: account.id },
+      invoice,
+      sum,
+      fee: 0
+    }],
+    merchant,
+    comment: null
+  }
+}
+
+function buildMerchant (entry: CardTransaction): Merchant | null {
+  const title = entry.merchName ?? entry.merchCategoryDesc
+  if (title == null && entry.merchCity == null && entry.merchCountry == null && entry.mccCode == null) {
+    return null
+  }
+  return {
+    title: title ?? 'Bybit Card',
+    country: entry.merchCountry,
+    city: entry.merchCity,
+    mcc: entry.mccCode,
+    location: null
+  }
+}

--- a/src/plugins/bybit/fetchApi.ts
+++ b/src/plugins/bybit/fetchApi.ts
@@ -1,0 +1,243 @@
+import crypto from 'crypto-js'
+import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
+import { InvalidPreferencesError, TemporaryError } from '../../errors'
+import { getArray, getOptNumber, getOptString, getString } from '../../types/get'
+import { CardTransaction, CardTransactionQueryType, CoinBalance, Credentials } from './models'
+
+const BASE_URL = 'https://api.bybit.com'
+const RECV_WINDOW = '20000'
+const MIN_REQUEST_INTERVAL_MS = 1500
+let lastRequestAt = 0
+
+export interface CardTransactionPage {
+  transactions: CardTransaction[]
+  page: number
+  pageSize: number
+  totalCount: number
+}
+
+interface GetRequest {
+  method: 'GET'
+  path: string
+  query: Record<string, string | number | undefined>
+}
+
+interface PostRequest {
+  method: 'POST'
+  path: string
+  body: Record<string, string | number | undefined>
+}
+
+type BybitRequest = GetRequest | PostRequest
+
+async function waitForRequestSlot (): Promise<void> {
+  const now = Date.now()
+  const waitMs = lastRequestAt + MIN_REQUEST_INTERVAL_MS - now
+  if (waitMs > 0) {
+    await new Promise(resolve => setTimeout(resolve, waitMs))
+  }
+  lastRequestAt = Date.now()
+}
+
+export function buildQueryString (query: Record<string, string | number | undefined>): string {
+  // Bybit V5 expects the signed query string to be in insertion order, not sorted.
+  // We keep the order of the keys as provided by the caller.
+  const parts: string[] = []
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === '') {
+      continue
+    }
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+  }
+  return parts.join('&')
+}
+
+export function stripEmpty (body: Record<string, string | number | undefined>): Record<string, string | number> {
+  // Strip undefined/empty values so the signed body matches the wire body.
+  const clean: Record<string, string | number> = {}
+  for (const [key, value] of Object.entries(body)) {
+    if (value === undefined || value === '') {
+      continue
+    }
+    clean[key] = value
+  }
+  return clean
+}
+
+export function signRequest (apiSecret: string, timestamp: string, apiKey: string, recvWindow: string, payload: string): string {
+  // Bybit V5 spec: sign = HMAC_SHA256(apiSecret, timestamp + apiKey + recvWindow + (queryString | bodyString))
+  const message = timestamp + apiKey + recvWindow + payload
+  return crypto.HmacSHA256(message, apiSecret).toString(crypto.enc.Hex)
+}
+
+async function callApi (creds: Credentials, request: BybitRequest): Promise<FetchResponse> {
+  await waitForRequestSlot()
+
+  const { apiKey, apiSecret } = creds
+  const timestamp = Date.now().toString()
+
+  let url: string
+  const options: FetchOptions = {
+    method: request.method,
+    sanitizeRequestLog: {
+      headers: { 'X-BAPI-API-KEY': true, 'X-BAPI-SIGN': true }
+    }
+  }
+
+  let payload: string
+  if (request.method === 'GET') {
+    const queryString = buildQueryString(request.query)
+    payload = queryString
+    url = `${BASE_URL}${request.path}${queryString.length > 0 ? `?${queryString}` : ''}`
+  } else {
+    const bodyObject = stripEmpty(request.body)
+    payload = JSON.stringify(bodyObject)
+    url = `${BASE_URL}${request.path}`
+    options.body = bodyObject
+  }
+
+  const signature = signRequest(apiSecret, timestamp, apiKey, RECV_WINDOW, payload)
+  options.headers = {
+    'X-BAPI-API-KEY': apiKey,
+    'X-BAPI-TIMESTAMP': timestamp,
+    'X-BAPI-RECV-WINDOW': RECV_WINDOW,
+    'X-BAPI-SIGN': signature,
+    'X-BAPI-SIGN-TYPE': '2'
+  }
+
+  const response = await fetchJson(url, options)
+
+  if (response.status === 429) {
+    throw new TemporaryError('Bybit: too many requests, try again later')
+  }
+  if (response.status === 401 || response.status === 403) {
+    throw new InvalidPreferencesError('Bybit: API key rejected (HTTP ' + String(response.status) + '). Recreate a read-only key in Bybit Dashboard → API.')
+  }
+
+  const retCode = getOptNumber(response.body, 'retCode')
+  if (retCode !== undefined && retCode !== 0) {
+    const retMsg = getOptString(response.body, 'retMsg') ?? 'unknown error'
+    // 10003 invalid api key, 10004 invalid sign, 33004 api key expired, 10005 permission denied
+    if (retCode === 10003 || retCode === 10004 || retCode === 33004 || retCode === 10005) {
+      throw new InvalidPreferencesError(`Bybit: ${retMsg} (retCode=${retCode}). Recreate a read-only API key in Bybit Dashboard → API with Bybit Card permissions enabled.`)
+    }
+    // 10006 / 10018 rate-limit / ip ban
+    if (retCode === 10006 || retCode === 10018) {
+      throw new TemporaryError(`Bybit: ${retMsg} (retCode=${retCode})`)
+    }
+    throw new TemporaryError(`Bybit API error: ${retMsg} (retCode=${retCode})`)
+  }
+
+  return response
+}
+
+export async function fetchFundingBalances (creds: Credentials): Promise<CoinBalance[]> {
+  const response = await callApi(creds, {
+    method: 'GET',
+    path: '/v5/asset/transfer/query-account-coins-balance',
+    query: { accountType: 'FUND' }
+  })
+
+  const balances = getArray(response.body, 'result.balance')
+  return balances.map(item => ({
+    coin: getString(item, 'coin'),
+    walletBalance: Number(getString(item, 'walletBalance')),
+    transferBalance: Number(getString(item, 'transferBalance'))
+  }))
+}
+
+export async function fetchCardTransactionsPage (
+  creds: Credentials,
+  params: {
+    type: CardTransactionQueryType
+    createBeginTime: number
+    createEndTime: number
+    page: number
+    limit: number
+  }
+): Promise<CardTransactionPage> {
+  const response = await callApi(creds, {
+    method: 'POST',
+    path: '/v5/card/transaction/query-asset-records',
+    body: {
+      type: params.type,
+      createBeginTime: params.createBeginTime,
+      createEndTime: params.createEndTime,
+      page: params.page,
+      limit: params.limit
+    }
+  })
+
+  const data = getArray(response.body, 'result.data')
+  return {
+    transactions: data.map(parseCardTransaction),
+    page: getOptNumber(response.body, 'result.pageNo') ?? params.page,
+    pageSize: getOptNumber(response.body, 'result.pageSize') ?? params.limit,
+    totalCount: getOptNumber(response.body, 'result.totalCount') ?? data.length
+  }
+}
+
+export async function fetchConvertCoinUsdtValues (creds: Credentials): Promise<Map<string, number>> {
+  // Convert API gives the "one-click" USDT-worth value (`uBalance`) for every coin in the
+  // selected wallet. For the Bybit Card the relevant wallet is Funding (eb_convert_funding).
+  // Requires the API key to have the "Exchange / Exchange History" (read-only) permission.
+  const response = await callApi(creds, {
+    method: 'GET',
+    path: '/v5/asset/exchange/query-coin-list',
+    query: { accountType: 'eb_convert_funding', side: 0 }
+  })
+  const list = getArray(response.body, 'result.coins')
+  const values = new Map<string, number>()
+  for (const item of list) {
+    const coin = getString(item, 'coin').toUpperCase()
+    values.set(coin, parseAmountString(item, 'uBalance'))
+  }
+  return values
+}
+
+function parseCardTransaction (item: unknown): CardTransaction {
+  return {
+    txnId: getString(item, 'txnId'),
+    orderNo: nullIfEmpty(getOptString(item, 'orderNo')),
+    side: getString(item, 'side'),
+    tradeStatus: getString(item, 'tradeStatus'),
+    txnCreate: getString(item, 'txnCreate'),
+    basicAmount: parseAmountString(item, 'basicAmount'),
+    basicCurrency: getOptString(item, 'basicCurrency') ?? 'USD',
+    baseAmount: parseAmountString(item, 'baseAmount'),
+    paidAmount: parseAmountString(item, 'paidAmount'),
+    paidCurrency: getString(item, 'paidCurrency'),
+    transactionAmount: parseAmountString(item, 'transactionAmount'),
+    transactionCurrency: getString(item, 'transactionCurrency'),
+    transactionCurrencyAmount: parseAmountString(item, 'transactionCurrencyAmount'),
+    merchName: nullIfEmpty(getOptString(item, 'merchName')),
+    merchCity: nullIfEmpty(getOptString(item, 'merchCity')),
+    merchCountry: nullIfEmpty(getOptString(item, 'merchCountry')),
+    mccCode: parseOptIntString(item, 'mccCode'),
+    merchCategoryDesc: nullIfEmpty(getOptString(item, 'merchCategoryDesc')),
+    pan4: nullIfEmpty(getOptString(item, 'pan4')),
+    declinedReason: nullIfEmpty(getOptString(item, 'declinedReason'))
+  }
+}
+
+function nullIfEmpty (value: string | undefined): string | null {
+  return value == null || value === '' ? null : value
+}
+
+function parseAmountString (item: unknown, path: string): number {
+  const raw = getOptString(item, path)
+  if (raw == null || raw === '') {
+    return 0
+  }
+  const parsed = Number(raw)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function parseOptIntString (item: unknown, path: string): number | null {
+  const raw = getOptString(item, path)
+  if (raw == null || raw === '') {
+    return null
+  }
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/plugins/bybit/index.ts
+++ b/src/plugins/bybit/index.ts
@@ -1,0 +1,40 @@
+import { ScrapeFunc, Transaction } from '../../types/zenmoney'
+import {
+  fetchAccounts,
+  fetchAuthorizationTransactions,
+  fetchConvertCoinUsdtValues,
+  fetchFinancialTransactions,
+  login
+} from './api'
+import {
+  createAggregatedAccount,
+  convertTransaction,
+  selectCardTransactionsForImport
+} from './converters'
+import { Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  const auth = await login(preferences)
+
+  const balances = await fetchAccounts(auth.credentials)
+  const convertUsdtValues = await fetchConvertCoinUsdtValues(auth.credentials)
+
+  const aggregateAccount = createAggregatedAccount(balances, auth.cardBalanceCoins, convertUsdtValues)
+  if (ZenMoney.isAccountSkipped(aggregateAccount.id)) {
+    return { accounts: [aggregateAccount], transactions: [] }
+  }
+
+  const endDate = toDate ?? new Date()
+  const financialEntries = await fetchFinancialTransactions(auth.credentials, fromDate, endDate)
+  const authorizationEntries = await fetchAuthorizationTransactions(auth.credentials, fromDate, endDate)
+  const entries = selectCardTransactionsForImport(financialEntries, authorizationEntries)
+  const transactions: Transaction[] = []
+  for (const entry of entries) {
+    const transaction = convertTransaction(entry, aggregateAccount)
+    if (transaction != null) {
+      transactions.push(transaction)
+    }
+  }
+
+  return { accounts: [aggregateAccount], transactions }
+}

--- a/src/plugins/bybit/models.ts
+++ b/src/plugins/bybit/models.ts
@@ -1,0 +1,50 @@
+export interface Preferences {
+  apiKey: string
+  apiSecret: string
+  startDate: string
+  cardBalanceCoins: string
+}
+
+export interface Auth {
+  credentials: Credentials
+  cardBalanceCoins: Set<string>
+}
+
+export interface Credentials {
+  apiKey: string
+  apiSecret: string
+}
+
+export type CardTransactionQueryType = 'SIDE_QUERY_AUTH' | 'SIDE_QUERY_FINANCIAL_ALL'
+
+export interface CoinBalance {
+  coin: string
+  walletBalance: number
+  transferBalance: number
+}
+
+// Subset of /v5/card/transaction/query-asset-records `data[]` items
+// that we actually use. All amount fields come as strings in the API
+// response and are converted to numbers at parse time.
+export interface CardTransaction {
+  txnId: string
+  orderNo: string | null
+  side: string
+  tradeStatus: string
+  txnCreate: string
+  basicAmount: number
+  basicCurrency: string
+  baseAmount: number
+  paidAmount: number
+  paidCurrency: string
+  transactionAmount: number
+  transactionCurrency: string
+  transactionCurrencyAmount: number
+  merchName: string | null
+  merchCity: string | null
+  merchCountry: string | null
+  mccCode: number | null
+  merchCategoryDesc: string | null
+  pan4: string | null
+  declinedReason: string | null
+}

--- a/src/plugins/bybit/preferences.xml
+++ b/src/plugins/bybit/preferences.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="apiKey"
+        obligatory="true"
+        title="Read-only API Key"
+        dialogTitle="Read-only API Key"
+        dialogMessage="Create a System-generated, Read-Only API key in Bybit Dashboard → API → Create New Key. Enable permissions: &quot;Bybit Card&quot; (required for the card transaction history endpoint), &quot;Wallet → Account Transfer / Subaccount Transfer&quot; (for the funding wallet balance probe), and &quot;Exchange → Exchange History&quot; (read-only; required by the convert coin-list endpoint that powers the aggregated USD balance). Do NOT enable trading or withdrawal permissions. Paste the API Key here."
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|apiKey|{@s}"
+    />
+    <EditTextPreference
+        key="apiSecret"
+        obligatory="true"
+        inputType="textPassword"
+        title="Read-only API Secret"
+        dialogTitle="Read-only API Secret"
+        dialogMessage="Paste the API Secret that was shown once when you created the API key. The secret is used to sign requests with HMAC-SHA256 and is never sent to Bybit in plain text."
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="||***********"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="From what date to load transactions"
+        defaultValue="2024-01-01T00:00:00.000Z"
+        dialogTitle="From what date to load transactions"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|startDate|{@s}"
+    />
+    <EditTextPreference
+        key="cardBalanceCoins"
+        obligatory="true"
+        defaultValue="USDT, USDC"
+        title="Card funding coins"
+        dialogTitle="Coins that fund the card"
+        dialogMessage="Comma-separated list, e.g. USDT, USDC. The plugin imports one Bybit Card account in USD (bybit_card). The account balance is the Bybit Convert uBalance for these Funding coins plus Funding USD fiat 1:1. Only USDT and USDC are allowed in this list."
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|cardBalanceCoins|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
## Summary

Adds a Bybit Card plugin for syncing Bybit Card transactions and USD balance into ZenMoney.

## Features

- Creates one USD credit-card account for Bybit Card
- Imports confirmed card transactions from `SIDE_QUERY_FINANCIAL_ALL`
- Imports pending card authorizations from `SIDE_QUERY_AUTH`
- Uses Bybit Convert API to calculate Funding wallet balance in USD
- Adds API throttling to reduce Bybit rate-limit errors
- Includes setup documentation for required Bybit API permissions

## Testing

- Tested against my own Bybit Card with different transaction types using `yarn run bybit`