### PR TITLE
[trading212] move to the csv export api to suppord the t212 card

### DIFF
--- a/src/plugins/trading212/__tests__/convertAccount.test.ts
+++ b/src/plugins/trading212/__tests__/convertAccount.test.ts
@@ -1,4 +1,5 @@
 import { convertAccount } from '../converters'
+import { AccountType } from '../../../types/zenmoney'
 
 describe('convertAccount', () => {
   it.each([
@@ -8,27 +9,73 @@ describe('convertAccount', () => {
         currency: 'EUR',
         totalValue: 1000.50,
         cash: {
-          availableToTrade: 0,
+          availableToTrade: 100.00,
           reservedForOrders: 0,
-          inPies: 0
+          inPies: 50.00
         },
         investments: {
-          currentValue: 1000.50,
+          currentValue: 800.50,
           totalCost: 900.00,
           realizedProfitLoss: 0,
           unrealizedProfitLoss: 100.50
         }
       },
       {
-        id: '12345',
-        type: 'investment',
-        title: 'Trading212',
-        instrument: 'EUR',
-        balance: 1000.50,
-        syncIds: ['12345']
+        account: {
+          id: '12345',
+          type: AccountType.investment,
+          title: 'Trading212',
+          instrument: 'EUR',
+          balance: 900.50,
+          syncIds: ['12345']
+        },
+        card: {
+          id: '12345-card',
+          type: AccountType.ccard,
+          title: 'Trading212 Card',
+          instrument: 'EUR',
+          balance: 100.00,
+          syncIds: ['12345-card']
+        }
+      }
+    ],
+    [
+      {
+        id: 99999,
+        currency: 'USD',
+        totalValue: 5000.00,
+        cash: {
+          availableToTrade: 2000.00,
+          reservedForOrders: 500.00,
+          inPies: 100.00
+        },
+        investments: {
+          currentValue: 2500.00,
+          totalCost: 2000.00,
+          realizedProfitLoss: 100.00,
+          unrealizedProfitLoss: 500.00
+        }
+      },
+      {
+        account: {
+          id: '99999',
+          type: AccountType.investment,
+          title: 'Trading212',
+          instrument: 'USD',
+          balance: 4500.00,
+          syncIds: ['99999']
+        },
+        card: {
+          id: '99999-card',
+          type: AccountType.ccard,
+          title: 'Trading212 Card',
+          instrument: 'USD',
+          balance: 500.00,
+          syncIds: ['99999-card']
+        }
       }
     ]
-  ])('converts account summary to investment account', (accountSummary, expected) => {
-    expect(convertAccount(accountSummary)).toEqual(expected)
+  ])('converts account summary to investment account and card', (accountSummary, expected) => {
+    expect(convertAccount(accountSummary as any)).toEqual(expected)
   })
 })

--- a/src/plugins/trading212/__tests__/convertTransactions.test.ts
+++ b/src/plugins/trading212/__tests__/convertTransactions.test.ts
@@ -1,60 +1,143 @@
+import { Movement } from '../../../types/zenmoney'
 import { convertTransactions } from '../converters'
-import { ApiTransaction } from '../models'
+import { ExportOperation, Preferences } from '../models'
+
+const defaultPreferences: Preferences = {
+  apiKey: 'test-key',
+  apiSecret: 'test-secret',
+  roundUpTransactions: false,
+  investCashback: false
+}
 
 describe('convertTransactions', () => {
   it.each([
     [
       '12345',
+      '12345-card',
       [
-        { type: 'DEPOSIT', dateTime: '2026-01-15T10:30:00Z', reference: '019be923-b231-74b2-af67-f57829f479fc', amount: 1000 },
-        { type: 'WITHDRAW', dateTime: '2026-01-16T14:20:00Z', reference: 'd9cd1d17-f010-45f9-90ef-99a825387795', amount: -500 }
-      ],
+        { ID: 'abc-123', Action: 'Market buy', Time: '2026-01-15T10:30:00Z', 'Gross Total': -1000, 'Currency (Gross Total)': 'EUR' },
+        { ID: 'abc-456', Action: 'Market sell', Time: '2026-01-16T14:20:00Z', 'Gross Total': 500, 'Currency (Gross Total)': 'EUR' }
+      ] as ExportOperation[],
       [
         {
           hold: false,
           date: new Date('2026-01-15T10:30:00Z'),
-          movements: [{ id: '019be923-b231-74b2-af67-f57829f479fc', account: { id: '12345' }, invoice: null, sum: 1000, fee: 0 }],
-          comment: 'Deposit',
+          movements: [{ id: 'abc-123', account: { id: '12345' }, invoice: null, sum: -1000, fee: 0 }],
+          comment: 'Market buy',
           merchant: null
         },
         {
           hold: false,
           date: new Date('2026-01-16T14:20:00Z'),
-          movements: [{ id: 'd9cd1d17-f010-45f9-90ef-99a825387795', account: { id: '12345' }, invoice: null, sum: -500, fee: 0 }],
-          comment: 'Withdrawal',
+          movements: [{ id: 'abc-456', account: { id: '12345' }, invoice: null, sum: 500, fee: 0 }],
+          comment: 'Market sell',
           merchant: null
         }
       ]
     ],
     [
       '67890',
+      '67890-card',
       [
-        { type: 'TRANSFER', dateTime: '2026-02-01T09:00:00Z', reference: '5844048e-743f-42df-b109-b3ec9db2b721', amount: 2500 },
-        { type: 'FEE', dateTime: '2026-02-01T09:00:01Z', reference: '049517c3-a11b-4d6f-a6ee-0191fb8be9ac', amount: -2.50 }
-      ],
+        { ID: 'div-001', Action: 'Dividend (Tax)', Time: '2026-02-01T09:00:00Z', 'Gross Total': -2.50, 'Currency (Gross Total)': 'USD' },
+        { ID: 'div-002', Action: 'Dividend (Dividend)', Time: '2026-02-01T09:00:00Z', 'Gross Total': 25.00, 'Currency (Gross Total)': 'USD' },
+        { ID: 'fee-001', Action: 'Stop limit order', Time: '2026-02-01T09:00:01Z', 'Gross Total': -1.00, 'Currency (Gross Total)': 'USD' }
+      ] as ExportOperation[],
       [
         {
           hold: false,
           date: new Date('2026-02-01T09:00:00Z'),
-          movements: [{ id: '5844048e-743f-42df-b109-b3ec9db2b721', account: { id: '67890' }, invoice: null, sum: 2500, fee: 0 }],
-          comment: 'Internal transfer',
+          movements: [{ id: 'div-001', account: { id: '67890' }, invoice: null, sum: -2.50, fee: 0 }],
+          comment: 'Dividend (Tax)',
+          merchant: null
+        },
+        {
+          hold: false,
+          date: new Date('2026-02-01T09:00:00Z'),
+          movements: [{ id: 'div-002', account: { id: '67890' }, invoice: null, sum: 25.00, fee: 0 }],
+          comment: 'Dividend (Dividend)',
           merchant: null
         },
         {
           hold: false,
           date: new Date('2026-02-01T09:00:01Z'),
-          movements: [{ id: '049517c3-a11b-4d6f-a6ee-0191fb8be9ac', account: { id: '67890' }, invoice: null, sum: -2.50, fee: 0 }],
-          comment: 'Transaction fee',
+          movements: [{ id: 'fee-001', account: { id: '67890' }, invoice: null, sum: -1.00, fee: 0 }],
+          comment: 'Stop limit order',
           merchant: null
         }
       ]
     ],
     [
       'empty-account',
-      [],
+      'empty-account-card',
+      [] as ExportOperation[],
       []
     ]
-  ])('converts api transactions to zenmoney format', (accountId, apiTransactions, expected) => {
-    expect(convertTransactions(apiTransactions as ApiTransaction[], accountId)).toEqual(expected)
+  ])('converts export operations to zenmoney format', (accountId, cardId, operations, expected) => {
+    expect(convertTransactions(operations, accountId, cardId, defaultPreferences)).toEqual(expected)
+  })
+
+  it('routes Card debit to card account', () => {
+    const operations: ExportOperation[] = [
+      { ID: 'card-001', Action: 'Card debit', Time: '2026-03-01T12:00:00Z', 'Gross Total': -15.50, 'Currency (Gross Total)': 'EUR', 'Merchant name': 'Coffee Shop', 'Merchant category': 'Food & Drinks' }
+    ]
+    const result = convertTransactions(operations, 'acc-1', 'acc-1-card', defaultPreferences)
+    expect(result).toHaveLength(1)
+    expect(result[0].movements[0].account).toEqual({ id: 'acc-1-card' })
+    expect(result[0].merchant).toMatchObject({ fullTitle: 'Coffee Shop', category: 'Food & Drinks' })
+  })
+
+  it('routes Spending cashback to card account when investCashback is false', () => {
+    const operations: ExportOperation[] = [
+      { ID: 'cashback-001', Action: 'Spending cashback', Time: '2026-03-01T12:00:00Z', 'Gross Total': 0.50, 'Currency (Gross Total)': 'EUR' }
+    ]
+    const result = convertTransactions(operations, 'acc-1', 'acc-1-card', defaultPreferences)
+    expect(result).toHaveLength(1)
+    expect(result[0].movements[0].account).toEqual({ id: 'acc-1-card' })
+  })
+
+  it('routes Spending cashback to investment account when investCashback is true', () => {
+    const operations: ExportOperation[] = [
+      { ID: 'cashback-002', Action: 'Spending cashback', Time: '2026-03-01T12:00:00Z', 'Gross Total': 0.75, 'Currency (Gross Total)': 'EUR' }
+    ]
+    const prefs: Preferences = { ...defaultPreferences, investCashback: true }
+    const result = convertTransactions(operations, 'acc-1', 'acc-1-card', prefs)
+    expect(result).toHaveLength(1)
+    expect(result[0].movements[0].account).toEqual({ id: 'acc-1' })
+  })
+
+  it('adds round-up transaction for Card debit when roundUpTransactions is enabled', () => {
+    const operations: ExportOperation[] = [
+      { ID: 'round-001', Action: 'Card debit', Time: '2026-04-01T10:00:00Z', 'Gross Total': -12.30, 'Currency (Gross Total)': 'EUR' }
+    ]
+    const prefs: Preferences = { ...defaultPreferences, roundUpTransactions: true }
+    const result = convertTransactions(operations, 'acc-1', 'acc-1-card', prefs)
+    expect(result).toHaveLength(2)
+
+    // First transaction: the card debit itself
+    expect(result[0].movements[0].account).toEqual({ id: 'acc-1-card' })
+    expect(result[0].movements[0].sum).toBe(-12.30)
+
+    // Second transaction: round-up (card -> investment)
+    expect(result[1].comment).toBe('Round up')
+    expect(result[1].movements).toHaveLength(2)
+    // Card leg: -0.70
+    expect(result[1].movements[0].account).toEqual({ id: 'acc-1-card' })
+    expect(result[1].movements[0].sum).toBe(-0.70)
+    // Investment leg: +0.70
+    const movements = result[1].movements as [Movement, Movement]
+    expect(movements[1].account).toEqual({ id: 'acc-1' })
+    expect(movements[1].sum).toBe(0.70)
+  })
+
+  it('does not add round-up when the amount is already whole', () => {
+    const operations: ExportOperation[] = [
+      { ID: 'round-002', Action: 'Card debit', Time: '2026-04-01T10:00:00Z', 'Gross Total': -15.00, 'Currency (Gross Total)': 'EUR' }
+    ]
+    const prefs: Preferences = { ...defaultPreferences, roundUpTransactions: true }
+    const result = convertTransactions(operations, 'acc-1', 'acc-1-card', prefs)
+    // Only the card debit, no round-up (amount is already whole)
+    expect(result).toHaveLength(1)
+    expect(result[0].movements[0].sum).toBe(-15.00)
   })
 })

--- a/src/plugins/trading212/api.ts
+++ b/src/plugins/trading212/api.ts
@@ -1,37 +1,24 @@
-import _ from 'lodash'
+import * as XLSX from 'xlsx'
 
-import { fetchAccountSummary, fetchTransactionsPage } from './fetchApi'
-import { AccountSummary, Preferences, ApiTransaction } from './models'
+import { fetch } from '../../common/network'
+import { fetchAccountSummary, requestExport, listExports } from './fetchApi'
+import { AccountSummary, Preferences, ExportOperation } from './models'
 
 export async function fetchAccount (preferences: Preferences): Promise<AccountSummary> {
   return await fetchAccountSummary(preferences)
 }
 
-export async function fetchTransactions (preferences: Preferences, fromDate?: Date, toDate?: Date): Promise<ApiTransaction[]> {
-  const transactions: ApiTransaction[] = []
+export async function fetchTransactions (preferences: Preferences, fromDate?: Date, toDate?: Date): Promise<ExportOperation[]> {
+  const { reportId } = await requestExport(preferences, fromDate, toDate)
 
-  let page = await fetchTransactionsPage(preferences)
-  transactions.push(...page.items)
-  while (page.nextPaghPath != null) {
-    page = await fetchTransactionsPage(preferences, page.nextPaghPath)
-    transactions.push(...page.items)
-
-    if ((fromDate != null) && new Date(transactions[transactions.length - 1].dateTime) < fromDate) {
-      break
-    }
+  await new Promise((resolve) => setTimeout(resolve, 10000))
+  const exports = await listExports(preferences)
+  const exportData = exports.find(e => e.reportId === reportId && e.status === 'Finished' && e.downloadLink)
+  if (exportData == null) {
+    throw new Error('Export took too long, try a shorter period')
   }
+  const exportResponse = await fetch(exportData.downloadLink)
+  const csv = XLSX.read(exportResponse.body, { type: 'string' }).Sheets.Sheet1
 
-  console.log(fromDate, toDate, transactions.length)
-
-  const sliceStart = (toDate != null)
-    ? _.findIndex(transactions, transaction => Date.parse(transaction.dateTime) <= toDate.getTime())
-    : 0
-
-  const sliceEnd = (fromDate != null)
-    ? _.findLastIndex(transactions, transaction => Date.parse(transaction.dateTime) >= fromDate.getTime())
-    : transactions.length - 1
-
-  console.log(sliceStart, sliceEnd)
-
-  return transactions.slice(sliceStart, sliceEnd + 1)
+  return XLSX.utils.sheet_to_json<ExportOperation>(csv)
 }

--- a/src/plugins/trading212/converters.ts
+++ b/src/plugins/trading212/converters.ts
@@ -1,45 +1,91 @@
 import { AccountOrCard, AccountType, Transaction } from '../../types/zenmoney'
-import { AccountSummary, ApiTransaction } from './models'
+import { AccountSummary, ExportOperation, Preferences } from './models'
 
-export function convertAccount (accountSummary: AccountSummary): AccountOrCard {
+export function convertAccount (accountSummary: AccountSummary): { account: AccountOrCard, card: AccountOrCard } {
   const id = accountSummary.id.toString()
+  const cardBalance = accountSummary.totalValue - accountSummary.investments.currentValue - accountSummary.cash.availableToTrade
   return {
-    id,
-    type: AccountType.investment,
-    title: 'Trading212',
-    instrument: accountSummary.currency,
-    balance: accountSummary.totalValue,
-    syncIds: [id]
+    account: {
+      id,
+      type: AccountType.investment,
+      title: 'Trading212',
+      instrument: accountSummary.currency,
+      balance: accountSummary.totalValue - cardBalance,
+      syncIds: [id]
+    },
+    card: {
+      id: id + '-card',
+      type: AccountType.ccard,
+      title: 'Trading212 Card',
+      instrument: accountSummary.currency,
+      balance: cardBalance,
+      syncIds: [id + '-card']
+    }
   }
 }
 
-export function convertTransactions (apiTransactions: ApiTransaction[], accountId: string): Transaction[] {
-  return apiTransactions.map(tr => convertTransaction(tr, accountId))
+export function convertTransactions (operations: ExportOperation[], accountId: string, cardId: string, preferences: Preferences): Transaction[] {
+  return operations.flatMap(op => convertTransaction(op, accountId, cardId, preferences))
 }
 
-function convertTransaction (tr: ApiTransaction, accountId: string): Transaction {
-  let comment: string = ''
-  if (tr.type === 'TRANSFER') {
-    comment = 'Internal transfer'
-  } else if (tr.type === 'DEPOSIT') {
-    comment = 'Deposit'
-  } else if (tr.type === 'FEE') {
-    comment = 'Transaction fee'
-  } else if (tr.type === 'WITHDRAW') {
-    comment = 'Withdrawal'
+function convertTransaction (op: ExportOperation, accountId: string, cardId: string, preferences: Preferences): Transaction[] {
+  const isCardDebit = op.Action === 'Card debit'
+  const isCardCashback = op.Action === 'Spending cashback' && !preferences.investCashback
+  const isCardTransaction = isCardDebit || isCardCashback
+
+  console.log('Converting operation', op)
+
+  const transactions: Transaction[] = [
+    {
+      hold: false,
+      date: new Date(op.Time),
+      movements: [{
+        id: op.ID,
+        account: { id: isCardTransaction ? cardId : accountId },
+        invoice: null,
+        sum: op['Gross Total'],
+        fee: 0
+      }],
+      comment: op.Action,
+      merchant: op['Merchant name'] != null
+        ? {
+            fullTitle: op['Merchant name'],
+            category: op['Merchant category'],
+            mcc: null,
+            location: null
+          }
+        : null
+    }
+  ]
+
+  if (preferences.roundUpTransactions && isCardDebit) {
+    const roundedSum = Math.ceil(Math.abs(op['Gross Total']))
+    const roundUpAmount = +(roundedSum - Math.abs(op['Gross Total'])).toPrecision(5)
+    if (roundUpAmount > 0) {
+      transactions.push({
+        hold: false,
+        date: new Date(op.Time),
+        movements: [
+          {
+            id: null,
+            account: { id: cardId },
+            invoice: null,
+            sum: -roundUpAmount,
+            fee: 0
+          },
+          {
+            id: null,
+            account: { id: accountId },
+            invoice: null,
+            sum: roundUpAmount,
+            fee: 0
+          }
+        ],
+        comment: 'Round up',
+        merchant: null
+      })
+    }
   }
 
-  return {
-    hold: false,
-    date: new Date(tr.dateTime),
-    movements: [{
-      id: tr.reference,
-      account: { id: accountId },
-      invoice: null,
-      sum: tr.amount,
-      fee: 0
-    }],
-    comment,
-    merchant: null
-  }
+  return transactions
 }

--- a/src/plugins/trading212/fetchApi.ts
+++ b/src/plugins/trading212/fetchApi.ts
@@ -1,6 +1,6 @@
 import { fetchJson, FetchOptions } from '../../common/network'
 import { InvalidLoginOrPasswordError, TemporaryError } from '../../errors'
-import { AccountSummary, Preferences, TransactionHistoryPage } from './models'
+import { AccountSummary, Preferences, ExportRequest, ExportData } from './models'
 
 const BASE_URL = 'https://live.trading212.com/api/v0/equity'
 
@@ -21,10 +21,32 @@ async function fetchApi<T> (url: string, { apiKey, apiSecret }: Preferences, opt
   return response.body as T
 }
 
-export async function fetchAccountSummary (preferences: Preferences): Promise<AccountSummary> {
-  return await fetchApi('/account/summary', preferences)
+export async function requestExport (preferences: Preferences, fromDate?: Date, toDate?: Date): Promise<ExportRequest> {
+  const now = new Date()
+  const yearAgo = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate())
+
+  const timeFrom = ((fromDate != null) && fromDate > yearAgo ? fromDate : yearAgo).toISOString()
+  const timeTo = ((toDate != null) && toDate < now ? toDate : now).toISOString()
+
+  return await fetchApi('/history/exports', preferences, {
+    method: 'POST',
+    body: {
+      dataIncluded: {
+        includeOrders: false,
+        includeDividends: true,
+        includeInterest: true,
+        includeTransactions: true
+      },
+      timeFrom,
+      timeTo
+    }
+  })
 }
 
-export async function fetchTransactionsPage (preferences: Preferences, path?: string): Promise<TransactionHistoryPage> {
-  return await fetchApi(`/history/transactions${path !== undefined ? `?${path}` : ''}`, preferences)
+export async function listExports (preferences: Preferences): Promise<ExportData[]> {
+  return await fetchApi('/history/exports', preferences)
+}
+
+export async function fetchAccountSummary (preferences: Preferences): Promise<AccountSummary> {
+  return await fetchApi('/account/summary', preferences)
 }

--- a/src/plugins/trading212/index.ts
+++ b/src/plugins/trading212/index.ts
@@ -4,14 +4,16 @@ import { fetchAccount, fetchTransactions } from './api'
 import { Preferences } from './models'
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
-  const account = convertAccount(await fetchAccount(preferences))
+  const { account, card } = convertAccount(await fetchAccount(preferences))
   const transactions = convertTransactions(
     await fetchTransactions(preferences, fromDate, toDate),
-    account.id
+    account.id,
+    card.id,
+    preferences
   )
 
   return {
-    accounts: [account],
+    accounts: [account, card],
     transactions
   }
 }

--- a/src/plugins/trading212/models.ts
+++ b/src/plugins/trading212/models.ts
@@ -1,22 +1,51 @@
 export interface Preferences {
   apiKey: string
   apiSecret: string
+  roundUpTransactions: boolean
+  investCashback: boolean
 }
 
 export interface AccountSummary {
   id: number
   currency: string
   totalValue: number
+  cash: {
+    availableToTrade: number
+    reservedForOrders: number
+    inPies: number
+  }
+  investments: {
+    currentValue: number
+    totalCost: number
+    realizedProfitLoss: number
+    unrealizedProfitLoss: number
+  }
 }
 
-export interface ApiTransaction {
-  type: 'WITHDRAW' | 'DEPOSIT' | 'FEE' | 'TRANSFER'
-  amount: number
-  reference: string
-  dateTime: string
+export interface ExportRequest {
+  reportId: number
 }
 
-export interface TransactionHistoryPage {
-  items: ApiTransaction[]
-  nextPaghPath: string | null
+export interface ExportData {
+  reportId: number
+  dataIncluded: {
+    includeOrders: boolean
+    includeDividends: boolean
+    includeInterest: boolean
+    incudeTransactions: boolean
+  }
+  timeFrom: string
+  timeTo: string
+  status: 'Queued' | 'Processing' | 'Running' | 'Canceled' | 'Failed' | 'Finished'
+  downloadLink: string
+}
+
+export interface ExportOperation {
+  ID: string
+  Action: string
+  Time: string
+  'Gross Total': number
+  'Currency (Gross Total)': string
+  'Merchant name'?: string
+  'Merchant category'?: string
 }

--- a/src/plugins/trading212/preferences.xml
+++ b/src/plugins/trading212/preferences.xml
@@ -5,7 +5,7 @@
         obligatory="true"
         title="API Key"
         dialogTitle="API Key"
-        dialogMessage="Enter your Trading212 API key. You can generate one in Settings -> API → Generate API key. The key must have the &quot;Unrestricted&quot; type and have &quot;Account data&quot; and &quot;History - Transactions&quot; permissions."
+        dialogMessage="Enter your Trading212 API key. You can generate one in Settings -> API → Generate API key. The key must have the &quot;Unrestricted&quot; type and have &quot;Account data&quot; and ALL of the &quot;History&quot; permissions. If you use the Trading212 debit card, you will have to manually add deposits to that card, since the API doesn't show them."
         positiveButtonText="OK"
         negativeButtonText="Cancel"
         summary="|apiKey|{@s}"
@@ -30,5 +30,21 @@
         positiveButtonText="OK"
         negativeButtonText="Cancel"
         summary="|startDate|{@s}"
+    />
+    <CheckBoxPreference
+        key="roundUpTransactions"
+        title="&quot;Invest spare change&quot; enabled"
+        dialogTitle="&quot;Invest spare change&quot; enabled"
+        dialogMessage="Trading212 API doesn't return the investments made with the &quot;Invest spare change&quot; feature. If you use the Trading212 debit card with this feature, enable this option to automatically create the rounding transactions."
+        defaultValue="false"
+        summary="||{@s}"
+    />
+    <CheckBoxPreference
+        key="investCashback"
+        title="&quot;Invest cashback&quot; enabled"
+        dialogTitle="&quot;Invest cashback&quot; enabled"
+        dialogMessage="Trading212 API doesn't tell where the cashback is debited. If you use the Trading212 debit card with this feature, enable this option to put cashback into the correct account."
+        defaultValue="false"
+        summary="||{@s}"
     />
 </PreferenceScreen>


### PR DESCRIPTION
The regular t212 api doesn't return transactions for their debit card (https://www.trading212.com/cards)

This PR changes it to the CSV export API which has those transactions, though unfortunately requires a 10 second wait to make sure the export is generated, and still doesn't show card deposits, so those have to be added manually :cry: I have contacted their support about adding the data to the API, if they decide to add it then the plugin could be switched back to the proper API.

AI disclosure: the tests in this PR are AI-generated (but manually verified). The rest of the code is handwritten and manually tested using the `yarn start` script.