### PR TITLE
[zepterbank-by]: Стабильная дедупликация истории и выписки

### DIFF
--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -292,4 +292,128 @@ describe('getTransactions', () => {
     expect(withHistory).toHaveLength(1)
     expect(statementOnly[0].movements[0].id).toBe(withHistory[0].movements[0].id)
   })
+
+  it('keeps separate same-day same-merchant history transactions distinct', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [
+        {
+          effectiveDate: '2026-05-25T10:00:00',
+          transacName: 'POS PURCHASE ',
+          amount: '20.00',
+          currencyIso: 'BYN',
+          cardAcceptor: 'INTERNET-BANKING ZEPTERBANK',
+          repeatable: false,
+          transOperType: 'debit',
+          transMcc: 'МСС4900'
+        },
+        {
+          effectiveDate: '2026-05-25T18:00:00',
+          transacName: 'POS PURCHASE ',
+          amount: '20.00',
+          currencyIso: 'BYN',
+          cardAcceptor: 'INTERNET-BANKING ZEPTERBANK',
+          repeatable: false,
+          transOperType: 'debit',
+          transMcc: 'МСС4900'
+        }
+      ],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: []
+      },
+      error: null
+    })
+
+    const transactions = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].movements[0].id).not.toBe(transactions[1].movements[0].id)
+  })
+
+  it('keeps separate same-day same-merchant statement transactions distinct', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [
+          {
+            transactionDate: '2026-05-25T00:00:00',
+            balanceDate: '2026-05-25',
+            operationName: 'Оплата в интернет-банке',
+            operationSum: '20.00',
+            transactionSum: '20.00',
+            transactionCurrency: '933',
+            transactionCurrencyISO: 'BYN',
+            operationSign: -1 as const,
+            operationCurrency: '933',
+            operationCurrencyIso: 'BYN',
+            merchant: 'BLR MINSK',
+            terminalLocation: 'INTERNET-BANKING ZEPTERBANK',
+            MCC: 'MCC 4900'
+          },
+          {
+            transactionDate: '2026-05-25T00:00:00',
+            balanceDate: '2026-05-25',
+            operationName: 'Оплата в интернет-банке',
+            operationSum: '20.00',
+            transactionSum: '20.00',
+            transactionCurrency: '933',
+            transactionCurrencyISO: 'BYN',
+            operationSign: -1 as const,
+            operationCurrency: '933',
+            operationCurrencyIso: 'BYN',
+            merchant: 'BLR MINSK',
+            terminalLocation: 'INTERNET-BANKING ZEPTERBANK',
+            MCC: 'MCC 4900'
+          }
+        ]
+      },
+      error: null
+    })
+
+    const transactions = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].movements[0].id).not.toBe(transactions[1].movements[0].id)
+  })
 })

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -138,4 +138,63 @@ describe('getTransactions', () => {
       convertStatementTransaction(statementOperation, account)
     ])
   })
+
+  it('deduplicates capitalization rows using statement balance date', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-05-29T18:04:10',
+      transacName: 'CREDIT ACCOUNT',
+      amount: '0.33',
+      currencyIso: 'BYN',
+      repeatable: false,
+      transOperType: 'credit',
+      transMcc: 'МСС0'
+    }
+    const statementOperation = {
+      transactionDate: '2026-05-31T16:39:22',
+      balanceDate: '2026-05-29',
+      operationName: 'Капитализация (%% тек.периода ко вкладу)',
+      operationSum: '0.33',
+      transactionSum: '0.00',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: 1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      corrMFO: 'ZEPTBY2X',
+      purpose: 'Начисление процентов на остаток по счету по договору'
+    }
+
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [historyTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [statementOperation]
+      },
+      error: null
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)).resolves.toEqual([
+      convertStatementTransaction(statementOperation, account)
+    ])
+  })
 })

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -74,4 +74,68 @@ describe('getTransactions', () => {
       convertCardTransaction(uniqueHistoryTransaction, account)
     ])
   })
+
+  it('deduplicates matching history and statement transactions that land in different UTC days', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-05-24T16:28:45',
+      transacName: 'POS PURCHASE ',
+      amount: '117.28',
+      currencyIso: 'BYN',
+      cardAcceptor: 'I.-SHOP"WWW.PASS.RW.BY"',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС4112'
+    }
+
+    const statementOperation = {
+      transactionDate: '2026-05-24T00:00:00',
+      balanceDate: '2026-05-26',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: '117.28',
+      transactionSum: '117.28',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      cardPAN: '0000********1111',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'I.-SHOP"WWW.PASS.RW.BY"',
+      purpose: 'Regression case for midnight statement entry',
+      MCC: 'MCC 4112'
+    }
+
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [historyTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [statementOperation]
+      },
+      error: null
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)).resolves.toEqual([
+      convertStatementTransaction(statementOperation, account)
+    ])
+  })
 })

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -6,6 +6,14 @@ import type { FetchCardTransaction, FetchProductStatementOutput, FetchTransactio
 const mockFetchCardTransactions = jest.fn()
 const mockFetchProductStatement = jest.fn()
 
+const withAnyMovementIds = (transaction: ReturnType<typeof convertCardTransaction>): ReturnType<typeof convertCardTransaction> => ({
+  ...transaction,
+  movements: transaction.movements.map((movement) => ({
+    ...movement,
+    id: expect.any(String) as unknown as string
+  }))
+})
+
 jest.mock('../../fetchApi', () => ({
   ...jest.requireActual('../../fetchApi'),
   fetchCardTransactions: mockFetchCardTransactions,
@@ -70,8 +78,8 @@ describe('getTransactions', () => {
       fromDate: new Date('2026-02-01T00:00:00.000Z'),
       toDate: new Date('2026-02-28T23:59:59.000Z')
     }, account)).resolves.toEqual([
-      ...statementResponse.operations.map((operation) => convertStatementTransaction(operation, account)),
-      convertCardTransaction(uniqueHistoryTransaction, account)
+      ...statementResponse.operations.map((operation) => withAnyMovementIds(convertStatementTransaction(operation, account))),
+      withAnyMovementIds(convertCardTransaction(uniqueHistoryTransaction, account))
     ])
   })
 
@@ -135,7 +143,7 @@ describe('getTransactions', () => {
       fromDate: new Date('2026-05-01T00:00:00.000Z'),
       toDate: new Date('2026-05-31T23:59:59.000Z')
     }, account)).resolves.toEqual([
-      convertStatementTransaction(statementOperation, account)
+      withAnyMovementIds(convertStatementTransaction(statementOperation, account))
     ])
   })
 
@@ -194,7 +202,94 @@ describe('getTransactions', () => {
       fromDate: new Date('2026-05-01T00:00:00.000Z'),
       toDate: new Date('2026-05-31T23:59:59.000Z')
     }, account)).resolves.toEqual([
-      convertStatementTransaction(statementOperation, account)
+      withAnyMovementIds(convertStatementTransaction(statementOperation, account))
     ])
+  })
+
+  it('keeps the same final id when matching history disappears and only statement remains', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-05-25T12:34:56',
+      transacName: 'POS PURCHASE ',
+      amount: '41.71',
+      currencyIso: 'BYN',
+      cardAcceptor: 'EUROOPT',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5411'
+    }
+    const statementOperation = {
+      transactionDate: '2026-05-25T00:00:00',
+      balanceDate: '2026-05-25',
+      operationName: 'Оплата товаров и услуг',
+      operationSum: '41.71',
+      transactionSum: '41.71',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'EUROOPT',
+      MCC: 'MCC 5411'
+    }
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [historyTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [statementOperation]
+      },
+      error: null
+    })
+
+    const withHistory = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [statementOperation]
+      },
+      error: null
+    })
+
+    const statementOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)
+
+    expect(statementOnly).toHaveLength(1)
+    expect(withHistory).toHaveLength(1)
+    expect(statementOnly[0].movements[0].id).toBe(withHistory[0].movements[0].id)
   })
 })

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -1,18 +1,32 @@
 import { convertCardAccount, convertCardTransaction, convertStatementTransaction } from '../../converters'
 import { TEST_ACCOUNTS } from '../../__mocks__/accounts.sample'
 import { TEST_CARD_TRANSACTIONS, TEST_STATEMENT_TRANSACTIONS } from '../../__mocks__/transactions.sample'
+import type { Transaction } from '../../../../types/zenmoney'
 import type { FetchCardTransaction, FetchProductStatementOutput, FetchTransactionsOutput } from '../../types/fetch.types'
 
 const mockFetchCardTransactions = jest.fn()
 const mockFetchProductStatement = jest.fn()
 
-const withAnyMovementIds = (transaction: ReturnType<typeof convertCardTransaction>): ReturnType<typeof convertCardTransaction> => ({
-  ...transaction,
-  movements: transaction.movements.map((movement) => ({
-    ...movement,
+const withAnyMovementIds = (transaction: Transaction): Transaction => {
+  const [firstMovement, secondMovement] = transaction.movements
+  const firstMovementWithAnyId = {
+    ...firstMovement,
     id: expect.any(String) as unknown as string
-  }))
-})
+  }
+
+  return {
+    ...transaction,
+    movements: secondMovement == null
+      ? [firstMovementWithAnyId]
+      : [
+          firstMovementWithAnyId,
+          {
+            ...secondMovement,
+            id: expect.any(String) as unknown as string
+          }
+        ]
+  }
+}
 
 jest.mock('../../fetchApi', () => ({
   ...jest.requireActual('../../fetchApi'),

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
@@ -1,8 +1,8 @@
-import { convertCardAccount, convertCardTransaction } from '../../converters'
+import { convertCardAccount, convertCardTransaction, convertStatementTransaction } from '../../converters'
 import { FetchCardTransaction } from '../../types/fetch.types'
 import { Movement, Transaction } from '../../../../types/zenmoney'
 import { TEST_ACCOUNTS } from '../../__mocks__/accounts.sample'
-import { TEST_CARD_TRANSACTIONS } from '../../__mocks__/transactions.sample'
+import { TEST_CARD_TRANSACTIONS, TEST_STATEMENT_TRANSACTIONS } from '../../__mocks__/transactions.sample'
 
 describe('convertCardTransaction', () => {
   const rawCardAccount1 = TEST_ACCOUNTS.CARD.find(acc => acc.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
@@ -24,7 +24,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
             fee: 0,
             invoice: null,
@@ -46,7 +46,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
             fee: 0,
             invoice: null,
@@ -68,7 +68,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
             fee: 0,
             invoice: null,
@@ -90,7 +90,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
             fee: 0,
             invoice: null,
@@ -112,7 +112,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
             fee: 0,
             invoice: null,
@@ -139,7 +139,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
             fee: 0,
             invoice: { sum: -3.19, instrument: 'BYN' },
@@ -161,7 +161,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
             fee: 0,
             invoice: { sum: 3, instrument: 'BYN' },
@@ -183,7 +183,7 @@ describe('convertCardTransaction', () => {
         comment: null,
         movements: [
           {
-            id: null,
+            id: expect.any(String),
             account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
             fee: 0,
             invoice: { sum: 1, instrument: 'BYN' },
@@ -217,7 +217,7 @@ describe('convertCardTransaction', () => {
       comment: null,
       movements: [
         {
-          id: null,
+          id: expect.any(String),
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
           fee: 0,
           invoice: null,
@@ -226,5 +226,17 @@ describe('convertCardTransaction', () => {
       ],
       merchant: null
     })
+  })
+
+  it('uses the same movement id for a matching card and statement transaction', () => {
+    const rawCardTransaction = TEST_CARD_TRANSACTIONS.Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8[0]
+    const rawStatementTransaction = TEST_STATEMENT_TRANSACTIONS.vc5275E7DJRNBWJaN9Ugpc86LZQ4F75Dda7xhb74[0]
+
+    if (rawCardTransaction == null || rawStatementTransaction == null) {
+      throw new Error('Matching transactions not found')
+    }
+
+    expect(convertCardTransaction(rawCardTransaction, cardAccount1).movements[0].id)
+      .toBe(convertStatementTransaction(rawStatementTransaction, cardAccount1).movements[0].id)
   })
 })

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
@@ -228,6 +228,31 @@ describe('convertCardTransaction', () => {
     })
   })
 
+  it('uses different movement ids for separate same-day same-merchant purchases', () => {
+    const firstTransaction = convertCardTransaction({
+      effectiveDate: '2026-05-05T10:00:00',
+      transacName: 'POS PURCHASE',
+      amount: '12.34',
+      currencyIso: 'BYN',
+      repeatable: false,
+      transOperType: 'debit',
+      cardAcceptor: 'SHOP KOPEECHKA',
+      transMcc: 'МСС5411'
+    }, cardAccount1)
+    const secondTransaction = convertCardTransaction({
+      effectiveDate: '2026-05-05T11:00:00',
+      transacName: 'POS PURCHASE',
+      amount: '12.34',
+      currencyIso: 'BYN',
+      repeatable: false,
+      transOperType: 'debit',
+      cardAcceptor: 'SHOP KOPEECHKA',
+      transMcc: 'МСС5411'
+    }, cardAccount1)
+
+    expect(firstTransaction.movements[0].id).not.toBe(secondTransaction.movements[0].id)
+  })
+
   it('uses the same movement id for a matching card and statement transaction', () => {
     const rawCardTransaction = TEST_CARD_TRANSACTIONS.Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8[0]
     const rawStatementTransaction = TEST_STATEMENT_TRANSACTIONS.vc5275E7DJRNBWJaN9Ugpc86LZQ4F75Dda7xhb74[0]

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-statement-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-statement-transaction.test.ts
@@ -25,7 +25,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-13T07:21:30.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
           fee: 0,
           invoice: null,
@@ -41,7 +41,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T18:46:07.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
           fee: 0,
           invoice: null,
@@ -57,7 +57,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T17:58:51.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
           fee: 0,
           invoice: null,
@@ -73,7 +73,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T14:53:18.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
           fee: 0,
           invoice: null,
@@ -89,7 +89,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T14:31:39.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8' },
           fee: 0,
           invoice: null,
@@ -110,7 +110,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-13T07:21:30.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
           fee: 0,
           invoice: { sum: 3, instrument: 'BYN' },
@@ -126,7 +126,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T17:58:52.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
           fee: 0,
           invoice: { sum: 1, instrument: 'BYN' },
@@ -142,7 +142,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T21:00:00.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: 'Y2errgEX8HfZ5efNYkj3XzirAqGrN7m523zs53P5' },
           fee: 0,
           invoice: { sum: -3.19, instrument: 'BYN' },
@@ -163,7 +163,7 @@ describe('convertStatementTransaction', () => {
         date: new Date('2026-02-12T18:46:07.000Z'),
         comment: null,
         movements: [{
-          id: null,
+          id: expect.any(String),
           account: { id: '3p6Kf9JU2RQW4HFE42QGVB556Sv4hgVxg4vZ7ZP2' },
           fee: 0,
           invoice: null,

--- a/src/plugins/zepterbank-by/__tests__/helpers/convert-iso-string-to-date.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/helpers/convert-iso-string-to-date.test.ts
@@ -1,4 +1,4 @@
-import { convertIsoDateStringToDate } from '../../helpers'
+import { convertIsoDateStringToDate, getBusinessDateIdentityKey } from '../../helpers'
 
 describe('convertIsoDateStringToDate', () => {
   it('converts +BUSINESS_TIME_OFFSET local time to correct UTC instant', () => {
@@ -43,5 +43,15 @@ describe('convertIsoDateStringToDate', () => {
   it('ignores milliseconds if present (current implementation will make seconds NaN -> invalid)', () => {
     const d = convertIsoDateStringToDate('2026-02-12T20:58:51.123' as any)
     expect(Number.isNaN(d.getTime())).toBe(true)
+  })
+})
+
+describe('getBusinessDateIdentityKey', () => {
+  it('keeps midnight statement records on the same local business day as daytime history records', () => {
+    const statementDate = convertIsoDateStringToDate('2026-05-24T00:00:00')
+    const historyDate = convertIsoDateStringToDate('2026-05-24T16:28:45')
+
+    expect(getBusinessDateIdentityKey(statementDate)).toBe('2026-05-24')
+    expect(getBusinessDateIdentityKey(historyDate)).toBe('2026-05-24')
   })
 })

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -7,14 +7,11 @@ import {
   FetchCardAccountMeta,
   FetchCurrentAccountMeta
 } from './types/fetch.types'
-import { convertIsoDateStringToDate } from './helpers'
+import { convertIsoDateStringToDate, getBusinessDateIdentityKey } from './helpers'
 import { appendCashbackComment } from './cashback.js'
 
 const normalizeIdPart = (value: string | null | undefined): string =>
   (value ?? '').replace(/\s+/g, ' ').trim().toUpperCase()
-
-const getDateIdentityKey = (date: Date): string =>
-  date.toISOString().slice(0, 10)
 
 const getAmountIdentityKey = ({
   accountInstrument,
@@ -52,7 +49,7 @@ const buildMovementId = ({
   return [
     'zepterbank-by',
     accountId,
-    getDateIdentityKey(date),
+    getBusinessDateIdentityKey(date),
     getAmountIdentityKey({ accountInstrument, sum, invoice }),
     String(mcc ?? ''),
     normalizeIdPart(merchantTitle)

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -10,6 +10,55 @@ import {
 import { convertIsoDateStringToDate } from './helpers'
 import { appendCashbackComment } from './cashback.js'
 
+const normalizeIdPart = (value: string | null | undefined): string =>
+  (value ?? '').replace(/\s+/g, ' ').trim().toUpperCase()
+
+const getDateIdentityKey = (date: Date): string =>
+  date.toISOString().slice(0, 10)
+
+const getAmountIdentityKey = ({
+  accountInstrument,
+  sum,
+  invoice
+}: {
+  accountInstrument: string
+  sum: number | null
+  invoice: { sum: number, instrument: string } | null
+}): string => {
+  if (invoice != null) {
+    return `invoice|${invoice.instrument}|${invoice.sum.toFixed(2)}`
+  }
+
+  return `sum|${accountInstrument}|${(sum ?? 0).toFixed(2)}`
+}
+
+const buildMovementId = ({
+  accountId,
+  accountInstrument,
+  date,
+  merchantTitle,
+  mcc,
+  sum,
+  invoice
+}: {
+  accountId: string
+  accountInstrument: string
+  date: Date
+  merchantTitle: string | null
+  mcc: number | null
+  sum: number | null
+  invoice: { sum: number, instrument: string } | null
+}): string => {
+  return [
+    'zepterbank-by',
+    accountId,
+    getDateIdentityKey(date),
+    getAmountIdentityKey({ accountInstrument, sum, invoice }),
+    String(mcc ?? ''),
+    normalizeIdPart(merchantTitle)
+  ].join('|')
+}
+
 const parseMcc = (mcc: string | undefined): number | null => {
   const digits = mcc?.replace(/\D/g, '') ?? ''
 
@@ -71,18 +120,30 @@ export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, a
   const amount = Number(`${fetchTransaction.transOperType === 'debit' ? '-' : ''}${fetchTransaction.amount}`)
   const merchantTitle = normalizeMerchantTitle(fetchTransaction.cardAcceptor)
   const mcc = parseMcc(fetchTransaction.transMcc)
+  const invoice = isInDifferentCurrency ? { sum: amount, instrument: fetchTransaction.currencyIso } : null
+  const sum = isInDifferentCurrency ? null : amount
+  const date = convertIsoDateStringToDate(fetchTransaction.effectiveDate)
+  const movementId = buildMovementId({
+    accountId: account.id,
+    accountInstrument: account.instrument,
+    date,
+    merchantTitle,
+    mcc,
+    sum,
+    invoice
+  })
 
   return {
     hold: null,
-    date: convertIsoDateStringToDate(fetchTransaction.effectiveDate),
+    date,
     comment: appendCashbackComment(fetchTransaction.transacName, mcc),
     movements: [
       {
-        id: null, // no transaction id presented
+        id: movementId,
         account: { id: account.id },
         fee: 0,
-        invoice: isInDifferentCurrency ? { sum: amount, instrument: fetchTransaction.currencyIso } : null,
-        sum: isInDifferentCurrency ? null : amount
+        invoice,
+        sum
       }
     ],
     merchant: merchantTitle !== null
@@ -103,17 +164,28 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
   const payee = fetchTransaction.terminalLocation ?? ''
   const [country = '', city = ''] = (fetchTransaction.merchant ?? '').split(' ')
   const mcc = parseMcc(fetchTransaction.MCC)
+  const invoice = hasInvoice ? { sum: transactionAmount, instrument: fetchTransaction.transactionCurrencyISO } : null
+  const date = convertIsoDateStringToDate(fetchTransaction.transactionDate)
+  const movementId = buildMovementId({
+    accountId: account.id,
+    accountInstrument: account.instrument,
+    date,
+    merchantTitle: payee,
+    mcc,
+    sum: operationAmount,
+    invoice
+  })
 
   return {
     hold: null,
-    date: convertIsoDateStringToDate(fetchTransaction.transactionDate),
+    date,
     comment: appendCashbackComment(fetchTransaction.operationName, mcc),
     movements: [
       {
-        id: null, // no transaction id presented
+        id: movementId,
         account: { id: account.id },
         fee: 0,
-        invoice: hasInvoice ? { sum: transactionAmount, instrument: fetchTransaction.transactionCurrencyISO } : null,
+        invoice,
         sum: operationAmount
       }
     ],

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -50,6 +50,7 @@ const buildMovementId = ({
     'zepterbank-by',
     accountId,
     getBusinessDateIdentityKey(date),
+    date.toISOString(),
     getAmountIdentityKey({ accountInstrument, sum, invoice }),
     String(mcc ?? ''),
     normalizeIdPart(merchantTitle)

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -79,6 +79,18 @@ const normalizeMerchantTitle = (title: string | undefined): string | null => {
     : null
 }
 
+const getStatementDedupDate = (fetchTransaction: FetchStatementOperation): Date | null => {
+  const isAccountCurrencyOnlyOperation =
+    Number(fetchTransaction.transactionSum) === 0 &&
+    Number(fetchTransaction.operationSum) !== 0
+
+  if (!isAccountCurrencyOnlyOperation || fetchTransaction.balanceDate == null) {
+    return null
+  }
+
+  return convertIsoDateStringToDate(`${fetchTransaction.balanceDate}T00:00:00`)
+}
+
 export const convertCardAccount = (fetchAccount: FetchCardAccount): Account & FetchCardAccountMeta => {
   return {
     id: fetchAccount.productCardId,
@@ -164,6 +176,7 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
   const mcc = parseMcc(fetchTransaction.MCC)
   const invoice = hasInvoice ? { sum: transactionAmount, instrument: fetchTransaction.transactionCurrencyISO } : null
   const date = convertIsoDateStringToDate(fetchTransaction.transactionDate)
+  const dedupDate = getStatementDedupDate(fetchTransaction)
   const movementId = buildMovementId({
     accountId: account.id,
     accountInstrument: account.instrument,
@@ -174,7 +187,7 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
     invoice
   })
 
-  return {
+  const transaction = {
     hold: null,
     date,
     comment: appendCashbackComment(fetchTransaction.operationName, mcc),
@@ -197,4 +210,14 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
         }
       : null
   }
+
+  if (dedupDate !== null) {
+    Object.defineProperty(transaction, 'dedupDate', {
+      value: dedupDate,
+      enumerable: false,
+      configurable: true
+    })
+  }
+
+  return transaction
 }

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -187,7 +187,7 @@ export const convertStatementTransaction = (fetchTransaction: FetchStatementOper
     invoice
   })
 
-  const transaction = {
+  const transaction: Transaction = {
     hold: null,
     date,
     comment: appendCashbackComment(fetchTransaction.operationName, mcc),

--- a/src/plugins/zepterbank-by/helpers.ts
+++ b/src/plugins/zepterbank-by/helpers.ts
@@ -1,4 +1,4 @@
-import { BUSINESS_TZ, DATETIME_REGEX } from './models'
+import { BUSINESS_TIME_OFFSET, BUSINESS_TZ, DATETIME_REGEX } from './models'
 
 export const isNonEmptyString = (v: unknown): v is string =>
   typeof v === 'string' && v.length > 0
@@ -28,4 +28,8 @@ export const convertDateToYyyyMmDd = (date: Date): string => {
   const d = String(date.getUTCDate()).padStart(2, '0')
 
   return `${y}-${m}-${d}`
+}
+
+export const getBusinessDateIdentityKey = (date: Date): string => {
+  return convertDateToYyyyMmDd(new Date(date.getTime() + BUSINESS_TIME_OFFSET))
 }

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -1,4 +1,5 @@
 import { Transaction } from '../../types/zenmoney'
+import { getBusinessDateIdentityKey } from './helpers'
 
 type TransactionSource = 'history' | 'statement'
 
@@ -56,7 +57,7 @@ const getMccSignature = (transaction: Transaction): string => {
 }
 
 const getDaySignature = (transaction: Transaction): string =>
-  transaction.date.toISOString().slice(0, 10)
+  getBusinessDateIdentityKey(transaction.date)
 
 const getDuplicateFingerprint = (transaction: Transaction): string => [
   getMovementAccountId(transaction),

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -87,15 +87,17 @@ const withStableMovementIds = (transactions: Transaction[]): Transaction[] => {
     const fingerprint = getDuplicateFingerprint(transaction)
     const occurrenceIndex = occurrenceIndexes.get(fingerprint) ?? 0
     occurrenceIndexes.set(fingerprint, occurrenceIndex + 1)
+    const [firstMovement, secondMovement] = transaction.movements
+    const firstMovementWithStableId = {
+      ...firstMovement,
+      id: ['zepterbank-by', fingerprint, occurrenceIndex].join('|')
+    }
 
     return {
       ...transaction,
-      movements: transaction.movements.map((movement, index) => index === 0
-        ? {
-            ...movement,
-            id: ['zepterbank-by', fingerprint, occurrenceIndex].join('|')
-          }
-        : movement)
+      movements: secondMovement == null
+        ? [firstMovementWithStableId]
+        : [firstMovementWithStableId, secondMovement]
     }
   })
 }

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -32,6 +32,9 @@ const getMovementAccountId = (transaction: Transaction): string => {
   return ''
 }
 
+const getMovementId = (transaction: Transaction): string | null =>
+  transaction.movements[0]?.id ?? null
+
 const getAmountSignature = (transaction: Transaction): string => {
   const movement = transaction.movements[0]
 
@@ -63,8 +66,16 @@ const getDuplicateFingerprint = (transaction: Transaction): string => [
   normalizeText(getMerchantTitle(transaction))
 ].join('|')
 
-const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean =>
-  getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
+const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => {
+  const leftId = getMovementId(left)
+  const rightId = getMovementId(right)
+
+  if (leftId !== null && rightId !== null) {
+    return leftId === rightId
+  }
+
+  return getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
+}
 
 export const mergeTransactions = (historyTransactions: Transaction[], statementTransactions: Transaction[]): Transaction[] => {
   const mergedTransactions: SourcedTransaction[] = historyTransactions.map((transaction) => ({

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -80,6 +80,26 @@ const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => 
   return getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
 }
 
+const withStableMovementIds = (transactions: Transaction[]): Transaction[] => {
+  const occurrenceIndexes = new Map<string, number>()
+
+  return transactions.map((transaction) => {
+    const fingerprint = getDuplicateFingerprint(transaction)
+    const occurrenceIndex = occurrenceIndexes.get(fingerprint) ?? 0
+    occurrenceIndexes.set(fingerprint, occurrenceIndex + 1)
+
+    return {
+      ...transaction,
+      movements: transaction.movements.map((movement, index) => index === 0
+        ? {
+            ...movement,
+            id: ['zepterbank-by', fingerprint, occurrenceIndex].join('|')
+          }
+        : movement)
+    }
+  })
+}
+
 export const mergeTransactions = (historyTransactions: Transaction[], statementTransactions: Transaction[]): Transaction[] => {
   const mergedTransactions: SourcedTransaction[] = historyTransactions.map((transaction) => ({
     source: 'history',
@@ -105,5 +125,5 @@ export const mergeTransactions = (historyTransactions: Transaction[], statementT
     })
   }
 
-  return mergedTransactions.map(({ transaction }) => transaction)
+  return withStableMovementIds(mergedTransactions.map(({ transaction }) => transaction))
 }

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -72,7 +72,7 @@ const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => 
   const rightId = getMovementId(right)
 
   if (leftId !== null && rightId !== null) {
-    return leftId === rightId
+    return leftId === rightId || getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
   }
 
   return getDuplicateFingerprint(left) === getDuplicateFingerprint(right)

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -8,6 +8,8 @@ interface SourcedTransaction {
   transaction: Transaction
 }
 
+type TransactionWithDedupDate = Transaction & { dedupDate?: Date }
+
 const normalizeText = (text: string | null | undefined): string =>
   (text ?? '').replace(/\s+/g, ' ').trim()
 
@@ -57,7 +59,7 @@ const getMccSignature = (transaction: Transaction): string => {
 }
 
 const getDaySignature = (transaction: Transaction): string =>
-  getBusinessDateIdentityKey(transaction.date)
+  getBusinessDateIdentityKey((transaction as TransactionWithDedupDate).dedupDate ?? transaction.date)
 
 const getDuplicateFingerprint = (transaction: Transaction): string => [
   getMovementAccountId(transaction),


### PR DESCRIPTION
Исправлена дедупликация zepterbank-by между карточной историей и выпиской по продукту.

Что изменено:

 - для cardTransactions и productStatement добавлены stable movement IDs;
 - ID строится через нормализованный fingerprint операции, account id, дату, сумму и устойчивые банковские признаки;
 - для statement операций с account-currency-only суммами используется balanceDate, чтобы капитализация и похожие записи совпадали с карточной историей;
 - добавлен business-date identity key, чтобы statement запись в полночь и дневная history запись попадали в один локальный бизнес-день;
 - merge теперь сначала сравнивает movement IDs, а потом fallback-эвристику;
 - после merge одинаковые fingerprint-операции получают occurrence index, чтобы две реальные одинаковые покупки в один день не схлопнулись в одну;
 - сохранена стабильность ID, когда history запись исчезает и остаётся только statement.

Тесты добавлены/обновлены для:

 - совпадения ID между matching card transaction и statement transaction;
 - statement midnight transaction против history daytime transaction;
 - capitalization rows по balanceDate;
 - стабильности ID после исчезновения history;
 - двух одинаковых same-day/same-merchant операций в history;
 - двух одинаковых same-day/same-merchant операций в statement;
 - helper для business-date identity key.
