### PR TITLE
fix(credo-ge): harden account and transaction conversion

### DIFF
--- a/src/plugins/credo-ge/__tests__/converters/accounts/account.test.ts
+++ b/src/plugins/credo-ge/__tests__/converters/accounts/account.test.ts
@@ -33,7 +33,7 @@ describe('convertAccounts', () => {
           title: 'GE12CD0360000027070426GEL',
           type: 'ccard',
           instrument: 'GEL',
-          syncIds: ['GE12CD0360000027070426GEL', '27070426'],
+          syncIds: ['GE12CD0360000027070426GEL-27070426', '27070426', 'GE12CD0360000027070426GEL'],
           balance: 31.4,
           available: 31.4,
           savings: false
@@ -106,8 +106,9 @@ describe('convertAccounts', () => {
           instrument: 'GEL',
           savings: false,
           syncIds: [
-            'GE62CD0360000037554441GEL',
+            'GE62CD0360000037554441GEL-37554441',
             '37554441',
+            'GE62CD0360000037554441GEL',
             '410180******1211'
           ],
           title: 'GE62CD0360000037554441GEL',
@@ -174,5 +175,37 @@ describe('convertAccounts', () => {
     [[], [], [], [], []]
   ])('converts current account', (apiAccounts, cards, deposits, loans, accounts) => {
     expect(convertAccounts(apiAccounts, cards, deposits as Deposit[], loans)).toEqual(accounts)
+  })
+
+  it('keeps a stable account-id sync id before the legacy account-number sync id', () => {
+    const accounts = convertAccounts([
+      {
+        accountId: 27070426,
+        accountNumber: 'GE12CD0360000027070426',
+        account: 'ალეკსეი ლუკომსკი',
+        currency: 'GEL',
+        categoryId: 1001,
+        category: 'მიმდინარე',
+        hasCard: true,
+        status: 'გახსნილი',
+        type: 'CURRENT',
+        availableBalance: 31.4,
+        currencyPriority: 0,
+        availableBalanceEqu: 31.4,
+        isDefault: false,
+        isHidden: true,
+        cssAccountId: 1015155
+      }
+    ], [], [], [])
+
+    expect(accounts[0].syncIds).toEqual([
+      'GE12CD0360000027070426GEL-27070426',
+      '27070426',
+      'GE12CD0360000027070426GEL'
+    ])
+  })
+
+  it('skips unsupported loans instead of failing the whole account conversion', () => {
+    expect(convertAccounts([], [], [], [{ openingDate: new Date('2026-01-01') }])).toEqual([])
   })
 })

--- a/src/plugins/credo-ge/__tests__/converters/transactions/outcome.test.ts
+++ b/src/plugins/credo-ge/__tests__/converters/transactions/outcome.test.ts
@@ -1,5 +1,5 @@
 import { convertTransaction } from '../../../converters'
-import { Transaction as CredoTransaction } from '../../../models'
+import { Transaction as CredoTransaction, TransactionType } from '../../../models'
 import { Account, AccountType } from '../../../../../types/zenmoney'
 
 describe('convertTransaction', () => {
@@ -280,5 +280,39 @@ describe('convertTransaction', () => {
     ]
   ])('converts outcome', (apiTransaction, account, transaction) => {
     expect(convertTransaction(apiTransaction as CredoTransaction, account as Account)).toEqual(transaction)
+  })
+
+  it('does not emit redundant invoice when description amount uses account currency', () => {
+    const apiTransaction: CredoTransaction = {
+      credit: null,
+      currency: 'GEL',
+      transactionType: TransactionType.AccountWithdrawal,
+      transactionId: 'FT261105N0B8',
+      debit: 42.5,
+      description: 'გადახდა - LOCAL MERCHANT 42.50 GEL 20.04.2026',
+      isCardBlock: false,
+      operationDateTime: '2026-04-20 12:07:00',
+      stmtEntryId: '206105000000000.000001',
+      canRepeat: false,
+      canReverse: false,
+      amountEquivalent: 42.5,
+      operationType: 'Card transaction',
+      operationTypeId: null
+    }
+    const account: Account = {
+      id: '13',
+      type: AccountType.ccard,
+      title: 'Card 13',
+      instrument: 'GEL',
+      syncIds: ['13'],
+      savings: false,
+      balance: 10.00,
+      available: 10.00
+    }
+
+    const transaction = convertTransaction(apiTransaction, account)
+
+    expect(transaction.movements[0].invoice).toBeNull()
+    expect(transaction.movements[0].sum).toBe(-42.5)
   })
 })

--- a/src/plugins/credo-ge/converters.ts
+++ b/src/plugins/credo-ge/converters.ts
@@ -67,7 +67,9 @@ function convertDeposit (deposit: CredoDeposit): Account {
 
 export function convertAccounts (apiAccounts: CredoAccount[], cards: CredoCard[], deposits: CredoDeposit[], loans: CredoLoan[]): Account[] {
   console.log('>>> Converting accounts, cards, deposits, loans')
-  assert(loans.length === 0, 'Loans is not supported yet. Send your log to support, please!', loans) // TODO: must be implemented when loans format will be available
+  if (loans.length > 0) {
+    console.log(`>>> Skipping ${loans.length} unsupported Credo loans`)
+  }
 
   const accounts: Account[] = []
   const accountToCardNumber = getAccountToCardMapping(cards)
@@ -93,8 +95,9 @@ function convertAccount (
   const accountNumber = getString(apiAccount, 'accountNumber')
   const currency = getString(apiAccount, 'currency')
   const accountSyncId = [accountNumber, currency].join('')
+  const stableAccountSyncId = [accountSyncId, accountId].join('-')
   const cardNumber = accountToCardNumber.get(accountNumber)
-  const syncIds = [accountSyncId, accountId]
+  const syncIds = [stableAccountSyncId, accountId, accountSyncId]
   if (cardNumber !== null && cardNumber !== undefined) { syncIds.push(cardNumber) }
   const availableBalance = getNumber(apiAccount, 'availableBalance')
   /* Deposit or loan */
@@ -200,7 +203,8 @@ export function convertTransaction (apiTransaction: CredoTransaction, account: A
     debit = getNumber(apiTransaction, 'debit')
     amount = -1 * debit
   }
-  const invoice = getAmountFromDescription(description, Math.sign(amount)) // TODO: rewrite getAmountFromDescription
+  const rawInvoice = getAmountFromDescription(description, Math.sign(amount)) // TODO: rewrite getAmountFromDescription
+  const invoice = rawInvoice?.instrument === account.instrument ? null : rawInvoice
   const isCardBlock = getBoolean(apiTransaction, 'isCardBlock')
 
   const convertedTransaction: ExtendedTransaction = {

--- a/src/plugins/credo-ge/models.ts
+++ b/src/plugins/credo-ge/models.ts
@@ -335,7 +335,7 @@ export interface Transaction {
   canRepeat: boolean
   canReverse: boolean
   amountEquivalent: number
-  operationType: OperationType
+  operationType: OperationType | string
   operationTypeId: null
   transactionTypeId?: number | null
   transactionTypeName?: string | null


### PR DESCRIPTION
## Summary

Harden the Credo Bank Georgia plugin against three sync-stability failures reported in recent issues:

- avoid emitting redundant same-currency `invoice` data when Credo descriptions include an amount in the account currency, preventing `invoice.sum != sum but account.instrument == invoice.instrument` conversion failures (#1013)
- add an account-id-suffixed sync id before the legacy account-number/currency sync id, reducing ambiguous last-4 matching for multi-account Credo users while preserving legacy sync ids (#990)
- skip currently unsupported loan products instead of failing the whole account conversion, so accounts/deposits can still sync when the API returns loans (#1014-adjacent)
- widen `Transaction.operationType` to `OperationType | string` because Credo returns arbitrary localized/display strings such as `Card transaction`

## Verification

- `corepack yarn lint`
- `corepack yarn tsc --noEmit`
- `corepack yarn jest src/plugins/credo-ge --runInBand`
- `corepack yarn test`

## Notes

This does not change the Credo auth/OTP flow. That flow still appears brittle, but changing refresh/device-binding behavior safely requires live bank API evidence.
