### PR TITLE
[bgpb] обработка p2p транзакций в истории более безопасно

### DIFF
--- a/src/plugins/bgpb/__tests__/api.test.js
+++ b/src/plugins/bgpb/__tests__/api.test.js
@@ -1,5 +1,100 @@
 import { parseXml } from '../../../common/xmlUtils'
-import { createDateIntervals, parseFullTransactionsMail, parseFullTransactionsMailCardLimit } from '../api'
+import {
+  createDateIntervals,
+  fetchBalance,
+  fetchFullTransactions,
+  fetchLastTransactions,
+  login,
+  parseFullTransactionsMail,
+  parseFullTransactionsMailCardLimit
+} from '../api'
+
+function makeNetworkResponse (body, url = 'https://mobapp-frontend.bgpb.by/test') {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    url,
+    headers: {
+      forEach: () => {}
+    },
+    text: async () => body
+  }
+}
+
+function stringifyDebugCalls (debug) {
+  return JSON.stringify(debug.mock.calls)
+}
+
+describe('request logging', () => {
+  let debug
+
+  beforeEach(() => {
+    debug = jest.spyOn(console, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    debug.mockRestore()
+  })
+
+  it('sanitizes XML request and response bodies', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Login SID="response-secret-sid"/></BS_Response>'))
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Balance Amount="1,00"/></BS_Response>'))
+
+    await expect(login('login-value', 'password-value')).resolves.toBe('response-secret-sid')
+    await expect(fetchBalance('request-secret-sid', {
+      productType: 'MS',
+      cardNumber: '518597******1111',
+      currencyCode: '933'
+    })).resolves.toBe(1)
+
+    const logs = stringifyDebugCalls(debug)
+    expect(logs).not.toContain('password-value')
+    expect(logs).not.toContain('request-secret-sid')
+    expect(logs).not.toContain('response-secret-sid')
+  })
+
+  it('sanitizes JSON session ids', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse(JSON.stringify({
+        errorCode: 0,
+        config: {
+          pageSize: 20
+        }
+      })))
+      .mockResolvedValueOnce(makeNetworkResponse(JSON.stringify({
+        errorCode: 0,
+        result: {
+          items: []
+        }
+      })))
+
+    await expect(fetchLastTransactions('json-secret-sid', [{
+      id: 'account',
+      type: 'card',
+      bankId: 'bank-id',
+      syncID: ['1111']
+    }], new Date('2026-05-21T00:00:00+0300'), new Date('2026-05-21T23:59:59+0300'))).resolves.toEqual([])
+
+    expect(stringifyDebugCalls(debug)).not.toContain('json-secret-sid')
+  })
+})
+
+describe('fetchFullTransactions', () => {
+  it('skips high-security statement requests', async () => {
+    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+    global.fetch = jest.fn()
+
+    await expect(fetchFullTransactions('sid', {
+      title: 'Card*1111',
+      transactionsAccId: 'statement-action'
+    }, new Date('2026-05-01T00:00:00+0300'), new Date('2026-05-21T00:00:00+0300'))).resolves.toEqual([])
+
+    expect(global.fetch).not.toHaveBeenCalled()
+    log.mockRestore()
+  })
+})
 
 describe('createDateIntervals', () => {
   it('should convert date period', () => {

--- a/src/plugins/bgpb/__tests__/converters/transactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions.test.js
@@ -666,7 +666,7 @@ describe('convertLastTransaction', () => {
     })
   }
 
-  it('uses the same movement id for matching statement and history transactions', () => {
+  it('includes orderNumber in history id for matching statement and history transactions', () => {
     const account = {
       id: 'account',
       instrument: 'BYN',
@@ -710,10 +710,12 @@ describe('convertLastTransaction', () => {
       reversal: 0
     }, [account])
 
-    expect(statementTransaction.movements[0].id).toBe(historyTransaction.movements[0].id)
+    expect(statementTransaction.movements[0].id).toContain('auth:185665')
+    expect(historyTransaction.movements[0].id).toContain('order:3289575665:auth:185665')
+    expect(statementTransaction.movements[0].id).not.toBe(historyTransaction.movements[0].id)
   })
 
-  it('keeps movement id stable when matching statement and history text differs', () => {
+  it('keeps order-based history id stable when matching statement and history text differs', () => {
     const account = {
       id: 'account',
       instrument: 'BYN',
@@ -757,7 +759,9 @@ describe('convertLastTransaction', () => {
       reversal: 0
     }, [account])
 
-    expect(statementTransaction.movements[0].id).toBe(historyTransaction.movements[0].id)
+    expect(statementTransaction.movements[0].id).toContain('auth:185665')
+    expect(historyTransaction.movements[0].id).toContain('order:3289575665:auth:185665')
+    expect(statementTransaction.movements[0].id).not.toBe(historyTransaction.movements[0].id)
   })
 
   it('keeps movement id stable when a history operation clears', () => {

--- a/src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js
+++ b/src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js
@@ -263,6 +263,101 @@ describe('convertLastTransaction', () => {
         comment: 'PEREVOD (SPISANIE)',
         hold: false
       }
+    ],
+    [
+      {
+        orderNumber: '392708',
+        bankId: 'bank-id',
+        direction: 'incoming',
+        date: '2026-05-21T11:45:00+0300',
+        currencyAmount: {
+          currency: 933,
+          amount: 12345
+        },
+        status: 'success',
+        terminal: 'P2P_BGPB_4, EPOS, PEREVOD (ZACHISLENIE)',
+        pan: '518597******1111',
+        transType: 781,
+        transTypeDesc: 'PEREVOD (ZACHISLENIE)',
+        authCode: '392708',
+        mcc: 6536,
+        reversal: 0
+      },
+      [
+        {
+          id: 'account',
+          instrument: 'BYN',
+          bankId: 'bank-id',
+          syncID: ['1111']
+        }
+      ],
+      {
+        date: new Date('2026-05-21T11:45:00+0300'),
+        movements:
+          [
+            {
+              id: null,
+              account: { id: 'account' },
+              invoice: null,
+              sum: 123.45,
+              fee: 0
+            }
+          ],
+        merchant: null,
+        comment: 'PEREVOD (ZACHISLENIE)',
+        hold: false
+      }
+    ],
+    [
+      {
+        orderNumber: '3299662709',
+        bankId: 'bank-id',
+        direction: 'incoming',
+        date: '2026-05-21T14:45:26+0300',
+        totalAmount: {
+          currency: 933,
+          amount: 123
+        },
+        currencyAmount: {
+          currency: 978,
+          amount: 123
+        },
+        status: 'success',
+        terminal: 'P2P_BGPB_4, EPOS, PEREVOD (ZACHISLENIE)',
+        pan: '518597******1111',
+        transType: 785,
+        transTypeDesc: 'PEREVOD (ZACHISLENIE)',
+        authCode: '666666',
+        mcc: 6536,
+        reversal: 0
+      },
+      [
+        {
+          id: 'account',
+          instrument: 'EUR',
+          bankId: 'bank-id',
+          syncID: ['1111']
+        }
+      ],
+      {
+        date: new Date('2026-05-21T14:45:26+0300'),
+        movements:
+          [
+            {
+              id: null,
+              account: { id: 'account' },
+              invoice: {
+                instrument: 'BYN',
+                sum: 1.23
+              },
+              sum: 1.23,
+              fee: 0
+            }
+          ],
+        merchant: null,
+        comment: 'PEREVOD (ZACHISLENIE)',
+        hold: false
+      }
     ]
   ])('converts last transactions', (apiTransaction, accounts, transaction) => {
     const convertedTransaction = convertLastTransaction(apiTransaction, accounts)
@@ -270,6 +365,38 @@ describe('convertLastTransaction', () => {
       expect(convertedTransaction.movements.every(movement => typeof movement.id === 'string' && movement.id.length > 0)).toBe(true)
     }
     expect(withNullMovementIds(convertedTransaction)).toEqual(transaction)
+  })
+
+  it('includes orderNumber in history movement ids', () => {
+    const transaction = convertLastTransaction({
+      orderNumber: '3299662709',
+      bankId: 'bank-id',
+      direction: 'incoming',
+      date: '2026-05-21T14:45:26+0300',
+      totalAmount: {
+        currency: 933,
+        amount: 123
+      },
+      currencyAmount: {
+        currency: 978,
+        amount: 123
+      },
+      status: 'success',
+      terminal: 'P2P_BGPB_4, EPOS, PEREVOD (ZACHISLENIE)',
+      pan: '518597******1111',
+      transType: 785,
+      transTypeDesc: 'PEREVOD (ZACHISLENIE)',
+      authCode: '666666',
+      mcc: 6536,
+      reversal: 0
+    }, [{
+      id: 'account',
+      instrument: 'EUR',
+      bankId: 'bank-id',
+      syncID: ['1111']
+    }])
+
+    expect(transaction.movements[0].id).toContain('order:3299662709')
   })
 })
 

--- a/src/plugins/bgpb/api.js
+++ b/src/plugins/bgpb/api.js
@@ -2,6 +2,7 @@ import cheerio from 'cheerio'
 import { flatMap } from 'lodash'
 import { createDateIntervals as commonCreateDateIntervals } from '../../common/dateUtils'
 import { fetch, fetchJson } from '../../common/network'
+import { sanitize } from '../../common/sanitize'
 import { generateRandomString } from '../../common/utils'
 import { parseXml } from '../../common/xmlUtils'
 
@@ -14,6 +15,7 @@ const HISTORY_BASE_PATH = 'history/client/2/1/'
 const HISTORY_CONFIG_ENDPOINT = `${HISTORY_BASE_PATH}getConfig`
 const HISTORY_EXT_OPERATIONS_ENDPOINT = `${HISTORY_BASE_PATH}ext-operations`
 const EXTRA_AUTH_REQUIRED_ERROR = 'Для выполнения действия требуется дополнительная аутентификация'
+const FULL_STATEMENT_REQUESTS_ENABLED = false
 
 const SOU_ADMIN_ENDPOINT = 'sou2/xml_online.admin'
 const SOU_REQUEST_ENDPOINT = 'sou2/xml_online.request'
@@ -47,6 +49,54 @@ function buildSessionXml (sid) {
   return '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n'
 }
 
+function sanitizeBgpbRequestLogBody (body) {
+  if (typeof body === 'string') {
+    return body
+      .replace(/\bSID="([^"]*)"/gi, (_match, value) => `SID="${sanitize(value, true)}"`)
+      .replace(/(<Parameter\s+Id="(?:Login|Password)"[^>]*>)([^<]*)(<\/Parameter>)/gi, (_match, openTag, value, closeTag) => {
+        return `${openTag}${sanitize(value, true)}${closeTag}`
+      })
+  }
+  if (Array.isArray(body)) {
+    return body.map(sanitizeBgpbRequestLogBody)
+  }
+  if (body && typeof body === 'object') {
+    return Object.fromEntries(Object.entries(body).map(([key, value]) => [
+      key,
+      /^(sid|sessionId)$/i.test(key) ? sanitize(value, true) : sanitizeBgpbRequestLogBody(value)
+    ]))
+  }
+  return body
+}
+
+function mergeSanitizeLogMask (defaults, mask) {
+  if (mask === undefined) {
+    return defaults
+  }
+  if (mask === true || typeof mask === 'function') {
+    return mask
+  }
+  if (mask && typeof mask === 'object') {
+    return {
+      ...defaults,
+      ...mask
+    }
+  }
+  return mask
+}
+
+function withDefaultSanitizeLogMasks (options) {
+  return {
+    ...options,
+    sanitizeRequestLog: mergeSanitizeLogMask({
+      body: sanitizeBgpbRequestLogBody
+    }, options.sanitizeRequestLog),
+    sanitizeResponseLog: mergeSanitizeLogMask({
+      body: sanitizeBgpbRequestLogBody
+    }, options.sanitizeResponseLog)
+  }
+}
+
 function buildMailAttachmentRequest (sid, mailId) {
   return '<BS_Request>\r\n' +
     '   <MailAttachment Id="' + mailId + '" No="0"/>\r\n' +
@@ -71,6 +121,7 @@ async function fetchApi (url, xml, options, predicate = () => true, error = (mes
   const boundaryStart = '--' + boundary + '\r\n'
   const boundaryLast = '--' + boundary + '--\r\n'
 
+  options = withDefaultSanitizeLogMasks(options)
   options.method = options.method ? options.method : 'POST'
   options.headers = {
     'User-Agent': `BGPB mobile/${APP_VERSION} (Android; unknownAndroidSDKbuiltforx86; ${DEVICE_PLATFORM})`,
@@ -107,6 +158,7 @@ async function fetchApi (url, xml, options, predicate = () => true, error = (mes
 }
 
 async function fetchApiJson (url, options, predicate = () => true, error = (message) => console.assert(false, message)) {
+  options = withDefaultSanitizeLogMasks(options)
   const response = await fetchJson(BASE_URL + url, options)
   if (predicate) {
     validateResponse(response, response => predicate(response), error)
@@ -562,6 +614,11 @@ async function fetchCardLastTransactions (sid, account, fromDate, toDate, histor
 
 export async function fetchFullTransactions (sid, account, fromDate, toDate = new Date()) {
   console.log('>>> Загрузка списка транзакций...')
+  if (!FULL_STATEMENT_REQUESTS_ENABLED) {
+    console.log(`>>> Полная выписка для "${account.title}" требует device-bound аутентификацию приложения, пропускаем.`)
+    return []
+  }
+
   toDate = toDate || new Date()
 
   const dates = createDateIntervals(fromDate, toDate)

--- a/src/plugins/bgpb/converters.js
+++ b/src/plugins/bgpb/converters.js
@@ -73,6 +73,9 @@ function findHistoryTransactionAccount (apiTransaction, accounts) {
 function createHistoryMerchant (apiTransaction) {
   const mcc = Number(apiTransaction.mcc)
   const terminal = typeof apiTransaction.terminal === 'string' ? apiTransaction.terminal.trim() : ''
+  if (/^P2P_BGPB_\d+\b/i.test(terminal)) {
+    return null
+  }
   if (!terminal && (isNaN(mcc) || mcc === 0)) {
     return null
   }
@@ -115,6 +118,9 @@ function getMerchantKeyParts (merchant) {
 }
 
 function createStableSourceKey (apiTransaction) {
+  if (isHistoryApiTransaction(apiTransaction) && apiTransaction.orderNumber) {
+    return joinIdParts(['order', apiTransaction.orderNumber, apiTransaction.authCode ? `auth:${apiTransaction.authCode}` : null])
+  }
   if (apiTransaction.authCode) {
     return `auth:${apiTransaction.authCode}`
   }
@@ -172,6 +178,18 @@ function convertHistoryLastTransaction (apiTransaction, accounts) {
   const sign = apiTransaction.direction === 'incoming' ? 1 : -1
   const totalAmount = parseMinorAmount(apiTransaction.totalAmount?.amount)
   const invoiceAmount = parseMinorAmount(apiTransaction.currencyAmount?.amount)
+  const historyAmounts = [
+    {
+      instrument: totalInstrument,
+      amount: totalAmount
+    },
+    {
+      instrument: invoiceInstrument,
+      amount: invoiceAmount
+    }
+  ]
+  const accountAmount = historyAmounts.find(item => item.instrument === account.instrument && item.amount !== null)?.amount ?? null
+  const invoice = historyAmounts.find(item => item.instrument !== account.instrument && item.amount !== null)
 
   if (totalAmount === null && invoiceAmount === null) {
     return null
@@ -186,13 +204,13 @@ function convertHistoryLastTransaction (apiTransaction, accounts) {
       {
         id: '',
         account: { id: account.id },
-        invoice: invoiceInstrument !== account.instrument && invoiceAmount !== null
+        invoice: invoice
           ? {
-              instrument: invoiceInstrument,
-              sum: sign * invoiceAmount
+              instrument: invoice.instrument,
+              sum: sign * invoice.amount
             }
           : null,
-        sum: totalInstrument === account.instrument && totalAmount !== null ? sign * totalAmount : null,
+        sum: accountAmount !== null ? sign * accountAmount : null,
         fee: 0
       }
     ],


### PR DESCRIPTION
## Что изменено

- Отключены BGPB full statement запросы через SOU `ExecuteAction`, которые требуют device-bound аутентификацию приложения.
- Исправлена конвертация P2P incoming операций из HistoryApi, где сумма могла приходить не в `totalAmount`, а в `currencyAmount`.
- Убран технический merchant для `P2P_BGPB_*`.
- В history movement id добавлен `orderNumber`, чтобы не склеивать разные операции с одинаковым `authCode`.
- Добавлен санитайзинг SID/sessionId и login/password в XML/JSON логах.

## Почему

Новая полная выписка BGPB требует app-bound контекст (`DeviceNo` + динамический password/OTP). Пока этот flow не реализован, такие запросы лучше не выполнять: карточные операции продолжают грузиться через HistoryApi, а device-bound выписка пропускается без падения синхронизации.

## Проверка

- `npm run jest -- src/plugins/bgpb --runInBand`
- `npm run lint -- src/plugins/bgpb/api.js src/plugins/bgpb/converters.js src/plugins/bgpb/__tests__/api.test.js src/plugins/bgpb/__tests__/converters/transactions.test.js src/plugins/bgpb/__tests__/converters/transactions/lastTransactions.test.js`