### PR TITLE
[solutionbank] Фикс разных названий мерчантов в минивыписке и полной выписке

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ plans/archive/
 review/
 
 # local capture/debug artifacts
+temp/
 .local/
 .tmp-*/
 .tmp-*

--- a/src/plugins/solutionbank/__tests__/api.test.js
+++ b/src/plugins/solutionbank/__tests__/api.test.js
@@ -374,6 +374,77 @@ describe('fetchOperations', () => {
     ])
   })
 
+  it('filters full statement operations by requested transaction date range', async () => {
+    const fromDate = new Date('2026-05-10T00:00:00.000+03:00')
+    const toDate = new Date('2026-05-20T23:59:59.000+03:00')
+    const account = {
+      id: 'account-id',
+      internalAccountId: 'internal-account-id',
+      accountType: '1',
+      bankCode: '288',
+      cardHash: 'card-hash',
+      instrumentCode: '933',
+      rkcCode: '004'
+    }
+
+    fetchMock.once({
+      method: 'POST',
+      matcher: baseUrl + 'products/getCardAccountFullStatement',
+      response: {
+        status: 200,
+        body: {
+          operations: [
+            {
+              operationName: 'Покупка товаров и услуг',
+              transactionAuthCode: 'before-range',
+              transactionDate: new Date('2026-05-12T12:00:00.000+03:00').getTime(),
+              operationDate: new Date('2026-05-09T12:00:00.000+03:00').getTime(),
+              transactionAmount: 10,
+              transactionCurrency: '933',
+              operationAmount: 10,
+              operationCurrency: '933',
+              operationPlace: 'SHOP BEFORE',
+              operationSign: '-1'
+            },
+            {
+              operationName: 'Покупка товаров и услуг',
+              transactionAuthCode: 'inside-range',
+              transactionDate: new Date('2026-05-15T12:00:00.000+03:00').getTime(),
+              operationDate: new Date('2026-05-15T12:00:00.000+03:00').getTime(),
+              transactionAmount: 20,
+              transactionCurrency: '933',
+              operationAmount: 20,
+              operationCurrency: '933',
+              operationPlace: 'SHOP INSIDE',
+              operationSign: '-1'
+            },
+            {
+              operationName: 'Покупка товаров и услуг',
+              transactionAuthCode: 'after-range',
+              transactionDate: new Date('2026-05-18T12:00:00.000+03:00').getTime(),
+              operationDate: new Date('2026-05-21T12:00:00.000+03:00').getTime(),
+              transactionAmount: 30,
+              transactionCurrency: '933',
+              operationAmount: 30,
+              operationCurrency: '933',
+              operationPlace: 'SHOP AFTER',
+              operationSign: '-1'
+            }
+          ]
+        }
+      }
+    })
+
+    await expect(fetchOperations(sessionToken, [account], fromDate, toDate)).resolves.toEqual([
+      expect.objectContaining({
+        id: 'inside-range',
+        transactionDate: new Date('2026-05-15T12:00:00.000+03:00'),
+        transactionAmount: -20,
+        merchant: 'SHOP INSIDE'
+      })
+    ])
+  })
+
   it('loads shared card account statement once and assigns operations by card PAN', async () => {
     let statementRequests = 0
     const fromDate = new Date('2026-05-01T00:00:00.000+03:00')

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -160,6 +160,90 @@ describe('convertTransaction', () => {
     expect(hold.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
   })
 
+  it('keeps same id when one merchant has a trailing quote trimmed by the bank', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-11T10:12:00+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -37.36,
+      merchant: 'APTEKA N1 OOO &quot;FARMPROEKT&quot;',
+      hold: true
+    }
+    const postedOperation = {
+      id: '453991',
+      account_id: 'mock-account-001',
+      operationName: 'Оплата товаров (услуг)',
+      operationDate: new Date('2026-06-12T10:12:00+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -37.36,
+      transactionDate: new Date('2026-06-11T00:00:00+03:00'),
+      transactionAmount: -37.36,
+      transactionCurrencyCode: '933',
+      merchant: 'APTEKA N1 OOO "FARMPROEKT',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
+  })
+
+  it('keeps same id when one merchant has a short extra suffix after the bank prefix', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-11T11:23:00+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -17.52,
+      merchant: 'APTEKA PYaTOI KATEGORII V S',
+      hold: true
+    }
+    const postedOperation = {
+      id: '453992',
+      account_id: 'mock-account-001',
+      operationName: 'Оплата товаров (услуг)',
+      operationDate: new Date('2026-06-12T11:23:00+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -17.52,
+      transactionDate: new Date('2026-06-11T00:00:00+03:00'),
+      transactionAmount: -17.52,
+      transactionCurrencyCode: '933',
+      merchant: 'APTEKA PYaTOI KATEGORII V',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
+  })
+
+  it('does not merge similar merchants with different amounts', () => {
+    const firstHold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-11T11:23:00+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -2.79,
+      merchant: 'MAGAZIN EUROOPT PRIME',
+      hold: true
+    }
+    const secondHold = {
+      ...firstHold,
+      transactionDate: new Date('2026-06-11T11:24:00+03:00'),
+      transactionAmount: -31.37
+    }
+    const transactions = merge([firstHold, secondHold], []).map(transaction => convertTransaction(transaction))
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].movements[0].id).not.toEqual(transactions[1].movements[0].id)
+  })
+
   it('distinguishes repeated holds with same identity', () => {
     const firstHold = {
       account_id: 'mock-account-001',

--- a/src/plugins/solutionbank/api.js
+++ b/src/plugins/solutionbank/api.js
@@ -377,7 +377,10 @@ export async function fetchOperations (sessionToken, accounts, fromDate, toDate)
   })
 
   const filteredOperations = operations.filter(function (op) {
-    return op !== undefined && op.operationAmount !== 0
+    return op !== undefined &&
+      op.transactionDate >= fromDate &&
+      op.transactionDate <= toDate &&
+      op.operationAmount !== 0
   })
 
   console.log(`>>> Загружено ${filteredOperations.length} операций.`)

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -1,6 +1,7 @@
 import { MD5 } from 'jshashes'
 import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
 const BANK_TIMEZONE_OFFSET_MS = 3 * 60 * 60 * 1000
+const MERCHANT_ID_PREFIX_LENGTH = 25
 const md5 = new MD5()
 
 export function convertAccount (json) {
@@ -121,7 +122,13 @@ function getMerchantIdValue (value) {
   if (value === undefined || value === null) {
     return ''
   }
-  return String(value).replace(/&quot;/g, '"').replace(/\s+/g, ' ').trim().toUpperCase()
+  return String(value)
+    .replace(/&quot;/g, '"')
+    .replace(/"/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toUpperCase()
+    .slice(0, MERCHANT_ID_PREFIX_LENGTH)
 }
 
 function getIdValue (value) {


### PR DESCRIPTION
## Что изменилось

- Нормализована строка магазина, которая используется в `solutionbank` для построения стабильного id операции.
- Исправлена дедупликация между мини-выпиской и полной выпиской, когда банк возвращает один и тот же платеж с немного разным названием магазина.
- Полная выписка теперь дополнительно фильтруется по запрошенному диапазону дат операции.
- Добавлены регрессионные тесты на обрезанные кавычки, обрезанный хвост merchant и похожие операции с разными суммами.

## Реальный пример

До исправления один и тот же платеж мог попасть в импорт дважды, потому что банк возвращал merchant немного по-разному в мини-выписке и полной выписке:

- `Visa Virtual (SV)*1817 -17.52 BYN`
  `APTEKA PYaTOI KATEGORII V S`

- `Visa Virtual (SV)*1817 -17.52 BYN`
  `APTEKA PYaTOI KATEGORII V`

Еще один пример:

- `Visa Virtual (SV)*1817 -37.36 BYN`
  `APTEKA N1 OOO "FARMPROEKT"`

- `Visa Virtual (SV)*1817 -37.36 BYN`
  `APTEKA N1 OOO "FARMPROEKT`

Сумма, карта, валюта и день операции совпадают, но строка магазина отличается из-за обрезанного хвоста или кавычки. Раньше такие записи получали разные id и импортировались как разные операции.

## Причина

`solutionbank` загружает операции из двух источников банка:

- `GetAuthHistory` - свежие/непроведенные операции по карте.
- `getCardAccountFullStatement` - уже проведенные операции по счету.

Один и тот же платеж может появиться в обоих источниках. При этом банк иногда возвращает merchant немного по-разному.

## Решение

Для построения id merchant теперь нормализуется:

- `&quot;` приводится к обычным кавычкам;
- кавычки игнорируются;
- повторяющиеся пробелы схлопываются;
- используется стабильный префикс merchant.

При этом совпадение все еще требует одинаковые счет/карту, день операции, сумму и валюту. Поэтому похожие операции с разными суммами не схлопываются, например:

- `Visa Virtual (SV)*1817 -2.79 BYN`
  `MAGAZIN EUROOPT PRIME`

- `Visa Virtual (SV)*1817 -31.37 BYN`
  `MAGAZIN EUROOPT PRIME`

## Проверка

- `node_modules\.bin\jest.cmd --testMatch "**/src/plugins/solutionbank/**/__tests__/**/*.js" --testPathIgnorePatterns "/node_modules/" --runInBand`
- `yarn lint`
- `git diff --check`