### PR TITLE
[cifrabank-ru] add Cifra Bank (Russia) plugin

### DIFF
--- a/src/plugins/cifrabank-ru/ZenmoneyManifest.xml
+++ b/src/plugins/cifrabank-ru/ZenmoneyManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>cifrabank-ru</id>
+    <company>0</company>
+    <description>
+        Plugin for Cifra Bank (Russia) — synchronizes accounts and operations
+        via the mobile API used by com.bankffin.portfolio.
+    </description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+</provider>

--- a/src/plugins/cifrabank-ru/__tests__/converters/accounts.test.ts
+++ b/src/plugins/cifrabank-ru/__tests__/converters/accounts.test.ts
@@ -1,0 +1,80 @@
+import { AccountType } from '../../../../types/zenmoney'
+import { buildCardNumberMap, convertAccounts } from '../../converters'
+
+describe('convertAccounts', () => {
+  it('converts CARD and CURRENT accounts and merges related card numbers', () => {
+    const apiAccounts: unknown[] = [
+      {
+        id: 1000001,
+        name: 'Счет в Цифра банк',
+        type: 'BANK',
+        number: '40817840000000000001',
+        currency: 'USD',
+        amount: 0,
+        subtype: 'CARD',
+        state: 'ACTIVE',
+        cardIDs: '900001'
+      },
+      {
+        id: 1000002,
+        name: 'Счет в Цифра банк',
+        type: 'BANK',
+        number: '40817810000000000002',
+        currency: 'RUB',
+        amount: 0,
+        subtype: 'CARD',
+        state: 'ACTIVE',
+        cardIDs: '900001'
+      },
+      {
+        id: 2000003,
+        name: 'Текущий счет',
+        type: 'BANK',
+        number: '40817840000000000003',
+        currency: 'USD',
+        amount: 0,
+        subtype: 'CURRENT',
+        state: 'ACTIVE',
+        cardIDs: null
+      }
+    ]
+    const apiCards: unknown[] = [
+      { id: 900001, number: '220300******0001' }
+    ]
+
+    const result = convertAccounts(apiAccounts, buildCardNumberMap(apiCards))
+
+    expect(result).toHaveLength(3)
+    expect(result[0]).toEqual({
+      account: {
+        id: '1000001',
+        type: AccountType.ccard,
+        title: 'Счет в Цифра банк (USD)',
+        instrument: 'USD',
+        syncIds: ['40817840000000000001', '220300******0001'],
+        balance: 0
+      },
+      products: [{ id: 1000001, subtype: 'CARD' }]
+    })
+    expect(result[1].account.type).toBe(AccountType.ccard)
+    expect(result[1].account.syncIds).toEqual(['40817810000000000002', '220300******0001'])
+    expect(result[2]).toEqual({
+      account: {
+        id: '2000003',
+        type: AccountType.checking,
+        title: 'Текущий счет',
+        instrument: 'USD',
+        syncIds: ['40817840000000000003'],
+        balance: 0
+      },
+      products: [{ id: 2000003, subtype: 'CURRENT' }]
+    })
+  })
+
+  it('skips non-ACTIVE accounts', () => {
+    const result = convertAccounts([
+      { id: 1, name: 'Closed', type: 'BANK', number: '11111', currency: 'RUB', amount: 0, subtype: 'CURRENT', state: 'CLOSED', cardIDs: null }
+    ], new Map())
+    expect(result).toEqual([])
+  })
+})

--- a/src/plugins/cifrabank-ru/__tests__/converters/operations.test.ts
+++ b/src/plugins/cifrabank-ru/__tests__/converters/operations.test.ts
@@ -1,0 +1,77 @@
+import { convertOperation } from '../../converters'
+
+describe('convertOperation', () => {
+  it('converts a card EXPENSE (RUB) with negative amount and numeric currency code', () => {
+    const apiOp = {
+      id: 700001,
+      accountId: 1000002,
+      operationType: 'EXPENSE',
+      operationKind: 'FINANCIAL',
+      accountNumber: '40817810000000000002',
+      date: '2024-01-15 12:00:00',
+      timestamp: 1705320000000,
+      amount: -1234.56,
+      currency: '810',
+      status: 'SUCCESS',
+      note: 'Тестовое описание операции',
+      mccCode: '5411',
+      payer: 'Тестовый Плательщик, счет 40817810000000000002, БИК 044525900',
+      recepient: 'Тестовый Получатель, счет 30232810000000000000, БИК 044525900',
+      category: 'Прочее',
+      locationName: 'TEST MERCHANT MOSCOW RU'
+    }
+    const tx = convertOperation(apiOp, '1000002')
+    if (tx == null) {
+      throw new Error('expected non-null transaction')
+    }
+    expect(tx.hold).toBe(false)
+    expect(tx.date.getTime()).toBe(1705320000000)
+    expect(tx.movements).toEqual([{
+      id: '700001',
+      account: { id: '1000002' },
+      invoice: null,
+      sum: -1234.56,
+      fee: 0
+    }])
+    expect(tx.merchant).toEqual({
+      fullTitle: 'TEST MERCHANT MOSCOW RU',
+      mcc: 5411,
+      location: null
+    })
+    expect(tx.comment).toBe('Тестовое описание операции')
+  })
+
+  it('converts an INCOME on USD account from /accounts/statement', () => {
+    const apiOp = {
+      id: 700002,
+      accountId: 2000003,
+      operationType: 'INCOME',
+      accountNumber: '40817840000000000003',
+      date: '2024-01-16 09:00:00',
+      timestamp: 1705395600000,
+      amount: 100,
+      currency: '840',
+      currencyDesc: 'Доллар Сша',
+      status: 'SUCCESS',
+      note: 'Тестовое поступление',
+      payer: 'Тестовый Банк-Отправитель, счет 30233840000000000000, БИК 044525900',
+      recepient: 'Тестовый Получатель, счет 40817840000000000003, БИК 044525900',
+      category: '- внутренние безналичные расчеты'
+    }
+    const tx = convertOperation(apiOp, '2000003')
+    if (tx == null) {
+      throw new Error('expected non-null transaction')
+    }
+    expect(tx.movements[0].sum).toBe(100)
+    expect(tx.merchant).toEqual({
+      fullTitle: 'Тестовый Банк-Отправитель',
+      mcc: null,
+      location: null
+    })
+  })
+
+  it('rejects operations without amount or currency', () => {
+    expect(convertOperation({ id: 1, date: '2024-01-01 00:00:00', amount: null, currency: '810', status: 'SUCCESS' }, 'x')).toBeNull()
+    expect(convertOperation({ id: 1, date: '2024-01-01 00:00:00', amount: 5, currency: null, status: 'SUCCESS' }, 'x')).toBeNull()
+  })
+})

--- a/src/plugins/cifrabank-ru/api.ts
+++ b/src/plugins/cifrabank-ru/api.ts
@@ -1,11 +1,20 @@
-import { fetchAccountStatement, fetchAccounts as fetchAccountsRaw, fetchCardOperations, fetchLogonWithSmsCode, fetchPassRequest, SessionExpiredError } from './fetchApi'
+import {
+  fetchAccountStatement,
+  fetchAccounts as fetchAccountsRaw,
+  fetchCardOperations,
+  fetchLogonWithSmsCode,
+  fetchPassRequest,
+  fetchRefreshToken,
+  fetchRelatedCards as fetchRelatedCardsRaw,
+  SessionExpiredError
+} from './fetchApi'
 import { Auth, Preferences, Product, Session } from './models'
 
 interface DecodedAccessToken {
   exp: number
 }
 
-function decodeAccessToken (token: string): DecodedAccessToken | null {
+export function decodeAccessToken (token: string): DecodedAccessToken | null {
   const parts = token.split('.')
   if (parts.length !== 3) {
     return null
@@ -23,17 +32,26 @@ function decodeAccessToken (token: string): DecodedAccessToken | null {
   }
 }
 
-function buildSession (tokens: { token: string, refresh: string }): Session {
-  const decoded = decodeAccessToken(tokens.token)
+function buildSession (token: string, refresh: string): Session {
+  const decoded = decodeAccessToken(token)
   return {
-    token: tokens.token,
-    refresh: tokens.refresh,
+    token,
+    refresh,
     expiresAt: decoded?.exp ?? Math.floor(Date.now() / 1000) + 60
   }
 }
 
-async function loginInteractively (preferences: Preferences): Promise<Session> {
-  const passRequestId = await fetchPassRequest(preferences.phone, preferences.cardNumber)
+// 16-hex-char id matching the format the official mobile client sends.
+export function generateDeviceId (): string {
+  const bytes = new Uint8Array(8)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Math.floor(Math.random() * 256)
+  }
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+async function loginInteractively (deviceId: string, preferences: Preferences): Promise<Session> {
+  const passRequestId = await fetchPassRequest(deviceId, preferences.phone, preferences.cardNumber)
   const smsCode = await ZenMoney.readLine('Введите код из SMS от Цифра Банка', {
     inputType: 'number',
     time: 120000
@@ -41,38 +59,41 @@ async function loginInteractively (preferences: Preferences): Promise<Session> {
   if (smsCode == null || smsCode.length === 0) {
     throw new Error('Не удалось получить код подтверждения')
   }
-  const tokens = await fetchLogonWithSmsCode(preferences.phone, passRequestId, smsCode)
-  return buildSession(tokens)
+  const tokens = await fetchLogonWithSmsCode(deviceId, preferences.phone, passRequestId, smsCode)
+  return buildSession(tokens.token, tokens.refresh)
 }
 
-// The bank's refresh-token endpoint requires a device-bound payload that the
-// mobile app constructs from PIN-encrypted material; we do not have an analogue,
-// so every plugin run authenticates via SMS. The Auth blob is therefore empty
-// today, but is preserved as an extension point for a future flow.
-export async function login (preferences: Preferences, _auth?: Auth): Promise<Session> {
-  return await loginInteractively(preferences)
+export async function login (preferences: Preferences, auth: Auth): Promise<Session> {
+  if (auth.refresh != null && auth.refresh.length > 0) {
+    const refreshed = await fetchRefreshToken(auth.deviceId, auth.refresh)
+    if (refreshed != null) {
+      return buildSession(refreshed, auth.refresh)
+    }
+    // Stored refresh token no longer works (revoked, expired, or rotated by a fresh logon
+    // on the real device) — fall through to interactive SMS login.
+  }
+  return await loginInteractively(auth.deviceId, preferences)
 }
 
-export async function fetchAccounts (session: Session): Promise<unknown[]> {
-  return await fetchAccountsRaw(session)
+export async function fetchAccounts (session: Session, deviceId: string): Promise<unknown[]> {
+  return await fetchAccountsRaw(session, deviceId)
+}
+
+export async function fetchRelatedCards (session: Session, deviceId: string): Promise<unknown[]> {
+  return await fetchRelatedCardsRaw(session, deviceId)
 }
 
 export async function fetchTransactions (
   session: Session,
+  deviceId: string,
   product: Product,
   fromDate: Date,
   toDate: Date
 ): Promise<unknown[]> {
-  try {
-    if (product.subtype === 'CARD') {
-      return await fetchCardOperations(session, product.id, fromDate, toDate)
-    }
-    return await fetchAccountStatement(session, product.id, fromDate, toDate)
-  } catch (e) {
-    if (e instanceof SessionExpiredError) {
-      // Re-throw so the surrounding scrape can decide; consumers can chain to a relogin later if needed.
-      throw e
-    }
-    throw e
+  if (product.subtype === 'CARD') {
+    return await fetchCardOperations(session, deviceId, product.id, fromDate, toDate)
   }
+  return await fetchAccountStatement(session, deviceId, product.id, fromDate, toDate)
 }
+
+export { SessionExpiredError }

--- a/src/plugins/cifrabank-ru/api.ts
+++ b/src/plugins/cifrabank-ru/api.ts
@@ -1,0 +1,78 @@
+import { fetchAccountStatement, fetchAccounts as fetchAccountsRaw, fetchCardOperations, fetchLogonWithSmsCode, fetchPassRequest, SessionExpiredError } from './fetchApi'
+import { Auth, Preferences, Product, Session } from './models'
+
+interface DecodedAccessToken {
+  exp: number
+}
+
+function decodeAccessToken (token: string): DecodedAccessToken | null {
+  const parts = token.split('.')
+  if (parts.length !== 3) {
+    return null
+  }
+  try {
+    const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+    const padded = payload + '='.repeat((4 - payload.length % 4) % 4)
+    const json = JSON.parse(Buffer.from(padded, 'base64').toString('utf-8')) as { exp?: number }
+    if (typeof json.exp !== 'number') {
+      return null
+    }
+    return { exp: json.exp }
+  } catch (e) {
+    return null
+  }
+}
+
+function buildSession (tokens: { token: string, refresh: string }): Session {
+  const decoded = decodeAccessToken(tokens.token)
+  return {
+    token: tokens.token,
+    refresh: tokens.refresh,
+    expiresAt: decoded?.exp ?? Math.floor(Date.now() / 1000) + 60
+  }
+}
+
+async function loginInteractively (preferences: Preferences): Promise<Session> {
+  const passRequestId = await fetchPassRequest(preferences.phone, preferences.cardNumber)
+  const smsCode = await ZenMoney.readLine('Введите код из SMS от Цифра Банка', {
+    inputType: 'number',
+    time: 120000
+  })
+  if (smsCode == null || smsCode.length === 0) {
+    throw new Error('Не удалось получить код подтверждения')
+  }
+  const tokens = await fetchLogonWithSmsCode(preferences.phone, passRequestId, smsCode)
+  return buildSession(tokens)
+}
+
+// The bank's refresh-token endpoint requires a device-bound payload that the
+// mobile app constructs from PIN-encrypted material; we do not have an analogue,
+// so every plugin run authenticates via SMS. The Auth blob is therefore empty
+// today, but is preserved as an extension point for a future flow.
+export async function login (preferences: Preferences, _auth?: Auth): Promise<Session> {
+  return await loginInteractively(preferences)
+}
+
+export async function fetchAccounts (session: Session): Promise<unknown[]> {
+  return await fetchAccountsRaw(session)
+}
+
+export async function fetchTransactions (
+  session: Session,
+  product: Product,
+  fromDate: Date,
+  toDate: Date
+): Promise<unknown[]> {
+  try {
+    if (product.subtype === 'CARD') {
+      return await fetchCardOperations(session, product.id, fromDate, toDate)
+    }
+    return await fetchAccountStatement(session, product.id, fromDate, toDate)
+  } catch (e) {
+    if (e instanceof SessionExpiredError) {
+      // Re-throw so the surrounding scrape can decide; consumers can chain to a relogin later if needed.
+      throw e
+    }
+    throw e
+  }
+}

--- a/src/plugins/cifrabank-ru/converters.ts
+++ b/src/plugins/cifrabank-ru/converters.ts
@@ -1,0 +1,171 @@
+import { AccountType, Amount, Movement, Transaction } from '../../types/zenmoney'
+import { getNumber, getOptArray, getOptNumber, getOptString, getString } from '../../types/get'
+import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
+import { ConvertedAccount } from './models'
+
+const CARD_SUBTYPES = new Set(['CARD'])
+const CHECKING_SUBTYPES = new Set(['CURRENT', 'SAVINGS'])
+
+export function convertAccounts (apiAccounts: unknown[], cardNumbersByCardId: Map<string, string>): ConvertedAccount[] {
+  const result: ConvertedAccount[] = []
+  for (const apiAccount of apiAccounts) {
+    const converted = convertAccount(apiAccount, cardNumbersByCardId)
+    if (converted != null) {
+      result.push(converted)
+    }
+  }
+  return result
+}
+
+function convertAccount (apiAccount: unknown, cardNumbersByCardId: Map<string, string>): ConvertedAccount | null {
+  if (getOptString(apiAccount, 'state') !== 'ACTIVE') {
+    return null
+  }
+  const id = getNumber(apiAccount, 'id')
+  const number = getString(apiAccount, 'number')
+  const subtype = (getOptString(apiAccount, 'subtype') ?? '').toUpperCase()
+  const accountType = subtype === 'CARD' ? AccountType.ccard : AccountType.checking
+  const instrument = (getOptString(apiAccount, 'currency') ?? 'RUB').toUpperCase()
+  const balance = getOptNumber(apiAccount, 'amount') ?? 0
+  const title = buildAccountTitle(apiAccount, subtype, instrument)
+
+  const syncIds = [number]
+  if (subtype === 'CARD') {
+    const cardNumbers = extractCardNumbers(apiAccount, cardNumbersByCardId)
+    for (const masked of cardNumbers) {
+      if (!syncIds.includes(masked)) {
+        syncIds.push(masked)
+      }
+    }
+  }
+
+  return {
+    account: {
+      id: String(id),
+      type: accountType,
+      title,
+      instrument,
+      syncIds,
+      balance
+    },
+    products: [{ id, subtype: CARD_SUBTYPES.has(subtype) ? 'CARD' : (CHECKING_SUBTYPES.has(subtype) ? 'CURRENT' : 'CURRENT') }]
+  }
+}
+
+function buildAccountTitle (apiAccount: unknown, subtype: string, instrument: string): string {
+  const baseName = getOptString(apiAccount, 'name') ?? 'Цифра банк'
+  if (subtype === 'CARD') {
+    return `${baseName} (${instrument})`
+  }
+  return baseName
+}
+
+function extractCardNumbers (apiAccount: unknown, cardNumbersByCardId: Map<string, string>): string[] {
+  const cardIDsRaw = getOptString(apiAccount, 'cardIDs')
+  if (cardIDsRaw == null || cardIDsRaw.length === 0) {
+    return []
+  }
+  return cardIDsRaw.split(',')
+    .map(id => id.trim())
+    .filter(id => id.length > 0)
+    .map(id => cardNumbersByCardId.get(id))
+    .filter((s): s is string => typeof s === 'string')
+}
+
+export function buildCardNumberMap (apiCards: unknown[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const apiCard of apiCards) {
+    const id = getOptNumber(apiCard, 'id') ?? getOptString(apiCard, 'id')
+    const number = getOptString(apiCard, 'number')
+    if (id != null && number != null) {
+      map.set(String(id), number)
+    }
+  }
+  return map
+}
+
+export function convertOperation (apiOperation: unknown, accountId: string): Transaction | null {
+  const status = getOptString(apiOperation, 'status')
+  if (status === 'REJECTED' || status === 'CANCELLED') {
+    return null
+  }
+  const timestamp = getOptNumber(apiOperation, 'timestamp')
+  const dateStr = getOptString(apiOperation, 'date')
+  const date = timestamp != null
+    ? new Date(timestamp)
+    : (dateStr != null ? new Date(dateStr.replace(' ', 'T')) : null)
+  if (date == null || Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  const accountAmount = parseAccountAmount(apiOperation)
+  if (accountAmount == null) {
+    return null
+  }
+  const opId = getOptNumber(apiOperation, 'id') ?? getOptString(apiOperation, 'id')
+
+  const movement: Movement = {
+    id: opId != null ? String(opId) : null,
+    account: { id: accountId },
+    invoice: null,
+    sum: accountAmount.sum,
+    fee: 0
+  }
+
+  return {
+    hold: status != null && status !== 'SUCCESS' && status !== 'COMPLETED',
+    date,
+    movements: [movement],
+    merchant: buildMerchant(apiOperation),
+    comment: getOptString(apiOperation, 'note') ?? null
+  }
+}
+
+function parseAccountAmount (apiOperation: unknown): Amount | null {
+  const amount = getOptNumber(apiOperation, 'amount')
+  if (amount == null) {
+    return null
+  }
+  const instrument = resolveInstrument(apiOperation)
+  if (instrument == null) {
+    return null
+  }
+  // For CARD operations the bank ships expenses as a negative number (e.g. -16000);
+  // for /accounts/statement EXPENSE rows also come with a negative sign.
+  // We keep the sign as-is so it lines up with Zenmoney's convention.
+  return { sum: amount, instrument }
+}
+
+function resolveInstrument (apiOperation: unknown): string | null {
+  const raw = getOptString(apiOperation, 'currency')
+  if (raw == null) {
+    return null
+  }
+  // If currency is a numeric ISO 4217 code (e.g. "810") map to letter code.
+  if (/^\d+$/.test(raw)) {
+    return codeToCurrencyLookup[raw] ?? null
+  }
+  return raw.toUpperCase()
+}
+
+function buildMerchant (apiOperation: unknown): Transaction['merchant'] {
+  const isExpense = getOptString(apiOperation, 'operationType') === 'EXPENSE'
+  const counterparty = isExpense ? getOptString(apiOperation, 'recepient') : getOptString(apiOperation, 'payer')
+  const trimmedCounterparty = counterparty != null ? counterparty.split(',')[0].trim() : null
+  const locationName = getOptString(apiOperation, 'locationName')
+  const mccRaw = getOptString(apiOperation, 'mccCode')
+  const mcc = mccRaw != null && /^\d+$/.test(mccRaw) ? Number(mccRaw) : null
+
+  const title = (locationName != null && locationName.length > 0 ? locationName : trimmedCounterparty) ?? null
+  if (title == null || title.length === 0) {
+    return null
+  }
+  return {
+    fullTitle: title,
+    mcc,
+    location: null
+  }
+}
+
+// Re-export for tests
+export const _internal = { getOptArray }

--- a/src/plugins/cifrabank-ru/fetchApi.ts
+++ b/src/plugins/cifrabank-ru/fetchApi.ts
@@ -10,13 +10,24 @@ const MOBILE_HOST = 'https://mo.ffinpay.ru'
 const APP_VERSION = '9.3.0'
 const APP_USER_AGENT = 'okhttp/5.3.2'
 
-function defaultHeaders (session?: Session): Record<string, string> {
-  const headers: Record<string, string> = {
+// The bank's authentication backend rejects requests that lack these mobile-app
+// markers, so we replicate the set the official client sends on every call.
+function appHeaders (deviceId: string): Record<string, string> {
+  return {
     Accept: 'application/json, text/plain, */*',
-    'Content-Type': 'application/json; charset=UTF-8',
     'User-Agent': APP_USER_AGENT,
-    'X-App-Version': APP_VERSION,
-    'X-Platform': 'android'
+    channel: 'mapi',
+    'x-version': APP_VERSION,
+    mobileos: 'Android',
+    getuniqueid: deviceId,
+    pushisenable: 'false'
+  }
+}
+
+function defaultHeaders (deviceId: string, session?: Session): Record<string, string> {
+  const headers: Record<string, string> = {
+    ...appHeaders(deviceId),
+    'Content-Type': 'application/json; charset=UTF-8'
   }
   if (session != null) {
     headers.Authorization = `Bearer ${session.token}`
@@ -24,17 +35,22 @@ function defaultHeaders (session?: Session): Record<string, string> {
   return headers
 }
 
-async function callJson (url: string, options: FetchOptions, session?: Session): Promise<FetchResponse> {
+async function callJson (
+  url: string,
+  options: FetchOptions,
+  deviceId: string,
+  session?: Session
+): Promise<FetchResponse> {
   return await fetchJson(url, {
     ...options,
     headers: {
-      ...defaultHeaders(session),
+      ...defaultHeaders(deviceId, session),
       ...(typeof options.headers === 'object' && options.headers !== null ? options.headers : {})
     }
   })
 }
 
-export async function fetchPassRequest (phone: string, cardNumber: string): Promise<number> {
+export async function fetchPassRequest (deviceId: string, phone: string, cardNumber: string): Promise<number> {
   // The bank expects sha256 of the raw card number (no spaces) as the answer to the CARD_NUMBER security question.
   const secAnswer = forge.md.sha256.create().update(cardNumber.replace(/\D/g, ''), 'utf8').digest().toHex()
   const response = await callJson(`${AUTH_HOST}/ncs-mobile/rest/v2/auth/pass-request`, {
@@ -46,7 +62,7 @@ export async function fetchPassRequest (phone: string, cardNumber: string): Prom
       secAnswer
     },
     sanitizeRequestLog: { body: { userId: true, secAnswer: true } }
-  })
+  }, deviceId)
   if (response.status !== 200 || !getBoolean(response.body, 'success')) {
     throw new InvalidLoginOrPasswordError('Не удалось начать вход в Цифра Банк. Проверьте номер телефона и номер карты.')
   }
@@ -54,6 +70,7 @@ export async function fetchPassRequest (phone: string, cardNumber: string): Prom
 }
 
 export async function fetchLogonWithSmsCode (
+  deviceId: string,
   phone: string,
   passRequestId: number,
   smsCode: string
@@ -70,7 +87,7 @@ export async function fetchLogonWithSmsCode (
     },
     sanitizeRequestLog: { body: { userId: true, password: true } },
     sanitizeResponseLog: { body: { token: true, refresh: true } }
-  })
+  }, deviceId)
   if (response.status !== 200 || getOptString(response.body, 'status') !== 'SUCCESS') {
     throw new InvalidLoginOrPasswordError('Не удалось войти: неверный SMS-код или истёк срок ожидания.')
   }
@@ -80,10 +97,28 @@ export async function fetchLogonWithSmsCode (
   }
 }
 
-export async function fetchAccounts (session: Session): Promise<unknown[]> {
+// The endpoint trades a refresh JWT for a fresh access JWT. The refresh token itself
+// stays valid (its TTL is months long, the access token lives ~3 minutes).
+export async function fetchRefreshToken (deviceId: string, refresh: string): Promise<string | null> {
+  const response = await fetchJson(`${AUTH_HOST}/ncs-mobile/rest/v2/auth/refresh-token`, {
+    method: 'GET',
+    headers: {
+      ...appHeaders(deviceId),
+      Authorization: `Bearer ${refresh}`
+    },
+    sanitizeRequestLog: { headers: { Authorization: true } },
+    sanitizeResponseLog: { body: { token: true } }
+  })
+  if (response.status !== 200 || getOptString(response.body, 'status') !== 'SUCCESS') {
+    return null
+  }
+  return getOptString(response.body, 'token') ?? null
+}
+
+export async function fetchAccounts (session: Session, deviceId: string): Promise<unknown[]> {
   const response = await callJson(`${MOBILE_HOST}/ncs-mobile/rest/v1/accounts`, {
     method: 'GET'
-  }, session)
+  }, deviceId, session)
   if (response.status === 401) {
     throw new SessionExpiredError()
   }
@@ -93,26 +128,39 @@ export async function fetchAccounts (session: Session): Promise<unknown[]> {
   return Array.isArray(response.body) ? response.body : []
 }
 
+export async function fetchRelatedCards (session: Session, deviceId: string): Promise<unknown[]> {
+  const response = await callJson(`${MOBILE_HOST}/ncs-mobile/rest/v1/cards/related`, {
+    method: 'GET'
+  }, deviceId, session)
+  if (response.status !== 200) {
+    return []
+  }
+  return Array.isArray(response.body) ? response.body : []
+}
+
 export async function fetchCardOperations (
   session: Session,
+  deviceId: string,
   accountId: number,
   fromDate: Date,
   toDate: Date
 ): Promise<unknown[]> {
-  return await fetchOperations(session, '/ncs-mobile/rest/v1/card/sca-operations/', accountId, fromDate, toDate)
+  return await fetchOperations(session, deviceId, '/ncs-mobile/rest/v1/card/sca-operations/', accountId, fromDate, toDate)
 }
 
 export async function fetchAccountStatement (
   session: Session,
+  deviceId: string,
   accountId: number,
   fromDate: Date,
   toDate: Date
 ): Promise<unknown[]> {
-  return await fetchOperations(session, '/ncs-mobile/rest/v1/accounts/statement/', accountId, fromDate, toDate)
+  return await fetchOperations(session, deviceId, '/ncs-mobile/rest/v1/accounts/statement/', accountId, fromDate, toDate)
 }
 
 async function fetchOperations (
   session: Session,
+  deviceId: string,
   path: string,
   accountId: number,
   fromDate: Date,
@@ -126,7 +174,7 @@ async function fetchOperations (
   ].join('&')
   const response = await callJson(`${MOBILE_HOST}${path}?${params}`, {
     method: 'GET'
-  }, session)
+  }, deviceId, session)
   if (response.status === 401) {
     throw new SessionExpiredError()
   }

--- a/src/plugins/cifrabank-ru/fetchApi.ts
+++ b/src/plugins/cifrabank-ru/fetchApi.ts
@@ -1,0 +1,154 @@
+import forge from 'node-forge'
+import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
+import { InvalidLoginOrPasswordError } from '../../errors'
+import { getBoolean, getNumber, getOptString, getString } from '../../types/get'
+import { Session } from './models'
+
+const AUTH_HOST = 'https://ffb-authentication.ffinpay.ru'
+const MOBILE_HOST = 'https://mo.ffinpay.ru'
+
+const APP_VERSION = '9.3.0'
+const APP_USER_AGENT = 'okhttp/5.3.2'
+
+function defaultHeaders (session?: Session): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json, text/plain, */*',
+    'Content-Type': 'application/json; charset=UTF-8',
+    'User-Agent': APP_USER_AGENT,
+    'X-App-Version': APP_VERSION,
+    'X-Platform': 'android'
+  }
+  if (session != null) {
+    headers.Authorization = `Bearer ${session.token}`
+  }
+  return headers
+}
+
+async function callJson (url: string, options: FetchOptions, session?: Session): Promise<FetchResponse> {
+  return await fetchJson(url, {
+    ...options,
+    headers: {
+      ...defaultHeaders(session),
+      ...(typeof options.headers === 'object' && options.headers !== null ? options.headers : {})
+    }
+  })
+}
+
+export async function fetchPassRequest (phone: string, cardNumber: string): Promise<number> {
+  // The bank expects sha256 of the raw card number (no spaces) as the answer to the CARD_NUMBER security question.
+  const secAnswer = forge.md.sha256.create().update(cardNumber.replace(/\D/g, ''), 'utf8').digest().toHex()
+  const response = await callJson(`${AUTH_HOST}/ncs-mobile/rest/v2/auth/pass-request`, {
+    method: 'POST',
+    body: {
+      userId: phone.replace(/\D/g, ''),
+      userIdType: 'PHONE',
+      secQuestion: 'CARD_NUMBER',
+      secAnswer
+    },
+    sanitizeRequestLog: { body: { userId: true, secAnswer: true } }
+  })
+  if (response.status !== 200 || !getBoolean(response.body, 'success')) {
+    throw new InvalidLoginOrPasswordError('Не удалось начать вход в Цифра Банк. Проверьте номер телефона и номер карты.')
+  }
+  return getNumber(response.body, 'passRequestId')
+}
+
+export async function fetchLogonWithSmsCode (
+  phone: string,
+  passRequestId: number,
+  smsCode: string
+): Promise<{ token: string, refresh: string }> {
+  const response = await callJson(`${AUTH_HOST}/ncs-mobile/rest/v3/auth/logon-request`, {
+    method: 'POST',
+    body: {
+      passwordType: 'SMS_CODE',
+      userIdType: 'PHONE',
+      authType: 'CARD_NUMBER',
+      password: smsCode,
+      userId: phone.replace(/\D/g, ''),
+      passRequestId
+    },
+    sanitizeRequestLog: { body: { userId: true, password: true } },
+    sanitizeResponseLog: { body: { token: true, refresh: true } }
+  })
+  if (response.status !== 200 || getOptString(response.body, 'status') !== 'SUCCESS') {
+    throw new InvalidLoginOrPasswordError('Не удалось войти: неверный SMS-код или истёк срок ожидания.')
+  }
+  return {
+    token: getString(response.body, 'token'),
+    refresh: getString(response.body, 'refresh')
+  }
+}
+
+export async function fetchAccounts (session: Session): Promise<unknown[]> {
+  const response = await callJson(`${MOBILE_HOST}/ncs-mobile/rest/v1/accounts`, {
+    method: 'GET'
+  }, session)
+  if (response.status === 401) {
+    throw new SessionExpiredError()
+  }
+  if (response.status !== 200) {
+    throw new Error(`Cifra Bank: failed to fetch accounts (${response.status})`)
+  }
+  return Array.isArray(response.body) ? response.body : []
+}
+
+export async function fetchCardOperations (
+  session: Session,
+  accountId: number,
+  fromDate: Date,
+  toDate: Date
+): Promise<unknown[]> {
+  return await fetchOperations(session, '/ncs-mobile/rest/v1/card/sca-operations/', accountId, fromDate, toDate)
+}
+
+export async function fetchAccountStatement (
+  session: Session,
+  accountId: number,
+  fromDate: Date,
+  toDate: Date
+): Promise<unknown[]> {
+  return await fetchOperations(session, '/ncs-mobile/rest/v1/accounts/statement/', accountId, fromDate, toDate)
+}
+
+async function fetchOperations (
+  session: Session,
+  path: string,
+  accountId: number,
+  fromDate: Date,
+  toDate: Date
+): Promise<unknown[]> {
+  const params = [
+    `accountId=${accountId}`,
+    'order=desc',
+    `dateFrom=${formatRangeDate(fromDate, 'start')}`,
+    `dateTo=${formatRangeDate(toDate, 'end')}`
+  ].join('&')
+  const response = await callJson(`${MOBILE_HOST}${path}?${params}`, {
+    method: 'GET'
+  }, session)
+  if (response.status === 401) {
+    throw new SessionExpiredError()
+  }
+  if (response.status !== 200) {
+    throw new Error(`Cifra Bank: failed to fetch operations from ${path} (${response.status})`)
+  }
+  return Array.isArray(response.body) ? response.body : []
+}
+
+// The bank expects local-time bounds formatted as "YYYY-MM-DD HH:MM:SS".
+function formatRangeDate (date: Date, edge: 'start' | 'end'): string {
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  const y = date.getFullYear()
+  const m = pad(date.getMonth() + 1)
+  const d = pad(date.getDate())
+  const time = edge === 'start' ? '00:00:01' : '23:59:00'
+  // URL-encode the space between date and time as '+'.
+  return encodeURIComponent(`${y}-${m}-${d} ${time}`).replace(/%20/g, '+')
+}
+
+export class SessionExpiredError extends Error {
+  constructor () {
+    super('Cifra Bank session expired')
+  }
+}

--- a/src/plugins/cifrabank-ru/index.ts
+++ b/src/plugins/cifrabank-ru/index.ts
@@ -1,37 +1,23 @@
 import { Account, ScrapeFunc, Transaction } from '../../types/zenmoney'
-import { fetchAccounts, fetchTransactions, login } from './api'
-import { fetchJson } from '../../common/network'
+import { fetchAccounts, fetchRelatedCards, fetchTransactions, generateDeviceId, login } from './api'
 import { buildCardNumberMap, convertAccounts, convertOperation } from './converters'
 import { Auth, Preferences } from './models'
-
-const CARDS_URL = 'https://mo.ffinpay.ru/ncs-mobile/rest/v1/cards/related'
-
-async function fetchCards (token: string): Promise<unknown[]> {
-  const response = await fetchJson(CARDS_URL, {
-    method: 'GET',
-    headers: {
-      Accept: 'application/json, text/plain, */*',
-      'User-Agent': 'okhttp/5.3.2',
-      Authorization: `Bearer ${token}`
-    }
-  })
-  if (response.status !== 200) {
-    return []
-  }
-  return Array.isArray(response.body) ? response.body : []
-}
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
   const effectiveToDate = toDate ?? new Date()
 
   const storedAuth = ZenMoney.getData('auth') as Auth | undefined
-  const session = await login(preferences, storedAuth)
-  ZenMoney.setData('auth', { refresh: session.refresh })
+  const auth: Auth = {
+    deviceId: storedAuth?.deviceId ?? generateDeviceId(),
+    refresh: storedAuth?.refresh
+  }
+  const session = await login(preferences, auth)
+  ZenMoney.setData('auth', { deviceId: auth.deviceId, refresh: session.refresh })
   ZenMoney.saveData()
 
   const [apiAccounts, apiCards] = await Promise.all([
-    fetchAccounts(session),
-    fetchCards(session.token)
+    fetchAccounts(session, auth.deviceId),
+    fetchRelatedCards(session, auth.deviceId)
   ])
   const cardNumberMap = buildCardNumberMap(apiCards)
   const convertedAccounts = convertAccounts(apiAccounts, cardNumberMap)
@@ -45,7 +31,7 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
     }
     const seenIds = new Set<string>()
     await Promise.all(products.map(async product => {
-      const apiOperations = await fetchTransactions(session, product, fromDate, effectiveToDate)
+      const apiOperations = await fetchTransactions(session, auth.deviceId, product, fromDate, effectiveToDate)
       for (const apiOperation of apiOperations) {
         const transaction = convertOperation(apiOperation, account.id)
         if (transaction == null) {

--- a/src/plugins/cifrabank-ru/index.ts
+++ b/src/plugins/cifrabank-ru/index.ts
@@ -1,0 +1,67 @@
+import { Account, ScrapeFunc, Transaction } from '../../types/zenmoney'
+import { fetchAccounts, fetchTransactions, login } from './api'
+import { fetchJson } from '../../common/network'
+import { buildCardNumberMap, convertAccounts, convertOperation } from './converters'
+import { Auth, Preferences } from './models'
+
+const CARDS_URL = 'https://mo.ffinpay.ru/ncs-mobile/rest/v1/cards/related'
+
+async function fetchCards (token: string): Promise<unknown[]> {
+  const response = await fetchJson(CARDS_URL, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json, text/plain, */*',
+      'User-Agent': 'okhttp/5.3.2',
+      Authorization: `Bearer ${token}`
+    }
+  })
+  if (response.status !== 200) {
+    return []
+  }
+  return Array.isArray(response.body) ? response.body : []
+}
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  const effectiveToDate = toDate ?? new Date()
+
+  const storedAuth = ZenMoney.getData('auth') as Auth | undefined
+  const session = await login(preferences, storedAuth)
+  ZenMoney.setData('auth', { refresh: session.refresh })
+  ZenMoney.saveData()
+
+  const [apiAccounts, apiCards] = await Promise.all([
+    fetchAccounts(session),
+    fetchCards(session.token)
+  ])
+  const cardNumberMap = buildCardNumberMap(apiCards)
+  const convertedAccounts = convertAccounts(apiAccounts, cardNumberMap)
+
+  const accounts: Account[] = []
+  const transactions: Transaction[] = []
+  await Promise.all(convertedAccounts.map(async ({ account, products }) => {
+    accounts.push(account)
+    if (ZenMoney.isAccountSkipped(account.id)) {
+      return
+    }
+    const seenIds = new Set<string>()
+    await Promise.all(products.map(async product => {
+      const apiOperations = await fetchTransactions(session, product, fromDate, effectiveToDate)
+      for (const apiOperation of apiOperations) {
+        const transaction = convertOperation(apiOperation, account.id)
+        if (transaction == null) {
+          continue
+        }
+        const dedupKey = transaction.movements[0]?.id
+        if (dedupKey != null) {
+          if (seenIds.has(dedupKey)) {
+            continue
+          }
+          seenIds.add(dedupKey)
+        }
+        transactions.push(transaction)
+      }
+    }))
+  }))
+
+  return { accounts, transactions }
+}

--- a/src/plugins/cifrabank-ru/models.ts
+++ b/src/plugins/cifrabank-ru/models.ts
@@ -1,15 +1,19 @@
 import { AccountOrCard } from '../../types/zenmoney'
 
-// Persisted between syncs (currently unused — bank refresh-token requires
-// device-bound material that we cannot reproduce, so we re-auth via SMS each sync).
+// Persisted between syncs.
 export interface Auth {
+  // Stable per-install device id sent in the `getuniqueid` header on every request.
+  deviceId: string
+  // Long-lived refresh JWT (~6 months). Used to obtain a fresh access token
+  // without re-running the SMS login flow.
   refresh?: string
 }
 
-// Active session, populated on each sync
+// Active session, populated on each sync.
 export interface Session {
   token: string
   refresh: string
+  // Epoch seconds when the access token expires (taken from JWT `exp`).
   expiresAt: number
 }
 
@@ -20,7 +24,7 @@ export interface Preferences {
 }
 
 export interface Product {
-  // numeric account id used by the operations endpoints
+  // Numeric account id used by the operations endpoints.
   id: number
   // Cifra Bank's subtype: CARD / CURRENT / etc. Selects the operations endpoint.
   subtype: string

--- a/src/plugins/cifrabank-ru/models.ts
+++ b/src/plugins/cifrabank-ru/models.ts
@@ -1,0 +1,32 @@
+import { AccountOrCard } from '../../types/zenmoney'
+
+// Persisted between syncs (currently unused — bank refresh-token requires
+// device-bound material that we cannot reproduce, so we re-auth via SMS each sync).
+export interface Auth {
+  refresh?: string
+}
+
+// Active session, populated on each sync
+export interface Session {
+  token: string
+  refresh: string
+  expiresAt: number
+}
+
+export interface Preferences {
+  phone: string
+  cardNumber: string
+  startDate: string
+}
+
+export interface Product {
+  // numeric account id used by the operations endpoints
+  id: number
+  // Cifra Bank's subtype: CARD / CURRENT / etc. Selects the operations endpoint.
+  subtype: string
+}
+
+export interface ConvertedAccount {
+  account: AccountOrCard
+  products: Product[]
+}

--- a/src/plugins/cifrabank-ru/preferences.xml
+++ b/src/plugins/cifrabank-ru/preferences.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="phone"
+        obligatory="true"
+        inputType="phone"
+        title="Номер телефона"
+        dialogTitle="Номер телефона"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|+7XXXXXXXXXX|{@s}"
+    />
+    <EditTextPreference
+        key="cardNumber"
+        obligatory="true"
+        inputType="number"
+        title="Номер карты"
+        dialogTitle="Номер карты"
+        dialogMessage="Полный номер банковской карты Цифра Банка (16 цифр без пробелов). Используется как ответ на проверочный вопрос при входе."
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||***********"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2024-01-01T00:00:00.000Z"
+        dialogTitle="С какой даты загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|гггг-мм-дд|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
## Summary
- New plugin `cifrabank-ru` that syncs accounts and operations from Цифра Банк (Russia) via the mobile API used by `com.bankffin.portfolio`.
- Auth: SMS login (`/ncs-mobile/rest/v2/auth/pass-request` + `/ncs-mobile/rest/v3/auth/logon-request`), then `GET /ncs-mobile/rest/v2/auth/refresh-token` to skip the SMS step on subsequent syncs. A stable per-install `deviceId` is generated on first run and persisted alongside the refresh token.
- Accounts list comes from `GET mo.ffinpay.ru/ncs-mobile/rest/v1/accounts` (plus `/cards/related` to enrich CARD accounts with the masked card number used as a syncId). Card sub-accounts use `/card/sca-operations/`, current accounts use `/accounts/statement/`. Numeric ISO-4217 currency codes (810/840/978) are mapped via the existing `codeToCurrencyLookup`.

## Test plan
- [x] `tsc --noEmit`, `ts-standard`, `jest src/plugins/cifrabank-ru` all green
- [x] Converter tests cover MULTI_CARD with 3 currency sub-accounts + CURRENT account, plus EXPENSE/INCOME operations on RUB/USD with numeric currency codes
- [x] End-to-end smoke test against the live API on a real account: SMS login → accounts + cards loaded → card and current-account operations synced