### PR TITLE
[etherscan] Fix pagination for accounts with many transactions

### DIFF
--- a/src/plugins/etherscan/__tests__/converters/append-transactions.test.ts
+++ b/src/plugins/etherscan/__tests__/converters/append-transactions.test.ts
@@ -1,0 +1,37 @@
+import { appendTransactions } from '../../common/converters'
+import type { Transaction } from '../../../../types/zenmoney'
+
+const transaction: Transaction = {
+  hold: null,
+  date: new Date('2026-01-01T00:00:00.000Z'),
+  movements: [{
+    id: '1',
+    account: { id: 'account' },
+    invoice: null,
+    sum: 1,
+    fee: 0
+  }],
+  merchant: null,
+  comment: null
+}
+
+describe('appendTransactions', () => {
+  it('appends large transaction batches without argument spreading', () => {
+    const target: Transaction[] = []
+    const transactions: Transaction[] = Array.from(
+      { length: 200000 },
+      (_, index): Transaction => ({
+        ...transaction,
+        movements: [{
+          ...transaction.movements[0],
+          id: String(index)
+        }]
+      })
+    )
+
+    appendTransactions(target, transactions)
+
+    expect(target).toHaveLength(transactions.length)
+    expect(target[199999].movements[0].id).toBe('199999')
+  })
+})

--- a/src/plugins/etherscan/__tests__/converters/token-transactions.test.ts
+++ b/src/plugins/etherscan/__tests__/converters/token-transactions.test.ts
@@ -12,6 +12,7 @@ const baseTransaction: TokenTransaction = {
   blockNumber: '1',
   timeStamp: '1658608646',
   hash: '0x90bb0dcbe8fa38387145aa17d6ad99f57da91d4c6d4b65b5f7cf56454f73234b',
+  logIndex: '1',
   nonce: '1',
   blockHash: '0x1',
   from: '0x1111111111111111111111111111111111111111',

--- a/src/plugins/etherscan/__tests__/converters/transaction/transaction.test.ts
+++ b/src/plugins/etherscan/__tests__/converters/transaction/transaction.test.ts
@@ -3,6 +3,7 @@ import { EthereumTransaction } from '../../../ether/types'
 
 const OWN_ACCOUNT = 'ACCOUNT_ID'
 const baseMock: EthereumTransaction = {
+  blockNumber: '1',
   timeStamp: '1658608646',
   hash: '0x90bb0dcbe8fa38387145aa17d6ad99f57da91d4c6d4b65b5f7cf56454f73234b',
   from: '1',

--- a/src/plugins/etherscan/common/converters.ts
+++ b/src/plugins/etherscan/common/converters.ts
@@ -1,5 +1,14 @@
 import { Transaction } from '../../../types/zenmoney'
 
+export function appendTransactions (
+  target: Transaction[],
+  transactions: Transaction[]
+): void {
+  for (const transaction of transactions) {
+    target.push(transaction)
+  }
+}
+
 function canBeMergedAsTransfer (left: Transaction, right: Transaction): boolean {
   const leftMovement = left.movements[0]
   const rightMovement = right.movements[0]

--- a/src/plugins/etherscan/common/pagination.test.ts
+++ b/src/plugins/etherscan/common/pagination.test.ts
@@ -1,0 +1,179 @@
+import {
+  type BlockTransaction,
+  type FetchPageOptions,
+  fetchPaginatedTransactions
+} from './pagination'
+
+interface TestTransaction extends BlockTransaction {
+  id: string
+}
+
+function buildTransactions (
+  count: number,
+  blockNumber: number,
+  idPrefix: string
+): TestTransaction[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `${idPrefix}-${index}`,
+    blockNumber: String(blockNumber)
+  }))
+}
+
+describe('fetchPaginatedTransactions', () => {
+  it('uses page only inside the result window and then advances endBlock', async () => {
+    const requests: FetchPageOptions[] = []
+
+    await fetchPaginatedTransactions<TestTransaction>({
+      startBlock: 1,
+      endBlock: 100,
+      getKey: (transaction) => transaction.id,
+      fetchPage: async (options) => {
+        requests.push(options)
+
+        if (options.endBlock === 100) {
+          return buildTransactions(
+            1000,
+            options.page === 10 ? 90 : 100,
+            `cursor-100-page-${options.page}`
+          )
+        }
+
+        return buildTransactions(1, 80, 'cursor-90-page-1')
+      }
+    })
+
+    expect(requests).toHaveLength(11)
+    expect(requests[9]).toEqual({
+      startBlock: 1,
+      endBlock: 100,
+      page: 10,
+      offset: 1000
+    })
+    expect(requests[10]).toEqual({
+      startBlock: 1,
+      endBlock: 90,
+      page: 1,
+      offset: 1000
+    })
+  })
+
+  it('deduplicates transactions from the overlapped cursor block', async () => {
+    const transactions = await fetchPaginatedTransactions<TestTransaction>({
+      startBlock: 1,
+      endBlock: 100,
+      getKey: (transaction) => transaction.id,
+      fetchPage: async (options) => {
+        if (options.endBlock === 100) {
+          const pageTransactions = buildTransactions(
+            1000,
+            options.page === 10 ? 90 : 100,
+            `cursor-100-page-${options.page}`
+          )
+
+          if (options.page === 10) {
+            pageTransactions[999] = {
+              id: 'overlap',
+              blockNumber: '90'
+            }
+          }
+
+          return pageTransactions
+        }
+
+        return [
+          {
+            id: 'overlap',
+            blockNumber: '90'
+          },
+          {
+            id: 'new',
+            blockNumber: '80'
+          }
+        ]
+      }
+    })
+
+    expect(transactions.filter((transaction) => transaction.id === 'overlap')).toHaveLength(1)
+    expect(transactions.some((transaction) => transaction.id === 'new')).toBe(true)
+  })
+
+  it('fails when a single cursor block fills the whole result window', async () => {
+    await expect(fetchPaginatedTransactions<TestTransaction>({
+      startBlock: 1,
+      endBlock: 100,
+      getKey: (transaction) => transaction.id,
+      fetchPage: async (options) => buildTransactions(
+        1000,
+        100,
+        `page-${options.page}`
+      )
+    })).rejects.toThrow('Cannot safely progress')
+  })
+
+  it('advances the cursor after a result-window error when a safe last block exists', async () => {
+    const requests: FetchPageOptions[] = []
+
+    await fetchPaginatedTransactions<TestTransaction>({
+      startBlock: 1,
+      endBlock: 100,
+      getKey: (transaction) => transaction.id,
+      fetchPage: async (options) => {
+        requests.push(options)
+
+        if (options.endBlock === 100) {
+          if (options.page === 10) {
+            throw new Error(
+              'Result window is too large, PageNo x Offset size must be less than or equal to 10000'
+            )
+          }
+
+          return buildTransactions(
+            1000,
+            options.page === 9 ? 90 : 100,
+            `cursor-100-page-${options.page}`
+          )
+        }
+
+        return buildTransactions(1, 80, 'cursor-90-page-1')
+      }
+    })
+
+    expect(requests[9]).toEqual({
+      startBlock: 1,
+      endBlock: 100,
+      page: 10,
+      offset: 1000
+    })
+    expect(requests[10]).toEqual({
+      startBlock: 1,
+      endBlock: 90,
+      page: 1,
+      offset: 1000
+    })
+  })
+
+  it('fails with a clear error when a pagination error happens before any cursor exists', async () => {
+    await expect(fetchPaginatedTransactions<TestTransaction>({
+      startBlock: 1,
+      endBlock: 100,
+      getKey: (transaction) => transaction.id,
+      fetchPage: async () => {
+        throw new Error('Query Timeout occured')
+      }
+    })).rejects.toThrow(
+      'Cannot safely progress after Etherscan pagination error for block range 1..100'
+    )
+  })
+
+  it('fails on invalid block numbers', async () => {
+    await expect(fetchPaginatedTransactions<TestTransaction>({
+      startBlock: 1,
+      endBlock: 100,
+      getKey: (transaction) => transaction.id,
+      fetchPage: async () => [{
+        id: 'invalid',
+        blockNumber: 'invalid'
+      }]
+    })).rejects.toThrow('Invalid blockNumber')
+  })
+})

--- a/src/plugins/etherscan/common/pagination.ts
+++ b/src/plugins/etherscan/common/pagination.ts
@@ -1,0 +1,130 @@
+const PAGE_SIZE = 1000
+const RESULT_WINDOW_LIMIT = 10000
+const MAX_PAGES = RESULT_WINDOW_LIMIT / PAGE_SIZE
+const RESULT_WINDOW_ERROR_PATTERN = /result window is too large|pageno\s*x\s*offset/i
+const QUERY_TIMEOUT_ERROR_PATTERN = /query timeout/i
+
+export interface BlockTransaction {
+  blockNumber: string
+}
+
+export interface FetchPageOptions {
+  startBlock: number
+  endBlock: number
+  page: number
+  offset: number
+}
+
+interface FetchPaginatedTransactionsOptions<TTransaction extends BlockTransaction> {
+  startBlock: number
+  endBlock: number
+  fetchPage: (options: FetchPageOptions) => Promise<TTransaction[]>
+  getKey: (transaction: TTransaction) => string
+}
+
+function parseBlockNumber (transaction: BlockTransaction): number {
+  const blockNumber = Number(transaction.blockNumber)
+
+  if (!Number.isSafeInteger(blockNumber)) {
+    throw new Error(`Invalid blockNumber from API: ${transaction.blockNumber}`)
+  }
+
+  return blockNumber
+}
+
+function getErrorMessage (error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  return String(error)
+}
+
+function isRecoverableCursorError (error: unknown): boolean {
+  const message = getErrorMessage(error)
+
+  return RESULT_WINDOW_ERROR_PATTERN.test(message) ||
+    QUERY_TIMEOUT_ERROR_PATTERN.test(message)
+}
+
+export async function fetchPaginatedTransactions<TTransaction extends BlockTransaction> ({
+  startBlock,
+  endBlock,
+  fetchPage,
+  getKey
+}: FetchPaginatedTransactionsOptions<TTransaction>): Promise<TTransaction[]> {
+  let cursor = endBlock
+  const transactions: TTransaction[] = []
+  const seen = new Set<string>()
+
+  while (cursor >= startBlock) {
+    let lastBlock: number | null = null
+    let exhausted = false
+
+    for (let page = 1; page <= MAX_PAGES; page++) {
+      let pageTransactions: TTransaction[]
+
+      try {
+        pageTransactions = await fetchPage({
+          startBlock,
+          endBlock: cursor,
+          page,
+          offset: PAGE_SIZE
+        })
+      } catch (error) {
+        if (!isRecoverableCursorError(error)) {
+          throw error
+        }
+
+        if (lastBlock === null) {
+          throw new Error(
+            'Cannot safely progress after Etherscan pagination error for ' +
+            `block range ${startBlock}..${cursor}: ${getErrorMessage(error)}`
+          )
+        }
+
+        break
+      }
+
+      if (pageTransactions.length === 0) {
+        exhausted = true
+        break
+      }
+
+      for (const transaction of pageTransactions) {
+        const key = getKey(transaction)
+
+        if (!seen.has(key)) {
+          seen.add(key)
+          transactions.push(transaction)
+        }
+      }
+
+      lastBlock = parseBlockNumber(pageTransactions[pageTransactions.length - 1])
+
+      if (pageTransactions.length < PAGE_SIZE) {
+        exhausted = true
+        break
+      }
+    }
+
+    if (exhausted || lastBlock === null) {
+      break
+    }
+
+    if (lastBlock > cursor) {
+      throw new Error('API returned rows in non-monotonic block order')
+    }
+
+    if (lastBlock === cursor) {
+      throw new Error(
+        `Cannot safely progress: block ${cursor} alone fills the ` +
+        `${RESULT_WINDOW_LIMIT} result window`
+      )
+    }
+
+    cursor = lastBlock
+  }
+
+  return transactions
+}

--- a/src/plugins/etherscan/ether/api.ts
+++ b/src/plugins/etherscan/ether/api.ts
@@ -1,5 +1,6 @@
 import { fetch } from '../common'
 import { Preferences } from '../types'
+import { fetchPaginatedTransactions } from '../common/pagination'
 import {
   AccountResponse,
   EthereumAccount,
@@ -26,50 +27,37 @@ interface AccountTransactionsOptions {
   account: string
   startBlock: number
   endBlock: number
-  page?: number
 }
-
-const PAGE_SIZE = 100
 
 export async function fetchAccountTransactions (
   preferences: Preferences,
   options: AccountTransactionsOptions
 ): Promise<EthereumTransaction[]> {
-  const { account, startBlock, endBlock, page = 1 } = options
+  const { account, startBlock, endBlock } = options
 
-  try {
-    const response = await fetch<TransactionResponse>({
-      chainid: preferences.chain,
-      module: 'account',
-      action: 'txlist',
-      address: account,
-      startblock: startBlock,
-      endblock: endBlock,
-      page,
-      offset: PAGE_SIZE,
-      sort: 'desc',
-      apikey: preferences.apiKey
-    })
+  return await fetchPaginatedTransactions({
+    startBlock,
+    endBlock,
+    getKey: (transaction) => transaction.hash,
+    fetchPage: async ({ startBlock, endBlock, page, offset }) => {
+      const response = await fetch<TransactionResponse>({
+        chainid: preferences.chain,
+        module: 'account',
+        action: 'txlist',
+        address: account,
+        startblock: startBlock,
+        endblock: endBlock,
+        page,
+        offset,
+        sort: 'desc',
+        apikey: preferences.apiKey
+      })
 
-    const transactions = response.result
+      if (!Array.isArray(response.result)) {
+        return []
+      }
 
-    if (response.result.length === PAGE_SIZE) {
-      return [
-        ...transactions,
-        ...(await fetchAccountTransactions(preferences, {
-          ...options,
-          page: page + 1
-        }))
-      ]
+      return response.result
     }
-
-    return transactions
-  } catch (error: any) {
-    // eslint-disable-line
-    if (error?.body?.message === 'No transactions found') {
-      return []
-    }
-
-    throw error
-  }
+  })
 }

--- a/src/plugins/etherscan/ether/index.ts
+++ b/src/plugins/etherscan/ether/index.ts
@@ -1,7 +1,7 @@
 import { Account, Transaction } from '../../../types/zenmoney'
 import { Scrape } from '../types'
 import { fetchAccounts, fetchAccountTransactions } from './api'
-import { mergeTransferTransactions } from '../common/converters'
+import { appendTransactions, mergeTransferTransactions } from '../common/converters'
 import { convertAccounts, convertTransactions } from './converters'
 import { Instruments } from '../common/config'
 
@@ -20,7 +20,10 @@ export const scrape: Scrape = async ({ preferences, startBlock, endBlock }) => {
       endBlock
     })
 
-    transactions.push(...convertTransactions(account.id, accountTransactions))
+    appendTransactions(
+      transactions,
+      convertTransactions(account.id, accountTransactions)
+    )
   }
 
   return {

--- a/src/plugins/etherscan/ether/types.ts
+++ b/src/plugins/etherscan/ether/types.ts
@@ -18,6 +18,7 @@ export interface EthereumAccount {
 }
 
 export interface EthereumTransaction {
+  blockNumber: string
   gasUsed: string
   hash: string
   from: string
@@ -28,7 +29,6 @@ export interface EthereumTransaction {
   timeStamp: string
 
   // Exists in API, but not used now. Keep for possible future updates
-  // blockNumber: string
   // nonce: string
   // blockHash: string
   // transactionIndex: string

--- a/src/plugins/etherscan/mocks/index.ts
+++ b/src/plugins/etherscan/mocks/index.ts
@@ -48,6 +48,7 @@ export const transactionsResponseMock1: TransactionResponse = {
   message: 'OK',
   result: [
     {
+      blockNumber: '1',
       hash: '1',
       from: '1',
       to: 'OTHER_ACCOUNT',
@@ -58,6 +59,7 @@ export const transactionsResponseMock1: TransactionResponse = {
       gasUsed: '21000'
     },
     {
+      blockNumber: '1',
       hash: '2',
       from: 'OTHER_ACCOUNT',
       to: '1',
@@ -68,6 +70,7 @@ export const transactionsResponseMock1: TransactionResponse = {
       gasUsed: '21000'
     },
     {
+      blockNumber: '1',
       hash: '3',
       from: '1',
       to: '2',
@@ -85,6 +88,7 @@ export const transactionsResponseMock2: TransactionResponse = {
   message: 'OK',
   result: [
     {
+      blockNumber: '1',
       hash: '3',
       from: '1',
       to: '2',
@@ -224,21 +228,21 @@ export function mockEndPoints (): void {
     }
   )
   fetchMock.once(
-    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=1&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY',
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=1&startblock=1&endblock=99999999&page=1&offset=1000&sort=desc&apikey=API_KEY',
     {
       status: 200,
       body: transactionsResponseMock1
     }
   )
   fetchMock.once(
-    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY',
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=1000&sort=desc&apikey=API_KEY',
     {
       status: 200,
       body: transactionsResponseMock2
     }
   )
   fetchMock.once(
-    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=3&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY',
+    'https://api.etherscan.io/v2/api?chainid=1&module=account&action=txlist&address=3&startblock=1&endblock=99999999&page=1&offset=1000&sort=desc&apikey=API_KEY',
     {
       status: 200,
       body: transactionsResponseMock3

--- a/src/plugins/etherscan/tokens/erc20.ts
+++ b/src/plugins/etherscan/tokens/erc20.ts
@@ -1,5 +1,6 @@
 import flatten from 'lodash/flatten'
 import { fetch } from '../common'
+import { fetchPaginatedTransactions } from '../common/pagination'
 import { type Preferences } from '../types'
 
 import {
@@ -59,12 +60,9 @@ export async function fetchAccounts (
   return flatten(result)
 }
 
-const PAGE_SIZE = 100
-
 interface AccountTransactionsOptions {
   startBlock: number
   endBlock: number
-  page?: number
 }
 
 export async function fetchAccountTransactions (
@@ -72,42 +70,32 @@ export async function fetchAccountTransactions (
   account: TokenAccount,
   options: AccountTransactionsOptions
 ): Promise<TokenTransaction[]> {
-  const { startBlock, endBlock, page = 1 } = options
+  const { startBlock, endBlock } = options
 
-  try {
-    const response = await fetch<TokenTransactionResponse>({
-      chainid: preferences.chain,
-      module: 'account',
-      action: 'tokentx',
-      contractaddress: account.contractAddress,
-      address: account.id,
-      startblock: startBlock,
-      endblock: endBlock,
-      page,
-      offset: PAGE_SIZE,
-      sort: 'desc',
-      apikey: preferences.apiKey
-    })
+  return await fetchPaginatedTransactions({
+    startBlock,
+    endBlock,
+    getKey: (transaction) => `${transaction.hash}:${transaction.logIndex}`,
+    fetchPage: async ({ startBlock, endBlock, page, offset }) => {
+      const response = await fetch<TokenTransactionResponse>({
+        chainid: preferences.chain,
+        module: 'account',
+        action: 'tokentx',
+        contractaddress: account.contractAddress,
+        address: account.id,
+        startblock: startBlock,
+        endblock: endBlock,
+        page,
+        offset,
+        sort: 'desc',
+        apikey: preferences.apiKey
+      })
 
-    const transactions = response.result
+      if (!Array.isArray(response.result)) {
+        return []
+      }
 
-    if (response.result.length === PAGE_SIZE) {
-      return [
-        ...transactions,
-        ...(await fetchAccountTransactions(preferences, account, {
-          ...options,
-          page: page + 1
-        }))
-      ]
+      return response.result
     }
-
-    return transactions
-  } catch (error: any) {
-    // eslint-disable-line
-    if (error?.body?.message === 'No transactions found') {
-      return []
-    }
-
-    throw error
-  }
+  })
 }

--- a/src/plugins/etherscan/tokens/index.ts
+++ b/src/plugins/etherscan/tokens/index.ts
@@ -1,5 +1,5 @@
 import { Transaction } from '../../../types/zenmoney'
-import { mergeTransferTransactions } from '../common/converters'
+import { appendTransactions, mergeTransferTransactions } from '../common/converters'
 import { Scrape } from '../types'
 
 import { convertAccounts, convertTransactions } from './converters'
@@ -19,8 +19,9 @@ export const scrape: Scrape = async ({ preferences, startBlock, endBlock }) => {
       }
     )
 
-    transactions.push(
-      ...convertTransactions(account, accountTransactions, preferences.chain)
+    appendTransactions(
+      transactions,
+      convertTransactions(account, accountTransactions, preferences.chain)
     )
   }
 

--- a/src/plugins/etherscan/tokens/types.ts
+++ b/src/plugins/etherscan/tokens/types.ts
@@ -8,6 +8,7 @@ export interface TokenTransaction {
   blockNumber: string
   timeStamp: string
   hash: string
+  logIndex: string
   nonce: string
   blockHash: string
   from: string


### PR DESCRIPTION
Etherscan is reducing the free-tier maximum records per request to 1000, so the plugin should use offset=1000 while respecting the separate empirical result-window limit where page x offset must stay at or below 10000.

Larger pages reduce the number of API calls needed for large accounts, which speeds up loading and helps stay within free-plan request limits.

Reference: https://docs.etherscan.io/changelog#upcoming-change-reduced-maximum-records-per-request-on-the-free-api-tier

With offset=1000, page 10 is the last safe page. The previous implementation used page as a global cursor, so accounts with many transactions could eventually request page 11 and fail with the Etherscan result-window error. Dense ranges also risked missing rows if pagination advanced with lastBlock - 1 because the final page can end in the middle of a block.

Add a shared block-cursor paginator for Etherscan txlist and tokentx requests. It reads pages 1 through 10 inside each cursor window, advances endblock to the last seen block with overlap, deduplicates locally by endpoint-specific keys, validates blockNumber before cursoring, and surfaces clear errors when safe progress is impossible. It also treats known result-window and query-timeout errors as cursor-window exhaustion when a safe last block has already been observed.

Fix a separate stack overflow found during a two-year range scrape by replacing large-array spread appends with a stack-safe appendTransactions helper. This avoids transactions.push(...largeArray), which can throw RangeError: Maximum call stack size exceeded for large converted transaction batches, especially under the ZenPlugins dev Promise mock that resolves callbacks synchronously.

Add regression coverage for cursor pagination, defensive Etherscan error handling, malformed block numbers, token dedupe keys, and large transaction batch appending.