### PR TITLE
[mtbank] Prefer personal DBO contract

### DIFF
--- a/src/plugins/mtbank/__tests__/api.test.js
+++ b/src/plugins/mtbank/__tests__/api.test.js
@@ -1,4 +1,4 @@
-import { createDateIntervals } from '../api'
+import { createDateIntervals, selectDboContract } from '../api'
 
 describe('createDateIntervals', () => {
   it('should convert date period', () => {
@@ -10,5 +10,34 @@ describe('createDateIntervals', () => {
         [new Date('2018-01-21T20:45:00+03:00'), new Date('2018-02-05T09:00:00.000+03:00')]
       ]
     )
+  })
+})
+
+describe('selectDboContract', () => {
+  it('prefers a registered personal contract over the first contract', () => {
+    const businessContract = {
+      contractNum: 'IB_B/123456',
+      status: 'REGISTERED',
+      role: 'B',
+      name: 'Company'
+    }
+    const personalContract = {
+      contractNum: 'IB_I/654321',
+      status: 'REGISTERED',
+      role: 'F',
+      name: 'User'
+    }
+
+    expect(selectDboContract([businessContract, personalContract])).toBe(personalContract)
+  })
+
+  it('keeps the previous fallback when no personal contract exists', () => {
+    const businessContract = {
+      contractNum: 'IB_B/123456',
+      status: 'REGISTERED',
+      role: 'B'
+    }
+
+    expect(selectDboContract([businessContract])).toBe(businessContract)
   })
 })

--- a/src/plugins/mtbank/api.js
+++ b/src/plugins/mtbank/api.js
@@ -128,6 +128,15 @@ async function fetchApiJsonWithSessionCookies (sessionCookies, url, options, pre
   return response
 }
 
+export function selectDboContract (contracts = []) {
+  const registeredContracts = contracts.filter(contract => contract.status === 'REGISTERED')
+
+  return registeredContracts.find(contract => contract.role === 'F') ||
+    contracts.find(contract => contract.role === 'F') ||
+    registeredContracts[0] ||
+    contracts[0]
+}
+
 export async function login (login, password) {
   const cookies = new Map()
 
@@ -184,7 +193,7 @@ export async function login (login, password) {
     'user/userRole',
     {
       method: 'POST',
-      body: res.body.data.userInfo.dboContracts[0],
+      body: selectDboContract(res.body.data.userInfo.dboContracts),
       sanitizeRequestLog: { body: true }
     },
     (response) => response.body.success,


### PR DESCRIPTION
# [mtbank] Prefer personal DBO contract when user has business and personal contracts

## Problem

MTBank users can have multiple `dboContracts` after `login/checkPassword4`, for example a business contract and a personal contract in the same bank account flow.

The current plugin always passes the first contract to `user/userRole`:

```js
body: res.body.data.userInfo.dboContracts[0]
```

If MTBank returns a business/legal-entity contract first, the session is switched to that contract context. The following `user/loadUser` call then returns products for the business context, while personal cards/accounts are not shown in ZenMoney.

## Fix

Select a personal contract first, using the existing `role: 'F'` value seen in MTBank test fixtures. Keep the previous behavior as a fallback when no personal contract is present:

1. Prefer registered personal contract: `status === 'REGISTERED' && role === 'F'`
2. Fallback to any personal contract: `role === 'F'`
3. Fallback to first registered contract
4. Fallback to first contract

## Tests

Added tests for:

- business contract first, personal contract second: personal contract is selected
- no personal contract: previous first-contract fallback is preserved

Verified locally:

```text
yarn jest mtbank
Test Suites: 6 passed, 6 total
Tests: 34 passed, 34 total

yarn lint src/plugins/mtbank/api.js src/plugins/mtbank/__tests__/api.test.js
Done
```

## User impact

This should fix the case where ZenMoney connects to MTBank but shows only the legal-entity/business context instead of personal cards/accounts.
