### PR TITLE
[sberbank-by]: Восстановить вход через новый OAuth Сбербанк BY

### DIFF
--- a/src/XMLHttpRequestViaZenAPI.js
+++ b/src/XMLHttpRequestViaZenAPI.js
@@ -91,8 +91,10 @@ function onResponse (err, responseBody, isBinaryBody) {
   }
 
   this.responseURL = ZenMoney.getLastUrl()
-  this.status = ZenMoney.getLastStatusCode();
-  [, this.statusText] = ZenMoney.getLastStatusString().match(/^HTTP\/1.1 \d+ (.*)$/)
+  this.status = ZenMoney.getLastStatusCode()
+  const statusString = ZenMoney.getLastStatusString() || ''
+  const statusMatch = statusString.match(/^HTTP\/\d(?:\.\d)?\s+\d+\s*(.*)$/)
+  this.statusText = statusMatch ? statusMatch[1] : ''
   const zenResponseHeaders = ZenMoney.getLastResponseHeaders()
   const xhrResponseHeaders = zenResponseHeaders
     .map(([key, value]) => `${key}: ${value}`)

--- a/src/plugins/sberbank-by/__tests__/api/fetchTransactions.test.js
+++ b/src/plugins/sberbank-by/__tests__/api/fetchTransactions.test.js
@@ -46,7 +46,7 @@ describe('fetchTransactions', () => {
 
     expect(transactions).toEqual(events)
     expect(fetchJson).toHaveBeenCalledTimes(1)
-    expect(fetchJson.mock.calls[0][0]).toBe('https://www.sber-bank.by/SBOLServer/rest/client/events')
+    expect(fetchJson.mock.calls[0][0]).toBe('https://digital.sber-bank.by/SBOLServer/rest/client/events')
     expect(fetchJson.mock.calls[0][1].body).toEqual({
       contractNumber,
       endDate: '2026-06-10',

--- a/src/plugins/sberbank-by/__tests__/api/login.test.js
+++ b/src/plugins/sberbank-by/__tests__/api/login.test.js
@@ -1,0 +1,124 @@
+jest.mock('../../../../common/network', () => ({
+  fetch: jest.fn()
+}))
+
+const { fetch } = require('../../../../common/network')
+const { login } = require('../../api')
+
+function mockOAuthFlow ({ loginLocation = '/api/sbol-auth/v1/oauth2/authorize?continue=true' } = {}) {
+  fetch
+    .mockResolvedValueOnce({
+      status: 200,
+      headers: {
+        'set-cookie': 'session-cookie=authorize-cookie; Max-Age=86400; Path=/; secure; HttpOnly'
+      },
+      body: '{"errorCode":"sbol.auth.unauthenticated.error"}'
+    })
+    .mockResolvedValueOnce({
+      status: 302,
+      headers: {
+        location: loginLocation,
+        'set-cookie': 'login-cookie=login-cookie; Max-Age=86400; Path=/; secure; HttpOnly'
+      },
+      body: ''
+    })
+    .mockResolvedValueOnce({
+      status: 302,
+      headers: {
+        location: 'https://digital.sber-bank.by/loginsbol?code=authorization-code'
+      },
+      body: ''
+    })
+    .mockResolvedValueOnce({
+      status: 200,
+      headers: {},
+      body: '{"access_token":"access-token","refresh_token":"refresh-token"}'
+    })
+}
+
+describe('login', () => {
+  beforeEach(() => {
+    fetch.mockReset()
+    global.ZenMoney = {
+      device: {
+        brand: 'test-brand',
+        manufacturer: 'test-manufacturer',
+        model: 'test-model',
+        osVersion: '14'
+      }
+    }
+  })
+
+  it('logs in through oauth2 authorization code flow', async () => {
+    mockOAuthFlow()
+
+    const device = {
+      androidId: 'android-id',
+      udid: 'udid'
+    }
+    const auth = await login({
+      login: 'test-login',
+      password: 'test-password'
+    }, device)
+
+    expect(auth).toEqual({
+      login: 'test-login',
+      password: 'test-password',
+      token: 'access-token',
+      refreshToken: 'refresh-token',
+      sessionId: expect.any(String),
+      device
+    })
+    expect(fetch).toHaveBeenCalledTimes(4)
+    expect(fetch.mock.calls[0][0]).toMatch(/^https:\/\/digital\.sber-bank\.by\/api\/sbol-auth\/v1\/oauth2\/authorize\?/)
+    expect(fetch.mock.calls[1][0]).toBe('https://digital.sber-bank.by/api/sbol-auth/v1/oauth2/login')
+    expect(fetch.mock.calls[1][1].headers.Cookie).toBe('session-cookie=authorize-cookie')
+    expect(fetch.mock.calls[1][1].body).toEqual({
+      username: 'test-login',
+      password: 'test-password'
+    })
+    expect(fetch.mock.calls[2][0]).toBe('https://digital.sber-bank.by/api/sbol-auth/v1/oauth2/authorize?continue=true')
+    expect(fetch.mock.calls[2][1].headers.Cookie).toBe('session-cookie=authorize-cookie; login-cookie=login-cookie')
+    expect(fetch.mock.calls[3][0]).toBe('https://digital.sber-bank.by/api/sbol-auth/v1/oauth2/token')
+    expect(fetch.mock.calls[3][1].body).toMatchObject({
+      grant_type: 'authorization_code',
+      code: 'authorization-code',
+      client_id: 'sbol-client'
+    })
+  })
+
+  it('maps internal bank oauth redirects to the public auth endpoint', async () => {
+    mockOAuthFlow({
+      loginLocation: 'https://sbol-auth.apps.k8s-prom1.belpsb.by/oauth2/authorize?continue=true'
+    })
+
+    await login({
+      login: 'test-login',
+      password: 'test-password'
+    }, {
+      androidId: 'android-id',
+      udid: 'udid'
+    })
+
+    expect(fetch.mock.calls[2][0]).toBe('https://digital.sber-bank.by/api/sbol-auth/v1/oauth2/authorize?continue=true')
+  })
+
+  it('continues internal bank root redirects through the public authorize endpoint', async () => {
+    mockOAuthFlow({
+      loginLocation: 'http://sbol-auth.apps.k8s-prom1.belpsb.by/'
+    })
+
+    await login({
+      login: 'test-login',
+      password: 'test-password'
+    }, {
+      androidId: 'android-id',
+      udid: 'udid'
+    })
+
+    expect(fetch.mock.calls[2][0]).toMatch(/^https:\/\/digital\.sber-bank\.by\/api\/sbol-auth\/v1\/oauth2\/authorize\?/)
+    expect(fetch.mock.calls[2][0]).toContain('continue=true')
+    expect(fetch.mock.calls[2][0]).toContain('response_type=code')
+    expect(fetch.mock.calls[2][0]).toContain('client_id=sbol-client')
+  })
+})

--- a/src/plugins/sberbank-by/__tests__/converters/transactions/convertTransactionsFunc.test.js
+++ b/src/plugins/sberbank-by/__tests__/converters/transactions/convertTransactionsFunc.test.js
@@ -521,4 +521,110 @@ describe('convertTransactions', () => {
       }
     ])
   })
+
+  it('merges online deposit top-up card outcome with target account income', () => {
+    const apiTransactions = [
+      {
+        sourceSystem: 8,
+        eventId: 'moneybox-income-event',
+        contractId: 'moneybox-contract',
+        eventDate: 1770003603000,
+        processingDate: 1770000000000,
+        transactionType: 1,
+        transactionCode: 'D_ZACH_BEZN',
+        transactionName: 'On-line пополнение договора с использованием сервиса Мобильный банкинг',
+        transactionSum: 75,
+        transactionCurrency: '933',
+        commissionSum: 0,
+        eventStatus: 1
+      },
+      {
+        sourceSystem: 3,
+        eventId: 'card-outcome-event',
+        souEventId: 'card-outcome-event',
+        contractId: 'card-contract',
+        cardPAN: '123456******0001',
+        cardId: 'card-0001',
+        eventDate: 1770003600000,
+        processingDate: null,
+        transactionType: -1,
+        transactionCode: '1455',
+        transactionName: 'Пополнение вклада в BYN (on-line) TESTDEPOSIT001',
+        transactionSum: 75,
+        transactionCurrency: '933',
+        commissionSum: 0,
+        rnnCode: '000000000001',
+        authorizationCode: '123456',
+        eventStatus: 0
+      },
+      {
+        sourceSystem: 8,
+        eventId: 'card-income-event',
+        contractId: 'card-contract',
+        eventDate: 1770000000000,
+        processingDate: 1769996400000,
+        transactionType: 1,
+        transactionCode: 'TRAN_ERIP',
+        transactionName: 'Пополнение счета через ЕРИП онлайн',
+        transactionSum: 75,
+        transactionCurrency: '933',
+        commissionSum: 0,
+        eventStatus: 1
+      }
+    ]
+    const accountsByNumber = {
+      'moneybox-contract': {
+        id: 'moneybox-account',
+        instrument: 'BYN'
+      },
+      'card-contract': {
+        id: 'card-account',
+        instrument: 'BYN'
+      }
+    }
+
+    const transactions = adjustTransactions({
+      transactions: convertTransactions(apiTransactions, accountsByNumber)
+    })
+
+    expect(transactions).toEqual([
+      {
+        movements: [
+          {
+            id: 'card-outcome-event',
+            account: { id: 'card-account' },
+            invoice: null,
+            sum: -75,
+            fee: 0
+          },
+          {
+            id: 'moneybox-income-event',
+            account: { id: 'moneybox-account' },
+            invoice: null,
+            sum: 75,
+            fee: 0
+          }
+        ],
+        date: new Date(1770003600000),
+        hold: null,
+        merchant: null,
+        comment: 'Пополнение вклада в BYN (on-line) TESTDEPOSIT001'
+      },
+      {
+        hold: false,
+        date: new Date(1770000000000),
+        movements: [
+          {
+            id: 'card-income-event',
+            account: { id: 'card-account' },
+            invoice: null,
+            sum: 75,
+            fee: 0
+          }
+        ],
+        merchant: null,
+        comment: 'Пополнение счета через ЕРИП онлайн'
+      }
+    ])
+  })
 })

--- a/src/plugins/sberbank-by/api.js
+++ b/src/plugins/sberbank-by/api.js
@@ -3,17 +3,35 @@ import forge from 'node-forge'
 import { stringify } from 'querystring'
 import { getByteStringFromString } from '../../common/byteStringUtils'
 import { toISODateString } from '../../common/dateUtils'
-import { fetchJson } from '../../common/network'
+import { fetch as fetchText, fetchJson } from '../../common/network'
 import { generateUUID } from '../../common/utils'
-import { BankMessageError, InvalidLoginOrPasswordError, InvalidOtpCodeError, TemporaryUnavailableError } from '../../errors'
+import { BankMessageError, InvalidLoginOrPasswordError, InvalidOtpCodeError, InvalidPreferencesError, TemporaryUnavailableError } from '../../errors'
 
-const host = 'www.sber-bank.by'
+const host = 'digital.sber-bank.by'
+const apiBaseUrl = `https://${host}/SBOLServer`
+const authBaseUrl = `https://${host}/api/sbol-auth/v1`
+const internalAuthHost = 'sbol-auth.apps.k8s-prom1.belpsb.by'
+const authRedirectUri = `https://${host}/loginsbol`
+const appVersion = '4.1.10'
+const sbolClientId = 'sbol-client'
+const sbolClientSecret = 'BzKFqWMa2T2Y'
 const defaultKeyValueSeparator = ':'
+const unknownDeviceErrorCodes = [
+  'sbol.auth.unknown-device.error',
+  'sbol.auth.untrusted-device.error'
+]
 
 export class AuthError {}
 
 export function getAuthToken ({ login, password }) {
   return 'Basic ' + forge.util.encode64(getByteStringFromString(login) + defaultKeyValueSeparator + getByteStringFromString(password))
+}
+
+function getSbolClientAuthToken () {
+  return getAuthToken({
+    login: sbolClientId,
+    password: sbolClientSecret
+  })
 }
 
 export function generateDevice (device) {
@@ -30,18 +48,49 @@ export function generateDevice (device) {
   }
 }
 
-async function callGate (url, options = {}) {
-  const headers = {
-    ...options.headers,
+function getDeviceModel () {
+  return ZenMoney.device?.model || 'Sync'
+}
+
+function getDeviceManufacturer () {
+  return ZenMoney.device?.manufacturer || ZenMoney.device?.brand || 'ZenMoney'
+}
+
+function getDeviceOsVersion () {
+  return ZenMoney.device?.osVersion || ZenMoney.device?.androidVersion || '14'
+}
+
+function getUserAgent () {
+  return `sbol/${appVersion} (android ${getDeviceOsVersion()}) ${getDeviceModel()}`
+}
+
+function getSbolHeaders (device, headers = {}) {
+  return {
+    ...headers,
     Accept: 'application/json; charset=UTF-8',
-    'X-Sbol-OS': 'android',
-    'X-Sbol-Version': '3.8.3',
-    'X-Sbol-Id': options.device.androidId,
-    'User-Agent': 'sbol/3.8.3 (android 8.0.0) ' + ZenMoney.device.model,
+    'X-Sbol-Os': 'android',
+    'X-Sbol-Version': appVersion,
+    'X-Sbol-Id': device.androidId,
+    'User-Agent': getUserAgent(),
     Host: host,
     Connection: 'Keep-Alive',
     'Accept-Encoding': 'gzip'
   }
+}
+
+function generateHex (bytes) {
+  return forge.util.bytesToHex(forge.random.getBytesSync(bytes))
+}
+
+function getTraceparentHeader () {
+  return `00-${generateHex(16)}-${generateHex(8)}-01`
+}
+
+async function callGate (url, options = {}) {
+  const headers = getSbolHeaders(options.device, {
+    ...options.sessionId && { 'X-Sbol-Session-Id': options.sessionId },
+    ...options.headers
+  })
 
   const response = await fetchJson(url, {
     stringify,
@@ -57,7 +106,7 @@ async function callGate (url, options = {}) {
 }
 
 async function prepareDevice (device) {
-  return callGate(`https://${host}/SBOLServer/rest/registration/prepareDevice`, {
+  return callGate(`${apiBaseUrl}/rest/registration/prepareDevice`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json;charset=UTF-8'
@@ -72,7 +121,7 @@ async function prepareDevice (device) {
 }
 
 async function trustDevice (smsCode, device) {
-  return callGate(`https://${host}/SBOLServer/rest/registration/trustedDevice`, {
+  return callGate(`${apiBaseUrl}/rest/registration/trustedDevice`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json;charset=UTF-8'
@@ -87,76 +136,262 @@ async function trustDevice (smsCode, device) {
   })
 }
 
-async function initiateLoginSequence (auth, device) {
-  const options = {
-    method: 'POST',
+function base64UrlEncode (byteString) {
+  return forge.util.encode64(byteString).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function generateCodeVerifier () {
+  return base64UrlEncode(forge.random.getBytesSync(64))
+}
+
+function generateCodeChallenge (verifier) {
+  const md = forge.md.sha256.create()
+  md.update(verifier, 'utf8')
+  return base64UrlEncode(md.digest().getBytes())
+}
+
+function parseBody (body) {
+  if (typeof body !== 'string' || body.length === 0) {
+    return body
+  }
+  try {
+    return JSON.parse(body)
+  } catch (e) {
+    return body
+  }
+}
+
+function getHeader (response, name) {
+  return response.headers[name.toLowerCase()] || response.headers[name]
+}
+
+function addResponseCookies (cookies, response) {
+  const setCookie = getHeader(response, 'set-cookie')
+  if (!setCookie) {
+    return
+  }
+  const cookieHeaders = Array.isArray(setCookie) ? setCookie : [setCookie]
+  for (const cookieHeader of cookieHeaders) {
+    for (const cookie of String(cookieHeader).split(/,(?=\s*[^;,]+=)/g)) {
+      const pair = cookie.split(';')[0]
+      const separatorIndex = pair.indexOf('=')
+      if (separatorIndex < 0) {
+        continue
+      }
+      const name = pair.substring(0, separatorIndex).trim()
+      const value = pair.substring(separatorIndex + 1).trim()
+      if (value) {
+        cookies[name] = value
+      } else {
+        delete cookies[name]
+      }
+    }
+  }
+}
+
+function getCookieHeader (cookies) {
+  return Object.keys(cookies).map(key => `${key}=${cookies[key]}`).join('; ')
+}
+
+function resolveAuthUrl (url) {
+  const resolvedUrl = new URL(url, `${authBaseUrl}/`)
+  if (resolvedUrl.hostname === internalAuthHost) {
+    const publicAuthBasePath = new URL(authBaseUrl).pathname
+    resolvedUrl.protocol = 'https:'
+    resolvedUrl.hostname = host
+    if (!resolvedUrl.pathname.startsWith(`${publicAuthBasePath}/`)) {
+      resolvedUrl.pathname = `${publicAuthBasePath}${resolvedUrl.pathname}`
+    }
+  }
+  return resolvedUrl.toString()
+}
+
+function getAuthCodeFromLocation (location) {
+  if (!location || location.indexOf(authRedirectUri) !== 0) {
+    return null
+  }
+  return new URL(location).searchParams.get('code')
+}
+
+function isRedirect (response) {
+  return response.status >= 300 && response.status < 400 && Boolean(getHeader(response, 'location'))
+}
+
+function isInternalAuthRootLocation (location) {
+  if (!location) {
+    return false
+  }
+  const parsedLocation = new URL(location, `${authBaseUrl}/`)
+  return parsedLocation.hostname === internalAuthHost && parsedLocation.pathname === '/'
+}
+
+function getAuthorizeUrl (codeChallenge, extraParams = {}) {
+  return `${authBaseUrl}/oauth2/authorize?${stringify({
+    response_type: 'code',
+    scope: 'read',
+    client_id: sbolClientId,
+    redirect_uri: authRedirectUri,
+    code_challenge_method: 'S256',
+    code_challenge: codeChallenge,
+    ...extraParams
+  })}`
+}
+
+function getLoginErrorDescription (response) {
+  return response.body?.errorDescription || response.body?.error_description || response.body?.message
+}
+
+function isInvalidLoginOrPassword (response) {
+  const errorCode = response.body?.errorCode || response.body?.error
+  const errorDescription = getLoginErrorDescription(response) || ''
+  return errorCode === 'sbol.auth.correct-login-password.error' ||
+    errorDescription.indexOf('Неверный логин или пароль') >= 0 ||
+    errorDescription.indexOf('Invalid username or password') >= 0
+}
+
+function isUnknownDeviceResponse (response) {
+  const errorCode = response.body?.errorCode
+  const sbolStatus = getHeader(response, 'sbol-status')
+  return response.status === 428 ||
+    unknownDeviceErrorCodes.includes(errorCode) ||
+    ['new_device', 'unknown_device', 'untrusted_device'].includes(sbolStatus)
+}
+
+function handleLoginFailureResponse (response) {
+  if (isInvalidLoginOrPassword(response)) {
+    throw new InvalidLoginOrPasswordError()
+  }
+  const description = getLoginErrorDescription(response)
+  if (description) {
+    throw new BankMessageError(description)
+  }
+  console.assert(false, 'Unknown login error', response)
+}
+
+async function fetchOAuth (url, { skipSbolHeaders = false, ...options } = {}) {
+  const oauthHeaders = {
+    ...options.headers,
+    traceparent: getTraceparentHeader()
+  }
+  const headers = skipSbolHeaders
+    ? oauthHeaders
+    : getSbolHeaders(options.device, oauthHeaders)
+  const response = await fetchText(url, {
+    stringify,
+    redirect: 'manual',
+    ...options,
+    headers,
+    sanitizeRequestLog: defaultsDeep({ headers: { Authorization: true, Cookie: true, 'X-Sbol-Id': true }, url: { query: { code_challenge: true } } }, options && options.sanitizeRequestLog),
+    sanitizeResponseLog: defaultsDeep({ headers: { 'set-cookie': true, location: true }, body: true }, options && options.sanitizeResponseLog)
+  })
+  response.body = parseBody(response.body)
+  return response
+}
+
+async function requestOAuthToken (auth, device) {
+  const sessionId = generateUUID()
+  const codeVerifier = generateCodeVerifier()
+  const codeChallenge = generateCodeChallenge(codeVerifier)
+  const cookies = {}
+
+  const authorizeResponse = await fetchOAuth(getAuthorizeUrl(codeChallenge), {
+    method: 'GET',
+    device,
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-      Authorization: getAuthToken(auth)
+      'X-Sbol-Model': getDeviceModel(),
+      'X-Sbol-Name': getDeviceManufacturer(),
+      'X-Sbol-DevOS': `android ${getDeviceOsVersion()}`
+    }
+  })
+  addResponseCookies(cookies, authorizeResponse)
+  if (authorizeResponse.status !== 200) {
+    return {
+      response: authorizeResponse,
+      sessionId
+    }
+  }
+
+  const loginResponse = await fetchOAuth(`${authBaseUrl}/oauth2/login`, {
+    method: 'POST',
+    device,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      provider: 'BASIC',
+      // The mobile app sends this header through BizoneInterceptor even when the report is unavailable.
+      'X-Sbol-Sdk': '',
+      'X-Sbol-Session-Id': sessionId,
+      'X-Geo-Consent': 'true',
+      Cookie: getCookieHeader(cookies)
     },
     body: {
-      client_id: auth.login,
-      client_secret: auth.password,
-      grant_type: 'client_credentials'
+      username: auth.login,
+      password: auth.password
     },
-    sanitizeRequestLog: { headers: { Authorization: true }, body: { client_id: true, client_secret: true } },
-    device
+    sanitizeRequestLog: { headers: { Cookie: true, 'X-Sbol-Id': true }, body: { username: true, password: true } }
+  })
+  addResponseCookies(cookies, loginResponse)
+  if (!isRedirect(loginResponse)) {
+    return {
+      response: loginResponse,
+      sessionId
+    }
   }
+
+  const loginLocation = getHeader(loginResponse, 'location')
+  // The app gets an internal root Location here; public ingress needs the original authorize endpoint with continue=true.
+  const continueUrl = isInternalAuthRootLocation(loginLocation)
+    ? getAuthorizeUrl(codeChallenge, { continue: true })
+    : resolveAuthUrl(loginLocation)
+  const continueResponse = await fetchOAuth(continueUrl, {
+    method: 'GET',
+    skipSbolHeaders: true,
+    device,
+    headers: {
+      Cookie: getCookieHeader(cookies)
+    }
+  })
+  addResponseCookies(cookies, continueResponse)
+  const authCode = getAuthCodeFromLocation(getHeader(continueResponse, 'location'))
+  if (!isRedirect(continueResponse) || !authCode) {
+    return {
+      response: continueResponse,
+      sessionId
+    }
+  }
+
+  const tokenResponse = await fetchOAuth(`${authBaseUrl}/oauth2/token`, {
+    method: 'POST',
+    device,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+      Authorization: getSbolClientAuthToken(),
+      'X-Sbol-Session-Id': sessionId
+    },
+    body: {
+      grant_type: 'authorization_code',
+      code: authCode,
+      redirect_uri: authRedirectUri,
+      client_id: sbolClientId,
+      code_verifier: codeVerifier
+    },
+    sanitizeRequestLog: { headers: { Authorization: true, 'X-Sbol-Id': true }, body: { code: true, code_verifier: true } }
+  })
+  return {
+    response: tokenResponse,
+    sessionId
+  }
+}
+
+async function initiateLoginSequence (auth, device) {
   const newDevice = generateDevice(device)
-  let response = await callGate(`https://${host}/SBOLServer/oauth/token`, options)
-  if ([400, 401].includes(response.status)) {
-    if (response.body.error_description) {
-      if ([
-        'Invalid username or password',
-        'Неверное имя пользователя или пароль'
-      ].some(str => response.body.error_description.indexOf(str) >= 0)) {
-        throw new InvalidLoginOrPasswordError()
-      }
-      if ([
-        'Неверный имя пользователя или пароль',
-        'Аккаунт временно заблокирован',
-        'Попробуйте после'
-      ].some(str => response.body.error_description.indexOf(str) >= 0)) {
-        throw new InvalidPreferencesError(response.body.error_description)
-      }
-      if ([
-        'Ожидается обработка Вашей заявки'
-      ].some(str => response.body.error_description.indexOf(str) >= 0)) {
-        throw new BankMessageError(response.body.error_description)
-      }
-      if ([
-        /^.*blocked.*$/,
-        /^.*Ваша учетная запись временно заблокирована.*$/,
-        /^.*Необходимо подтвердить регистрацию.*$/
-      ].some(regexp => response.body.error_description.match(regexp))) {
-        throw new BankMessageError(response.body.error_description)
-      }
-      if (![
-        'device',
-        'неизвестного устройства'
-      ].some(str => response.body.error_description.indexOf(str) >= 0)) {
-        console.assert(false, 'Unknown login error')
-      }
+  let loginResult = await requestOAuthToken(auth, newDevice)
+  if (isUnknownDeviceResponse(loginResult.response)) {
+    const sbolUdid = getHeader(loginResult.response, 'sbol-udid')
+    if (sbolUdid) {
+      newDevice.udid = sbolUdid
     }
-    const optionsBearer = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-        Authorization: 'Bearer null'
-      },
-      body: {
-        client_id: auth.login,
-        client_secret: auth.password,
-        grant_type: 'client_credentials'
-      },
-      sanitizeRequestLog: { headers: { Authorization: true }, body: { client_id: true, client_secret: true } },
-      device
-    }
-    response = await callGate(`https://${host}/SBOLServer/oauth/token`, optionsBearer)
-    if (response.headers['sbol-udid'] && response.headers['sbol-status'] && response.headers['sbol-status'] === 'new_device') {
-      newDevice.udid = response.headers['sbol-udid']
-    }
-    response = await prepareDevice(newDevice)
+    let response = await prepareDevice(newDevice)
     console.assert(response.body.errorInfo.errorCode === '0', 'Error while registering device.', response)
 
     const code = await ZenMoney.readLine('Введите код из SMS')
@@ -167,44 +402,57 @@ async function initiateLoginSequence (auth, device) {
       console.assert(response.body.errorInfo.errorCode === '0', 'Error while registering device.', response)
     }
 
-    response = await callGate(`https://${host}/SBOLServer/oauth/token`, options)
+    loginResult = await requestOAuthToken(auth, newDevice)
+  }
+  const response = loginResult.response
+  if (!response.body?.access_token) {
+    handleLoginFailureResponse(response)
   }
   return {
     response,
-    device: newDevice
+    device: newDevice,
+    sessionId: loginResult.sessionId
   }
 }
 
 export async function updateToken (auth) {
-  const response = await callGate(`https://${host}/SBOLServer/oauth/token`, {
+  if (!auth.refreshToken || !auth.sessionId) {
+    return login(auth, auth.device)
+  }
+  const response = await fetchOAuth(`${authBaseUrl}/oauth2/token`, {
     method: 'POST',
+    device: auth.device,
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
-      Authorization: getAuthToken(auth)
+      Authorization: getSbolClientAuthToken(),
+      'X-Sbol-Session-Id': auth.sessionId
     },
     body: {
-      client_id: auth.login,
-      client_secret: auth.password,
-      grant_type: 'client_credentials'
+      grant_type: 'refresh_token',
+      refresh_token: auth.refreshToken,
+      client_id: sbolClientId
     },
-    sanitizeRequestLog: { headers: { Authorization: true }, body: { client_id: true, client_secret: true } },
-    device: auth.device
+    sanitizeRequestLog: { headers: { Authorization: true, 'X-Sbol-Id': true }, body: { refresh_token: true } }
   })
-  console.assert(response.body.access_token, 'Error, while getting token.', response)
+  if (!response.body?.access_token) {
+    return login(auth, auth.device)
+  }
   return {
     ...auth,
-    token: response.body.access_token
+    token: response.body.access_token,
+    refreshToken: response.body.refresh_token || auth.refreshToken
   }
 }
 
 async function fetchListMoneyBox (auth) {
-  const response = await callGate(`https://${host}/SBOLServer/rest/client/getListMoneybox`, {
+  const response = await callGate(`${apiBaseUrl}/rest/client/getListMoneybox`, {
     method: 'GET',
     headers: {
       Authorization: 'Bearer ' + auth.token
     },
     sanitizeRequestLog: { headers: { Authorization: true } },
-    device: auth.device
+    device: auth.device,
+    sessionId: auth.sessionId
   })
   if (response.body.error === 'invalid_token') {
     throw new AuthError()
@@ -229,18 +477,21 @@ export async function login ({ login, password }, device) {
     login,
     password,
     token: accessToken,
+    refreshToken: loginResult.response.body.refresh_token,
+    sessionId: loginResult.sessionId,
     device: loginResult.device
   }
 }
 
 export async function fetchAccounts (auth) {
-  const response = await callGate(`https://${host}/SBOLServer/rest/client/contracts`, {
+  const response = await callGate(`${apiBaseUrl}/rest/client/contracts`, {
     method: 'GET',
     headers: {
       Authorization: 'Bearer ' + auth.token
     },
     sanitizeRequestLog: { headers: { Authorization: true } },
-    device: auth.device
+    device: auth.device,
+    sessionId: auth.sessionId
   })
   if (response.body.error === 'invalid_token') {
     throw new AuthError()
@@ -261,7 +512,7 @@ export async function updateBalances (auth, accounts) {
   await Promise.all(accounts.map(async (account) => {
     if (account.cardList && account.cardList.length > 0) {
       const card = account.cardList[0]
-      const response = await callGate(`https://${host}/SBOLServer/rest/client/balance`, {
+      const response = await callGate(`${apiBaseUrl}/rest/client/balance`, {
         method: 'POST',
         headers: {
           Authorization: 'Bearer ' + auth.token,
@@ -274,6 +525,7 @@ export async function updateBalances (auth, accounts) {
         },
         sanitizeRequestLog: { headers: { Authorization: true } }, // , body: { cardExpire: true, cardId: true, currency: true } },
         device: auth.device,
+        sessionId: auth.sessionId,
         stringify: JSON.stringify
       })
       console.assert(response.body.errorInfo && response.body.errorInfo.errorCode === '0', 'Error while getting actual balance for account', account)
@@ -298,9 +550,10 @@ export async function fetchTransactions (auth, products, fromDate, toDate, contr
     },
     sanitizeRequestLog: { headers: { Authorization: true } },
     device: auth.device,
+    sessionId: auth.sessionId,
     stringify: JSON.stringify
   }
-  const response = await callGate(`https://${host}/SBOLServer/rest/client/events`, {
+  const response = await callGate(`${apiBaseUrl}/rest/client/events`, {
     ...options,
     body: {
       contractNumber,

--- a/src/plugins/sberbank-by/converters.js
+++ b/src/plugins/sberbank-by/converters.js
@@ -109,6 +109,35 @@ function getApiTransactionReferenceCodes (apiTransaction) {
   return { rrn, authorizationCode }
 }
 
+function getApiTransactionCurrency (apiTransaction) {
+  return apiTransaction.transactionCurrency.length === 3
+    ? apiTransaction.transactionCurrency
+    : apiTransaction.transactionCurrency.length === 2 ? `0${apiTransaction.transactionCurrency}` : `00${apiTransaction.transactionCurrency}`
+}
+
+function getApiTransactionSignedSum (apiTransaction) {
+  return apiTransaction.transactionType
+    ? apiTransaction.transactionType * apiTransaction.transactionSum
+    : apiTransaction.transactionSum
+}
+
+function getAmountGroupKey (date, instrument, sum) {
+  return [toISODateString(date), instrument, Math.abs(sum)].join('_')
+}
+
+function getApiTransactionAmountGroupKey (apiTransaction) {
+  return getAmountGroupKey(
+    new Date(apiTransaction.eventDate),
+    codeToCurrency[getApiTransactionCurrency(apiTransaction)],
+    getApiTransactionSignedSum(apiTransaction)
+  )
+}
+
+function isOnlineDepositTargetIncome (apiTransaction) {
+  return /On-line пополнение договора.*Мобильный банкинг/i.test(apiTransaction.transactionName) &&
+    getApiTransactionSignedSum(apiTransaction) > 0
+}
+
 function getAccountLevelEventId (apiTransaction, rrn, authorizationCode) {
   return !rrn && !authorizationCode && !(apiTransaction.cardId || apiTransaction.cardPAN)
     ? apiTransaction.eventId || ''
@@ -179,11 +208,18 @@ function shouldReplaceTransaction (currentTransaction, nextTransaction) {
 
 export function convertTransactions (apiTransactions, accountsByContractNumber) {
   const adjustedApiTransactions = deduplicateApiTransactions(apiTransactions)
+  const onlineDepositTargetGroupKeys = new Set(
+    adjustedApiTransactions
+      .filter(isOnlineDepositTargetIncome)
+      .map(getApiTransactionAmountGroupKey)
+  )
   const transactions = []
   const transactionIndexes = {}
   for (const transaction of adjustedApiTransactions) {
     if (accountsByContractNumber[transaction.contractId]) {
-      const answer = convertTransaction(transaction, accountsByContractNumber[transaction.contractId])
+      const answer = convertTransaction(transaction, accountsByContractNumber[transaction.contractId], {
+        onlineDepositTargetGroupKeys
+      })
       if (answer !== null) {
         const key = getTransactionDedupKey(answer)
         if (key === null) {
@@ -276,17 +312,15 @@ export function convertLoan (apiAccount) {
   }
 }
 
-export function convertTransaction (apiTransaction, account) {
+export function convertTransaction (apiTransaction, account, context = {}) {
   if (apiTransaction.eventStatus === -1 || apiTransaction.transactionSum === 0) {
     return null
   }
   const { rrn, authorizationCode } = getApiTransactionReferenceCodes(apiTransaction)
-  const currency = apiTransaction.transactionCurrency.length === 3
-    ? apiTransaction.transactionCurrency
-    : apiTransaction.transactionCurrency.length === 2 ? `0${apiTransaction.transactionCurrency}` : `00${apiTransaction.transactionCurrency}`
+  const currency = getApiTransactionCurrency(apiTransaction)
   const invoice = {
     instrument: codeToCurrency[currency],
-    sum: apiTransaction.transactionType ? apiTransaction.transactionType * apiTransaction.transactionSum : apiTransaction.transactionSum
+    sum: getApiTransactionSignedSum(apiTransaction)
   }
   const transaction = {
     hold: apiTransaction.eventStatus === 0,
@@ -312,7 +346,7 @@ export function convertTransaction (apiTransaction, account) {
     parseCashTransfer,
     parsePayee
   ]
-  parsers.some(parser => parser(transaction, apiTransaction, account, invoice))
+  parsers.some(parser => parser(transaction, apiTransaction, account, invoice, context))
 
   const accountLevelEventId = getAccountLevelEventId(apiTransaction, rrn, authorizationCode)
   if (accountLevelEventId) {
@@ -368,7 +402,7 @@ function parseComment (transaction, apiTransaction) {
   return false
 }
 
-function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
+function parseInnerTransfer (transaction, apiTransaction, account, invoice, context) {
   if ([
     /^.*на свои карты.*$/i
   ].some(regexp => regexp.test(apiTransaction.transactionName))) {
@@ -387,8 +421,19 @@ function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
     return true
   }
   if ([
+    /On-line пополнение договора.*Мобильный банкинг/i
+  ].some(regexp => regexp.test(apiTransaction.transactionName))) {
+    transaction.groupKeys = [getAmountGroupKey(transaction.date, invoice.instrument, invoice.sum)]
+    return true
+  }
+  if ([
     /Пополнение вклада.*\(on-line\).*/i
   ].some(regexp => regexp.test(apiTransaction.transactionName))) {
+    const groupKey = getAmountGroupKey(transaction.date, invoice.instrument, invoice.sum)
+    if (context.onlineDepositTargetGroupKeys?.has(groupKey)) {
+      transaction.groupKeys = [groupKey]
+      return true
+    }
     const syncIds = apiTransaction.transactionName.match(/\(on-line\) ([\d\w]*)/i)
     transaction.movements.push({
       id: null,
@@ -402,7 +447,7 @@ function parseInnerTransfer (transaction, apiTransaction, account, invoice) {
       sum: -invoice.sum,
       fee: 0
     })
-    transaction.groupKeys = [toISODateString(transaction.date) + '_' + invoice.instrument + '_' + Math.abs(invoice.sum)]
+    transaction.groupKeys = [groupKey]
     return true
   }
   return false


### PR DESCRIPTION
## Что изменилось

Исправлен узкий кейс в Sberbank BY: при онлайн-пополнении вклада/копилки банк отдает в `/events` две стороны операции:

- списание с карты;
- зачисление на вклад/копилку.

Плагин уже видел реальное зачисление, но дополнительно дорисовывал синтетическую сторону `Checking`, из-за чего операция могла задваиваться в приложении.

Теперь, если целевая сторона операции уже приш## Что изменилось

Восстановлена работа `sberbank-by` после отключения старого mobile API Сбербанка с 01.07.2026.

- Переведен вход со старого `SBOLServer/oauth/token` / `client_credentials` на OAuth2 authorization-code flow с PKCE из APK 4.1.10.
- Обновлены host и заголовки мобильного клиента: `digital.sber-bank.by`, версия `4.1.10`, `X-Sbol-Session-Id`, `traceparent`, `refresh_token`.
- Добавлена обработка банковского внутреннего redirect `sbol-auth.apps.k8s-prom1.belpsb.by`: авторизация продолжается через публичный `/api/sbol-auth/v1/oauth2/authorize?...&continue=true`.
- API-запросы к счетам, балансам, копилкам и операциям теперь используют новый host и session id.
- Исправлен dev-краш `XMLHttpRequestViaZenAPI` на нестандартном HTTP status string.

Также в ветке остается исправление дублей при пополнении вклада/копилки:

- если обе стороны transfer уже пришли из `/events`, плагин не дорисовывает синтетический `Checking`.

## Проверка

- Live-запуск плагина: получено 3 счета и 20 операций.
- `yarn lint src/plugins/sberbank-by/api.js src/plugins/sberbank-by/__tests__/api/login.test.js src/XMLHttpRequestViaZenAPI.js`
- `yarn jest --testMatch "**/src/plugins/sberbank-by/__tests__/**/*.test.js"`
- `yarn webpack build --config ./scripts/webpack.config.js --mode=production --env PLUGIN=sberbank-by`
- `git diff --check`

## Дополнительно

Старый `/SBOLServer/oauth/token` проверен на `www.sber-bank.by` и `digital.sber-bank.by`: оба варианта возвращают `503 service_unavailable`, поэтому возвращаться к старому flow нельзя.ла из `/events`, карточное списание группируется с ней в один transfer. Fallback с синтетическим `Checking` сохранен для случаев, когда целевая сторона не пришла.

## Проверка

- `yarn jest --testMatch "**/src/plugins/sberbank-by/__tests__/**/*.test.js"`
- `yarn lint src/plugins/sberbank-by/converters.js src/plugins/sberbank-by/__tests__/converters/transactions/convertTransactionsFunc.test.js`
- `git diff --check master...HEAD`