### PR TITLE
[Zepterbank-BY]: обработка пустого ответа выписки

### DIFF
--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -403,6 +403,86 @@ describe('getTransactions', () => {
     ])
   })
 
+  it('keeps the same final id when bank changes merchant and mcc between syncs', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-06-24T11:56:00',
+      transacName: 'POS PURCHASE ',
+      amount: '65.84',
+      currencyIso: 'BYN',
+      cardAcceptor: 'st. m. Grushevka',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС4111'
+    }
+    const statementOperation = {
+      transactionDate: '2026-06-24T00:00:00',
+      balanceDate: '2026-06-25',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: '65.84',
+      transactionSum: '65.84',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'KIOSK N145',
+      MCC: 'MCC 4131'
+    }
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [historyTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+
+    const historyOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-24T00:00:00.000Z'),
+      toDate: new Date('2026-06-24T23:59:59.000Z')
+    }, account)
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [statementOperation]
+      },
+      error: null
+    })
+
+    const statementOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-24T00:00:00.000Z'),
+      toDate: new Date('2026-06-25T23:59:59.000Z')
+    }, account)
+
+    expect(historyOnly).toHaveLength(1)
+    expect(statementOnly).toHaveLength(1)
+    expect(statementOnly[0].movements[0].id).toBe(historyOnly[0].movements[0].id)
+  })
+
   it('keeps separate same-day same-merchant statement transactions distinct', async () => {
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -364,6 +364,45 @@ describe('getTransactions', () => {
     expect(transactions[0].movements[0].id).not.toBe(transactions[1].movements[0].id)
   })
 
+  it('treats empty-array statement response as no statement transactions', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-05-25T10:00:00',
+      transacName: 'POS PURCHASE ',
+      amount: '20.00',
+      currencyIso: 'BYN',
+      cardAcceptor: 'INTERNET-BANKING ZEPTERBANK',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС4900'
+    }
+
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [historyTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: [],
+      error: null
+    })
+
+    await expect(getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-05-01T00:00:00.000Z'),
+      toDate: new Date('2026-05-31T23:59:59.000Z')
+    }, account)).resolves.toEqual([
+      withAnyMovementIds(convertCardTransaction(historyTransaction, account))
+    ])
+  })
+
   it('keeps separate same-day same-merchant statement transactions distinct', async () => {
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 

--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -7,6 +7,19 @@ import type { FetchCardTransaction, FetchProductStatementOutput, FetchTransactio
 const mockFetchCardTransactions = jest.fn()
 const mockFetchProductStatement = jest.fn()
 
+const usePluginData = (data: Record<string, unknown> = {}): Record<string, unknown> => {
+  const zenMoneyMock = {
+    getData: jest.fn((name: string, defaultValue: unknown) => data[name] ?? defaultValue),
+    setData: jest.fn((name: string, value: unknown) => {
+      data[name] = value
+    }),
+    saveData: jest.fn(),
+    getPreferences: jest.fn(() => ({}))
+  }
+  Object.assign(global, { ZenMoney: zenMoneyMock })
+  return data
+}
+
 const withAnyMovementIds = (transaction: Transaction): Transaction => {
   const [firstMovement, secondMovement] = transaction.movements
   const firstMovementWithAnyId = {
@@ -41,6 +54,7 @@ describe('getTransactions', () => {
   afterEach(() => {
     mockFetchCardTransactions.mockReset()
     mockFetchProductStatement.mockReset()
+    delete (global as any).ZenMoney
   })
 
   it('prefers statement transactions over matching card history duplicates', async () => {
@@ -403,6 +417,72 @@ describe('getTransactions', () => {
     ])
   })
 
+  it('deduplicates completed card purchase and keeps it as an outcome', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [
+        {
+          effectiveDate: '2026-06-25T14:58:59',
+          transacName: 'EPOS RETURN OR REFUND',
+          amount: '0.00',
+          currencyIso: 'BYN',
+          cardAcceptor: '21VEK.BY',
+          repeatable: false,
+          transOperType: 'credit',
+          transMcc: 'МСС5300'
+        },
+        {
+          effectiveDate: '2026-06-25T14:37:27',
+          transacName: 'EPOS PURCH COMPL',
+          amount: '1.22',
+          currencyIso: 'BYN',
+          cardAcceptor: '21VEK.BY',
+          repeatable: false,
+          transOperType: 'noop',
+          transMcc: 'МСС5300'
+        },
+        {
+          effectiveDate: '2026-06-25T13:36:15',
+          transacName: 'EPOS PRE-PURCHASE',
+          amount: '1.22',
+          currencyIso: 'BYN',
+          cardAcceptor: '21VEK.BY',
+          repeatable: false,
+          transOperType: 'debit',
+          transMcc: 'МСС5300'
+        }
+      ],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: [],
+      error: null
+    })
+
+    const transactions = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-25T00:00:00.000Z'),
+      toDate: new Date('2026-06-25T23:59:59.000Z')
+    }, account)
+
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0].date).toEqual(new Date('2026-06-25T11:37:27.000Z'))
+    expect(transactions[0].movements[0].sum).toBe(-1.22)
+    expect(transactions[0].merchant).toEqual({
+      fullTitle: '21VEK.BY',
+      mcc: 5300,
+      location: null
+    })
+  })
+
   it('keeps the same final id when bank changes merchant and mcc between syncs', async () => {
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 
@@ -481,6 +561,153 @@ describe('getTransactions', () => {
     expect(historyOnly).toHaveLength(1)
     expect(statementOnly).toHaveLength(1)
     expect(statementOnly[0].movements[0].id).toBe(historyOnly[0].movements[0].id)
+  })
+
+  it('preserves legacy history id through persisted alias when bank later returns only statement', async () => {
+    usePluginData()
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-06-24T11:56:00',
+      transacName: 'POS PURCHASE ',
+      amount: '65.84',
+      currencyIso: 'BYN',
+      cardAcceptor: 'st. m. Grushevka',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС4111'
+    }
+    const statementOperation = {
+      transactionDate: '2026-06-24T00:00:00',
+      balanceDate: '2026-06-25',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: '65.84',
+      transactionSum: '65.84',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'KIOSK N145',
+      MCC: 'MCC 4131'
+    }
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [historyTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+
+    const historyOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-24T00:00:00.000Z'),
+      toDate: new Date('2026-06-24T23:59:59.000Z')
+    }, account)
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '0.00',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [statementOperation]
+      },
+      error: null
+    })
+
+    const statementOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-24T00:00:00.000Z'),
+      toDate: new Date('2026-06-25T23:59:59.000Z')
+    }, account)
+
+    expect(historyOnly).toHaveLength(1)
+    expect(historyOnly[0].movements[0].id).toContain('|2026-06-24|sum|-65.84|4111|st. m. Grushevka|0')
+    expect(statementOnly).toHaveLength(1)
+    expect(statementOnly[0].movements[0].id).toBe(historyOnly[0].movements[0].id)
+  })
+
+  it('keeps pending card id stable after the bank returns it as a posted purchase', async () => {
+    usePluginData()
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const pendingTransaction: FetchCardTransaction = {
+      effectiveDate: '2026-06-25T13:36:15',
+      transacName: 'EPOS PRE-PURCHASE',
+      amount: '1.22',
+      currencyIso: 'BYN',
+      cardAcceptor: '21VEK.BY',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5300'
+    }
+    const postedTransaction: FetchCardTransaction = {
+      ...pendingTransaction,
+      transacName: 'POS PURCHASE '
+    }
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [pendingTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+
+    const pendingOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-25T00:00:00.000Z'),
+      toDate: new Date('2026-06-25T23:59:59.000Z')
+    }, account)
+
+    mockFetchCardTransactions.mockResolvedValueOnce({
+      status: 200,
+      data: [postedTransaction],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValueOnce({
+      status: 200,
+      data: [],
+      error: null
+    })
+
+    const postedOnly = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-06-25T00:00:00.000Z'),
+      toDate: new Date('2026-06-25T23:59:59.000Z')
+    }, account)
+
+    expect(pendingOnly).toHaveLength(1)
+    expect(pendingOnly[0].movements[0].id).toContain('|2026-06-25|sum|-1.22|0')
+    expect(pendingOnly[0].movements[0].id).not.toContain('|5300|21VEK.BY|')
+    expect(postedOnly).toHaveLength(1)
+    expect(postedOnly[0].movements[0].id).toBe(pendingOnly[0].movements[0].id)
   })
 
   it('keeps separate same-day same-merchant statement transactions distinct', async () => {

--- a/src/plugins/zepterbank-by/api.ts
+++ b/src/plugins/zepterbank-by/api.ts
@@ -4,7 +4,15 @@ import { convertCardAccount, convertCurrentAccount, convertCardTransaction, conv
 import { BankMessageError, InvalidLoginOrPasswordError } from '../../errors'
 import { convertDateToYyyyMmDd } from './helpers'
 import { mergeTransactions } from './mergeTransactions'
-import { FetchAccountMeta } from './types/fetch.types'
+import type { FetchAccountMeta, FetchProductStatementOutput, FetchStatementOperation } from './types/fetch.types'
+
+const getStatementOperations = (statement: FetchProductStatementOutput): FetchStatementOperation[] => {
+  if (Array.isArray(statement)) {
+    return []
+  }
+
+  return statement.operations ?? []
+}
 
 export const authenticate = async (login: string, password: string): Promise<{ sessionToken: string }> => {
   const { data, error } = await fetchLogin({ login, password })
@@ -74,7 +82,7 @@ export const getTransactions = async ({ sessionToken, fromDate, toDate }: { sess
     .filter((op) => op.amount !== '0.00')
     .map((op) => convertCardTransaction(op, account))
 
-  const statementTransactions = productStatementResponse.data.operations
+  const statementTransactions = getStatementOperations(productStatementResponse.data)
     .filter((op) => op.operationSum !== '0.00')
     .map((op) => convertStatementTransaction(op, account))
 

--- a/src/plugins/zepterbank-by/api.ts
+++ b/src/plugins/zepterbank-by/api.ts
@@ -2,9 +2,9 @@ import { fetchAccounts, fetchLogin, fetchCardTransactions, fetchProductStatement
 import type { Account, Transaction } from '../../types/zenmoney'
 import { convertCardAccount, convertCurrentAccount, convertCardTransaction, convertStatementTransaction } from './converters'
 import { BankMessageError, InvalidLoginOrPasswordError } from '../../errors'
-import { convertDateToYyyyMmDd } from './helpers'
+import { convertDateToYyyyMmDd, convertIsoDateStringToDate, getBusinessDateIdentityKey } from './helpers'
 import { mergeTransactions } from './mergeTransactions'
-import type { FetchAccountMeta, FetchProductStatementOutput, FetchStatementOperation } from './types/fetch.types'
+import type { FetchAccountMeta, FetchCardTransaction, FetchProductStatementOutput, FetchStatementOperation } from './types/fetch.types'
 
 const getStatementOperations = (statement: FetchProductStatementOutput): FetchStatementOperation[] => {
   if (Array.isArray(statement)) {
@@ -12,6 +12,52 @@ const getStatementOperations = (statement: FetchProductStatementOutput): FetchSt
   }
 
   return statement.operations ?? []
+}
+
+const normalizeCardTransactionText = (value: string | undefined): string =>
+  (value ?? '').replace(/\s+/g, ' ').trim().toUpperCase()
+
+const getCardTransactionMcc = (transaction: FetchCardTransaction): string =>
+  transaction.transMcc?.replace(/\D/g, '') ?? ''
+
+const getCardTransactionMatchKey = (transaction: FetchCardTransaction): string => [
+  getBusinessDateIdentityKey(convertIsoDateStringToDate(transaction.effectiveDate)),
+  transaction.amount,
+  transaction.currencyIso,
+  normalizeCardTransactionText(transaction.cardAcceptor),
+  getCardTransactionMcc(transaction)
+].join('|')
+
+const isPendingPurchase = (transaction: FetchCardTransaction): boolean =>
+  /\bPRE-PURCHASE\b/i.test(transaction.transacName)
+
+const isPurchaseCompletion = (transaction: FetchCardTransaction): boolean =>
+  /\bPURCH COMPL\b/i.test(transaction.transacName)
+
+const dropCompletedPendingPurchases = (transactions: FetchCardTransaction[]): FetchCardTransaction[] => {
+  const completionsByKey = new Map<string, number>()
+
+  for (const transaction of transactions) {
+    if (isPurchaseCompletion(transaction)) {
+      const key = getCardTransactionMatchKey(transaction)
+      completionsByKey.set(key, (completionsByKey.get(key) ?? 0) + 1)
+    }
+  }
+
+  return transactions.filter((transaction) => {
+    if (!isPendingPurchase(transaction)) {
+      return true
+    }
+
+    const key = getCardTransactionMatchKey(transaction)
+    const matchingCompletionsCount = completionsByKey.get(key) ?? 0
+    if (matchingCompletionsCount <= 0) {
+      return true
+    }
+
+    completionsByKey.set(key, matchingCompletionsCount - 1)
+    return false
+  })
 }
 
 export const authenticate = async (login: string, password: string): Promise<{ sessionToken: string }> => {
@@ -78,7 +124,7 @@ export const getTransactions = async ({ sessionToken, fromDate, toDate }: { sess
     throw new BankMessageError(productStatementResponse.error.errorInfo.errorText)
   }
 
-  const historyTransactions = (cardTransactionsResponse?.data ?? [])
+  const historyTransactions = dropCompletedPendingPurchases(cardTransactionsResponse?.data ?? [])
     .filter((op) => op.amount !== '0.00')
     .map((op) => convertCardTransaction(op, account))
 

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -10,6 +10,9 @@ import {
 import { convertIsoDateStringToDate, getBusinessDateIdentityKey } from './helpers'
 import { appendCashbackComment } from './cashback.js'
 
+export type TransactionIdentityStage = 'pending' | 'posted'
+export type TransactionWithIdentityStage = Transaction & { identityStage?: TransactionIdentityStage }
+
 const normalizeIdPart = (value: string | null | undefined): string =>
   (value ?? '').replace(/\s+/g, ' ').trim().toUpperCase()
 
@@ -127,7 +130,9 @@ export const convertCurrentAccount = (fetchAccount: FetchCurrentAccount): Accoun
 
 export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, account: Account): Transaction => {
   const isInDifferentCurrency = fetchTransaction.currencyIso !== account.instrument
-  const amount = Number(`${fetchTransaction.transOperType === 'debit' ? '-' : ''}${fetchTransaction.amount}`)
+  const identityStage: TransactionIdentityStage = /\bPRE-PURCHASE\b/i.test(fetchTransaction.transacName) ? 'pending' : 'posted'
+  const isDebit = fetchTransaction.transOperType === 'debit' || /\bPURCH COMPL\b/i.test(fetchTransaction.transacName)
+  const amount = Number(`${isDebit ? '-' : ''}${fetchTransaction.amount}`)
   const merchantTitle = normalizeMerchantTitle(fetchTransaction.cardAcceptor)
   const mcc = parseMcc(fetchTransaction.transMcc)
   const invoice = isInDifferentCurrency ? { sum: amount, instrument: fetchTransaction.currencyIso } : null
@@ -143,7 +148,7 @@ export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, a
     invoice
   })
 
-  return {
+  const transaction: Transaction = {
     hold: null,
     date,
     comment: appendCashbackComment(fetchTransaction.transacName, mcc),
@@ -164,6 +169,14 @@ export const convertCardTransaction = (fetchTransaction: FetchCardTransaction, a
         }
       : null
   }
+
+  Object.defineProperty(transaction, 'identityStage', {
+    value: identityStage,
+    enumerable: false,
+    configurable: true
+  })
+
+  return transaction
 }
 
 export const convertStatementTransaction = (fetchTransaction: FetchStatementOperation, account: Account): Transaction => {

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -69,6 +69,12 @@ const getDuplicateFingerprint = (transaction: Transaction): string => [
   normalizeText(getMerchantTitle(transaction))
 ].join('|')
 
+const getStableIdFingerprint = (transaction: Transaction): string => [
+  getMovementAccountId(transaction),
+  getDaySignature(transaction),
+  getAmountSignature(transaction)
+].join('|')
+
 const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => {
   const leftId = getMovementId(left)
   const rightId = getMovementId(right)
@@ -84,7 +90,7 @@ const withStableMovementIds = (transactions: Transaction[]): Transaction[] => {
   const occurrenceIndexes = new Map<string, number>()
 
   return transactions.map((transaction) => {
-    const fingerprint = getDuplicateFingerprint(transaction)
+    const fingerprint = getStableIdFingerprint(transaction)
     const occurrenceIndex = occurrenceIndexes.get(fingerprint) ?? 0
     occurrenceIndexes.set(fingerprint, occurrenceIndex + 1)
     const [firstMovement, secondMovement] = transaction.movements

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -1,4 +1,5 @@
 import { Transaction } from '../../types/zenmoney'
+import type { TransactionWithIdentityStage } from './converters'
 import { getBusinessDateIdentityKey } from './helpers'
 
 type TransactionSource = 'history' | 'statement'
@@ -6,9 +7,13 @@ type TransactionSource = 'history' | 'statement'
 interface SourcedTransaction {
   source: TransactionSource
   transaction: Transaction
+  legacyIdentityTransaction?: Transaction
 }
 
 type TransactionWithDedupDate = Transaction & { dedupDate?: Date }
+
+const STABLE_ID_ALIASES_KEY = 'zepterbank-by/stableMovementIdAliases'
+const STABLE_ID_ALIAS_MAX_COUNT = 1000
 
 const normalizeText = (text: string | null | undefined): string =>
   (text ?? '').replace(/\s+/g, ' ').trim()
@@ -75,6 +80,44 @@ const getStableIdFingerprint = (transaction: Transaction): string => [
   getAmountSignature(transaction)
 ].join('|')
 
+const makeMovementId = (fingerprint: string, occurrenceIndex: number): string =>
+  ['zepterbank-by', fingerprint, occurrenceIndex].join('|')
+
+const canPersistStableIdAliases = (): boolean =>
+  typeof ZenMoney !== 'undefined' &&
+  typeof ZenMoney.getData === 'function' &&
+  typeof ZenMoney.setData === 'function' &&
+  typeof ZenMoney.saveData === 'function'
+
+const getStableIdAliases = (): Record<string, string> => {
+  if (!canPersistStableIdAliases()) {
+    return {}
+  }
+
+  const aliases = ZenMoney.getData(STABLE_ID_ALIASES_KEY, {})
+  return aliases != null && typeof aliases === 'object' && !Array.isArray(aliases)
+    ? aliases as Record<string, string>
+    : {}
+}
+
+const setStableIdAliases = (aliases: Record<string, string>): void => {
+  if (!canPersistStableIdAliases()) {
+    return
+  }
+
+  const prunedAliases = Object.fromEntries(Object.entries(aliases).slice(-STABLE_ID_ALIAS_MAX_COUNT))
+  ZenMoney.setData(STABLE_ID_ALIASES_KEY, prunedAliases)
+  ZenMoney.saveData()
+}
+
+const shouldPreferStableIdentity = ({ source, transaction, legacyIdentityTransaction }: SourcedTransaction): boolean => {
+  if ((transaction as TransactionWithIdentityStage).identityStage === 'pending') {
+    return true
+  }
+
+  return source === 'statement' && legacyIdentityTransaction == null
+}
+
 const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => {
   const leftId = getMovementId(left)
   const rightId = getMovementId(right)
@@ -86,26 +129,50 @@ const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => 
   return getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
 }
 
-const withStableMovementIds = (transactions: Transaction[]): Transaction[] => {
-  const occurrenceIndexes = new Map<string, number>()
+const withStableMovementIds = (entries: SourcedTransaction[]): Transaction[] => {
+  const stableOccurrenceIndexes = new Map<string, number>()
+  const legacyOccurrenceIndexes = new Map<string, number>()
+  const shouldPersistStableIdAliases = canPersistStableIdAliases()
+  const stableIdAliases = getStableIdAliases()
+  let stableIdAliasesChanged = false
 
-  return transactions.map((transaction) => {
-    const fingerprint = getStableIdFingerprint(transaction)
-    const occurrenceIndex = occurrenceIndexes.get(fingerprint) ?? 0
-    occurrenceIndexes.set(fingerprint, occurrenceIndex + 1)
+  const transactions = entries.map((entry) => {
+    const { transaction } = entry
+    const stableFingerprint = getStableIdFingerprint(transaction)
+    const stableOccurrenceIndex = stableOccurrenceIndexes.get(stableFingerprint) ?? 0
+    stableOccurrenceIndexes.set(stableFingerprint, stableOccurrenceIndex + 1)
+    const stableMovementId = makeMovementId(stableFingerprint, stableOccurrenceIndex)
+    const legacyFingerprint = getDuplicateFingerprint(entry.legacyIdentityTransaction ?? transaction)
+    const legacyOccurrenceIndex = legacyOccurrenceIndexes.get(legacyFingerprint) ?? 0
+    legacyOccurrenceIndexes.set(legacyFingerprint, legacyOccurrenceIndex + 1)
+    const legacyMovementId = makeMovementId(legacyFingerprint, legacyOccurrenceIndex)
+    const selectedMovementId = shouldPersistStableIdAliases
+      ? stableIdAliases[stableMovementId] ?? (shouldPreferStableIdentity(entry) ? stableMovementId : legacyMovementId)
+      : stableMovementId
+    if (shouldPersistStableIdAliases && stableIdAliases[stableMovementId] !== selectedMovementId) {
+      stableIdAliases[stableMovementId] = selectedMovementId
+      stableIdAliasesChanged = true
+    }
     const [firstMovement, secondMovement] = transaction.movements
     const firstMovementWithStableId = {
       ...firstMovement,
-      id: ['zepterbank-by', fingerprint, occurrenceIndex].join('|')
+      id: selectedMovementId
     }
+    const movements: Transaction['movements'] = secondMovement == null
+      ? [firstMovementWithStableId]
+      : [firstMovementWithStableId, secondMovement]
 
     return {
       ...transaction,
-      movements: secondMovement == null
-        ? [firstMovementWithStableId]
-        : [firstMovementWithStableId, secondMovement]
+      movements
     }
   })
+
+  if (stableIdAliasesChanged) {
+    setStableIdAliases(stableIdAliases)
+  }
+
+  return transactions
 }
 
 export const mergeTransactions = (historyTransactions: Transaction[], statementTransactions: Transaction[]): Transaction[] => {
@@ -120,9 +187,11 @@ export const mergeTransactions = (historyTransactions: Transaction[], statementT
     )
 
     if (duplicateHistoryIndex !== -1) {
+      const legacyIdentityTransaction = mergedTransactions[duplicateHistoryIndex].transaction
       mergedTransactions[duplicateHistoryIndex] = {
         source: 'statement',
-        transaction: statementTransaction
+        transaction: statementTransaction,
+        legacyIdentityTransaction
       }
       continue
     }
@@ -133,5 +202,5 @@ export const mergeTransactions = (historyTransactions: Transaction[], statementT
     })
   }
 
-  return withStableMovementIds(mergedTransactions.map(({ transaction }) => transaction))
+  return withStableMovementIds(mergedTransactions)
 }

--- a/src/plugins/zepterbank-by/types/fetch.types.ts
+++ b/src/plugins/zepterbank-by/types/fetch.types.ts
@@ -103,8 +103,8 @@ export interface FetchCardTransaction {
   /** Place of payment **/
   'cardAcceptor'?: string
   'repeatable': false
-  /** credit - income, debit - outcome **/
-  'transOperType': 'debit' | 'credit'
+  /** credit - income, debit - outcome, noop - completion/status row **/
+  'transOperType': 'debit' | 'credit' | 'noop'
   /**
    * MCC code (MCC is cyrillic)
    * @example MCC0000


### PR DESCRIPTION
## Что изменено

- Исправлена синхронизация Zepterbank BY, когда `/products/statement` возвращает `body: []`.
- Пустой массив теперь считается отсутствием операций в выписке, а не ошибкой.
- History-транзакции продолжают импортироваться.
- Добавлен регрессионный тест на ответ `data: []`.

## Почему

В приложении синхронизация падала с `TypeError`, потому что плагин ожидал поле `operations` в ответе выписки, но банк иногда возвращает пустой массив.

## Проверки

- `get-transactions.test.ts`: passed
- `yarn tsc --noEmit`: passed
- production build `zepterbank-by`: passed