### PR TITLE
[simbank-kg] add Simbank Kyrgyzstan statement-import plugin

### DIFF
--- a/src/plugins/simbank-kg/README.md
+++ b/src/plugins/simbank-kg/README.md
@@ -1,0 +1,82 @@
+# Simbank (Kyrgyzstan) — statement import
+
+File-based community plugin. It imports a Simbank (КР, brand of ОАО "Дос-Кредобанк")
+card statement that the user exports from the bank and selects manually. The file is
+parsed **entirely on the device** — the plugin makes no network requests.
+
+## Where to get the statement
+
+In the **Simbank mobile app**: open the card settings and tap **"Выписка по карте"**
+("Card statement"), then save the PDF. Statements come in Russian, Kyrgyz or English —
+any of them works, and importing the same statement in more than one language does not
+create duplicates.
+
+## Supported file format
+
+- `.pdf` card statement ("ВЫПИСКА ПО КАРТЕ" / "КАРТА БОЮНЧА КӨЧҮРМӨ" / "CARD STATEMENT")
+  as produced by Simbank. One card / one currency per file.
+- Multiple files can be selected at once — files for the same card are merged.
+
+## How it works
+
+1. `ZenMoney.pickDocuments` lets the user pick the statement file(s).
+2. `parser-pdf.ts` extracts the PDF text (`common/pdfUtils.parsePdf`) and reads, by
+   label, the masked card number, currency, end-of-period balance, the credit limit
+   (`Сумма установленного лимита`) and the amount owed (`Сумма использованного лимита`),
+   then the transaction table (`Дата | Детали операции | Сумма | Плата за кредит | Баланс после операции`).
+   Each row's date and time sit on their own lines and the description may wrap, so
+   the parser is a small line-based state machine: a `DD-MM-YYYY` + `HH:MM:SS` pair
+   begins a row, and following lines accumulate as the description until the line that
+   ends with the signed amount, the credit-fee dash and the running balance.
+3. `converters.ts` maps each row to a ZenMoney `Transaction`:
+   - the "Сумма" column is already signed (expense negative, income positive);
+   - the "Плата за кредит" column is usually "-" (no fee → `fee: 0`); when it carries a
+     number it's an informational credit fee that doesn't move the running balance;
+   - the description becomes the merchant, except service rows (`Simbank` fees,
+     `Регулярный платеж`, `Округление баланса`, `Процент на остаток`) which are kept
+     as a comment with no merchant.
+
+### Account / credit card
+
+The account `balance` is the **own-funds** balance — the `Баланс после операции` of the
+latest transaction (negative = debt to the bank). It's read from the table, not from the
+header's `Остаток на конец периода` (which is the *available* balance = own funds + credit
+limit), so it's language-independent. When a credit limit is set the account is a **credit
+card**: `creditLimit` from `Сумма установленного лимита`, `totalAmountDue` the amount owed
+(`Сумма использованного лимита`, else `max(0, −balance)`); Zenmoney then shows
+available = `balance + creditLimit`. With no limit it's a plain `checking` account. The
+limit is read per-statement, so if it changes or is disabled, the freshest imported
+statement wins (`mergeStatements`).
+
+### Transaction ids
+
+The statement has no operation-reference column, so each movement id is a
+**deterministic hash** (`cyrb53`) of the raw row
+(`card | date-time | amount | balance | description`). The id is stable across
+re-exports, which keeps deduplication working between syncs.
+
+### Sync behaviour
+
+Each statement file holds a single card. The plugin imports **everything in the
+picked file** on every run:
+
+- no first-run "accounts only" gate — transactions come on the very first run;
+- no `fromDate` window — a manually chosen statement is imported in full. (The
+  `startDate` preference is kept only because the platform requires it; it does not
+  restrict what is imported.)
+
+Re-importing the same (or an overlapping) file is safe: movements are deduplicated
+by their deterministic id, and statements for the same card are merged into one
+account (freshest balance wins).
+
+## Tests
+
+```
+yarn jest simbank-kg     # tests
+yarn test simbank-kg     # typecheck + lint + tests
+yarn start simbank-kg    # browser dev-harness
+```
+
+Tests run on an inline, anonymized fixture (`__tests__/parseStatementText.test.ts`)
+plus table-driven converter cases (`__tests__/converters.test.ts`) — no real
+statement file (which contains personal data) is committed.

--- a/src/plugins/simbank-kg/ZenmoneyManifest.xml
+++ b/src/plugins/simbank-kg/ZenmoneyManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>simbank-kg</id>
+    <version>1.0</version>
+    <build>1</build>
+    <company>0</company>
+    <modular>true</modular>
+    <codeRequired>false</codeRequired>
+    <api>public</api>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <description>Импорт выписки Simbank (Кыргызстан) из файла .pdf. Как получить файл: в мобильном приложении Simbank откройте настройки карты и нажмите «Выписка по карте», сохраните PDF (русский, кыргызский или английский — подойдёт любой) и выберите его здесь. Можно выбрать сразу несколько файлов; они обрабатываются локально на устройстве.</description>
+</provider>

--- a/src/plugins/simbank-kg/__tests__/api.test.ts
+++ b/src/plugins/simbank-kg/__tests__/api.test.ts
@@ -1,0 +1,46 @@
+import { TemporaryError } from '../../../errors'
+import { parseSimbankStatementFromFiles, validateDocuments } from '../api'
+
+const blob = (size: number, type: string): Blob => ({ size, type } as unknown as Blob)
+const reader = (text: string): (() => Promise<{ text: string }>) => async () => ({ text })
+
+describe('validateDocuments', () => {
+  it('accepts pdf and (Android) empty MIME types', () => {
+    expect(() => validateDocuments([blob(1000, 'application/pdf'), blob(1000, '')])).not.toThrow()
+  })
+
+  it('rejects a non-pdf type', () => {
+    expect(() => validateDocuments([blob(1000, 'text/plain')])).toThrow(TemporaryError)
+  })
+
+  it('rejects an oversized file', () => {
+    expect(() => validateDocuments([blob(5 * 1000 * 1000, 'application/pdf')])).toThrow(TemporaryError)
+  })
+})
+
+describe('parseSimbankStatementFromFiles', () => {
+  const minimalStatement = [
+    'Simbank',
+    'Номер карты клиента :  402183****0412',
+    '21-12-2025',
+    '09:00:00',
+    'Grab -10,00 - 90,00'
+  ].join('\n')
+
+  it('parses a readable Simbank statement', async () => {
+    const result = await parseSimbankStatementFromFiles([blob(1000, 'application/pdf')], reader(minimalStatement))
+    expect(result).not.toBeNull()
+    expect(result?.[0].account.id).toBe('402183****0412')
+    expect(result?.[0].transactions).toHaveLength(1)
+  })
+
+  it('wraps a non-Simbank / unparsable file as a user-facing TemporaryError', async () => {
+    let thrown: unknown = null
+    try {
+      await parseSimbankStatementFromFiles([blob(1000, 'application/pdf')], reader('just some random pdf text'))
+    } catch (e) {
+      thrown = e
+    }
+    expect(thrown).toBeInstanceOf(TemporaryError)
+  })
+})

--- a/src/plugins/simbank-kg/__tests__/converters.test.ts
+++ b/src/plugins/simbank-kg/__tests__/converters.test.ts
@@ -1,0 +1,81 @@
+import { convertTransaction, parseFormattedNumber, parseOperation, parseSimbankDate, signedSum } from '../converters'
+import { SimbankStatementTransaction } from '../models'
+
+describe('parseFormattedNumber', () => {
+  it.each([
+    ['47 090,52', 47090.52],
+    ['-579,48', -579.48],
+    ['+0,01', 0.01],
+    ['-3 282,84', -3282.84],
+    ['-1 338,20', -1338.20],
+    ['198 661,80', 198661.80],
+    ['−1 338,20', -1338.20], // U+2212 minus sign
+    ['–2 688,44', -2688.44] // en dash
+  ])('parses %s → %s', (input, expected) => {
+    expect(parseFormattedNumber(input)).toBe(expected)
+  })
+
+  it('returns NaN for empty', () => {
+    expect(parseFormattedNumber('')).toBeNaN()
+    expect(parseFormattedNumber('-')).toBeNaN()
+  })
+})
+
+describe('signedSum', () => {
+  it('keeps the printed sign', () => {
+    expect(signedSum('-579,48')).toBe(-579.48)
+    expect(signedSum('+0,01')).toBe(0.01)
+  })
+})
+
+describe('parseSimbankDate', () => {
+  it('combines date and time', () => {
+    expect(parseSimbankDate('21-12-2025', '09:49:14')).toBe('2025-12-21T09:49:14.000')
+  })
+
+  it('defaults the time when missing', () => {
+    expect(parseSimbankDate('21-06-2026')).toBe('2026-06-21T00:00:00.000')
+  })
+
+  it('throws on a bad date', () => {
+    expect(() => parseSimbankDate('nonsense')).toThrow()
+  })
+})
+
+describe('parseOperation', () => {
+  it('treats a plain name as a merchant', () => {
+    expect(parseOperation('PADINI CONCEPT STORE')).toEqual({
+      merchant: { fullTitle: 'PADINI CONCEPT STORE', mcc: null, location: null },
+      comment: null
+    })
+  })
+
+  it.each([
+    'Simbank',
+    'Регулярный платеж "Пу-пу-пу"',
+    'Округление баланса "Пу-пу-пу"',
+    'Процент на остаток личных средств'
+  ])('treats service row "%s" as a comment', (desc) => {
+    expect(parseOperation(desc)).toEqual({ merchant: null, comment: desc })
+  })
+})
+
+describe('convertTransaction', () => {
+  const raw = (amount: string, description: string): SimbankStatementTransaction => ({
+    date: '2025-12-21T09:49:14.000', amount, balance: '47 090,52', description, uid: 'u1', originString: ''
+  })
+
+  it('produces a single non-transfer movement', () => {
+    const { transaction } = convertTransaction('402183****0412', raw('-579,48', 'SB061'))
+    expect(transaction.movements).toHaveLength(1)
+    expect(transaction.movements[0]).toEqual({
+      id: 'u1',
+      account: { id: '402183****0412' },
+      invoice: null,
+      sum: -579.48,
+      fee: 0
+    })
+    expect(transaction.hold).toBe(false)
+    expect(transaction.date).toEqual(new Date('2025-12-21T09:49:14.000'))
+  })
+})

--- a/src/plugins/simbank-kg/__tests__/mergeStatements.test.ts
+++ b/src/plugins/simbank-kg/__tests__/mergeStatements.test.ts
@@ -1,0 +1,71 @@
+import { mergeStatements } from '../converters'
+import { SimbankStatementAccount, SimbankStatementTransaction } from '../models'
+import { AccountOrCard, AccountType } from '../../../types/zenmoney'
+
+const account = (id: string, date: string, balance: number, creditLimit: number | null = null, usedLimit: number | null = null): SimbankStatementAccount => ({
+  id, title: 'Simbank *' + id.slice(-4), balance, creditLimit, usedLimit, instrument: 'KGS', date
+})
+
+const tx = (uid: string, amount: string): SimbankStatementTransaction => ({
+  date: '2025-12-21T10:00:00.000', amount, balance: '0,00', description: 'op', uid, originString: ''
+})
+
+describe('mergeStatements', () => {
+  it('returns nothing for null', () => {
+    expect(mergeStatements(null)).toEqual({ accounts: [], transactions: [] })
+  })
+
+  it('merges several files of the SAME card into one (no duplicate-id crash)', () => {
+    const result = mergeStatements([
+      { account: account('402183****0412', '2026-06-10T00:00:00.000', 100), transactions: [tx('a', '-10,00')] },
+      { account: account('402183****0412', '2026-06-21T00:00:00.000', 200), transactions: [tx('b', '-20,00')] }
+    ])
+    expect(result.accounts).toHaveLength(1)
+    expect(new Set(result.accounts.map(a => a.id)).size).toBe(1)
+    // freshest statement wins the balance
+    expect(result.accounts[0].balance).toBe(200)
+    expect(result.transactions).toHaveLength(2)
+  })
+
+  it('deduplicates overlapping rows across files by movement id', () => {
+    const result = mergeStatements([
+      { account: account('402183****0412', '2026-06-10T00:00:00.000', 100), transactions: [tx('a', '-10,00'), tx('b', '-20,00')] },
+      { account: account('402183****0412', '2026-06-21T00:00:00.000', 200), transactions: [tx('a', '-10,00'), tx('b', '-20,00'), tx('c', '-30,00')] }
+    ])
+    expect(result.accounts).toHaveLength(1)
+    expect(result.transactions).toHaveLength(3)
+    expect(result.transactions.map(t => t.movements[0].id).sort((a, b) => (a ?? '').localeCompare(b ?? ''))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps distinct cards separate', () => {
+    const result = mergeStatements([
+      { account: account('402183****0412', '2026-06-21T00:00:00.000', 200), transactions: [tx('a', '-10,00')] },
+      { account: account('555555****9999', '2026-06-21T00:00:00.000', 50), transactions: [tx('x', '-5,00')] }
+    ])
+    expect(result.accounts).toHaveLength(2)
+    expect(new Set(result.accounts.map(a => a.id)).size).toBe(2)
+  })
+
+  it('takes the credit limit from the freshest statement (limit may change)', () => {
+    const result = mergeStatements([
+      { account: account('402183****0412', '2026-05-31T00:00:00.000', -1338.20, 200000), transactions: [tx('a', '-10,00')] },
+      { account: account('402183****0412', '2026-06-21T00:00:00.000', -50000, 100000), transactions: [tx('b', '-20,00')] }
+    ])
+    expect(result.accounts).toHaveLength(1)
+    const acc = result.accounts[0] as AccountOrCard
+    expect(acc.type).toBe(AccountType.ccard)
+    expect(acc.creditLimit).toBe(100000) // freshest statement's limit
+    expect(acc.balance).toBe(-50000) // own funds from the freshest statement
+  })
+
+  it('falls back to a checking account when the freshest statement has no limit (disabled)', () => {
+    const result = mergeStatements([
+      { account: account('402183****0412', '2026-05-31T00:00:00.000', 198661.80, 200000), transactions: [tx('a', '-10,00')] },
+      { account: account('402183****0412', '2026-06-21T00:00:00.000', 1234.00, null), transactions: [tx('b', '-20,00')] }
+    ])
+    const acc = result.accounts[0] as AccountOrCard
+    expect(acc.type).toBe(AccountType.checking)
+    expect(acc.creditLimit).toBeUndefined()
+    expect(acc.balance).toBe(1234.00)
+  })
+})

--- a/src/plugins/simbank-kg/__tests__/parseStatementText.test.ts
+++ b/src/plugins/simbank-kg/__tests__/parseStatementText.test.ts
@@ -1,0 +1,207 @@
+import { collapseLetterSpacing, looksLikeSimbankStatement, parseStatementText } from '../parser-pdf'
+import { convertAccount, convertTransactions } from '../converters'
+import { AccountType } from '../../../types/zenmoney'
+
+// Anonymized copy of a real statement layout, mirroring the text `parsePdf` (pdfjs)
+// produces: "Label :  value" prefixes, letter-spaced glyph runs (currency, some
+// merchant names), the per-page header that repeats, a wrapped description, a
+// positive amount and a negative running balance.
+const TEXT = [
+  'ВЫПИСКА ПО КАРТЕ',
+  'Период :  21-12-2025 - 21-06-2026',
+  'Номер карты клиента :  402183****0412',
+  'Имя клиента :  Иван Иванов',
+  'Валюта :  K G S',
+  'Остаток на начало периода :  2 4 7   0 9 0 , 5 2   K G S',
+  'Остаток на конец периода :  1 9 8   6 6 1 , 8 0   K G S',
+  'Сумма установленного лимита :  2 0 0   0 0 0 , 0 0   K G S',
+  'Сумма использованного лимита :  1   3 3 8 , 2 0   K G S',
+  'Дата Детали операции Сумма',
+  'Плата за',
+  'кредит',
+  'Баланс после',
+  'операции',
+  '21-12-2025',
+  '09:49:14',
+  'SB061-BBCC (LALA P -579,48 - 47 090,52',
+  '21-12-2025',
+  '09:49:18',
+  'Simbank -0,52 - 47 090,00',
+  '21-12-2025',
+  '11:54:01',
+  'Регулярный',
+  'платеж "Пу-пу-пу"',
+  '-100,00 - 46 520,01',
+  '22-12-2025',
+  '21:50:40',
+  'Самат Дербишалиев +0,01 - 26 390,01',
+  '18-06-2026',
+  '11:46:29',
+  'G r a b -2 688,44 - -418,44',
+  '21-06-2026',
+  '04:49:58',
+  'P A D I N I   C O N C E P T   S T O R E -6 621,00 - -1 338,20'
+].join('\n')
+
+describe('collapseLetterSpacing', () => {
+  it('collapses letter-spaced runs while keeping word gaps', () => {
+    expect(collapseLetterSpacing('G r a b')).toBe('Grab')
+    expect(collapseLetterSpacing('P A D I N I   C O N C E P T   S T O R E')).toBe('PADINI CONCEPT STORE')
+    expect(collapseLetterSpacing('K   M A R K E T   M O N A R C H Y   D N')).toBe('K MARKET MONARCHY DN')
+  })
+
+  it('leaves normal text (single-spaced real words) untouched', () => {
+    expect(collapseLetterSpacing('SB061-BBCC (LALA P')).toBe('SB061-BBCC (LALA P')
+    expect(collapseLetterSpacing('VTS Netflix.com')).toBe('VTS Netflix.com')
+    expect(collapseLetterSpacing('Самат Дербишалиев')).toBe('Самат Дербишалиев')
+  })
+
+  it('does not collapse a name that merely has single-letter words', () => {
+    // Mixed tokens (not every token is a single char) → keep as-is, never "KFCBISHKEK".
+    expect(collapseLetterSpacing('K F C BISHKEK')).toBe('K F C BISHKEK')
+    expect(collapseLetterSpacing('H & M - LOT 10')).toBe('H & M - LOT 10')
+  })
+})
+
+describe('parseStatementText', () => {
+  it('recognizes a Simbank statement', () => {
+    expect(looksLikeSimbankStatement(TEXT)).toBe(true)
+    expect(looksLikeSimbankStatement('hello world')).toBe(false)
+  })
+
+  it('parses account metadata (letter-spaced balance/currency/limit)', () => {
+    const { account } = parseStatementText(TEXT)
+    expect(account).toEqual({
+      id: '402183****0412',
+      title: 'Simbank *0412',
+      balance: -1338.20, // own funds = "Баланс после операции" of the latest row
+      creditLimit: 200000,
+      usedLimit: 1338.20,
+      instrument: 'KGS',
+      date: '2026-06-21T00:00:00.000'
+    })
+  })
+
+  it('parses transaction rows (skips header noise, joins wrapped/letter-spaced descriptions)', () => {
+    const { transactions } = parseStatementText(TEXT)
+    expect(transactions).toHaveLength(6)
+    expect(transactions.map(t => [t.date, t.description, t.amount, t.balance])).toEqual([
+      ['2025-12-21T09:49:14.000', 'SB061-BBCC (LALA P', '-579,48', '47090,52'],
+      ['2025-12-21T09:49:18.000', 'Simbank', '-0,52', '47090,00'],
+      ['2025-12-21T11:54:01.000', 'Регулярный платеж "Пу-пу-пу"', '-100,00', '46520,01'],
+      ['2025-12-22T21:50:40.000', 'Самат Дербишалиев', '+0,01', '26390,01'],
+      ['2026-06-18T11:46:29.000', 'Grab', '-2688,44', '-418,44'],
+      ['2026-06-21T04:49:58.000', 'PADINI CONCEPT STORE', '-6621,00', '-1338,20']
+    ])
+  })
+
+  it('keeps a money-shaped token inside the description (no column shift)', () => {
+    const text = [
+      'ВЫПИСКА ПО КАРТЕ',
+      'Simbank',
+      'Период :  21-12-2025 - 21-06-2026',
+      'Номер карты клиента :  402183****0412',
+      'Валюта :  K G S',
+      'Остаток на конец периода :  900,00 KGS',
+      '21-12-2025',
+      '09:00:00',
+      'Fuel 35,50 -100,00 - 900,00'
+    ].join('\n')
+    const { transactions } = parseStatementText(text)
+    expect(transactions).toHaveLength(1)
+    expect([transactions[0].description, transactions[0].amount, transactions[0].balance]).toEqual(['Fuel 35,50', '-100,00', '900,00'])
+  })
+
+  it('parses the credit-fee column without dropping the row', () => {
+    const text = [
+      'ВЫПИСКА ПО КАРТЕ',
+      'Simbank',
+      'Период :  21-12-2025 - 21-06-2026',
+      'Номер карты клиента :  402183****0412',
+      'Остаток на конец периода :  -54 169,93 KGS',
+      '26-05-2026',
+      '11:12:47',
+      'Эльвира М. -7 416,00 216,00 -54 169,93'
+    ].join('\n')
+    const { transactions } = parseStatementText(text)
+    expect(transactions).toHaveLength(1)
+    expect([transactions[0].description, transactions[0].amount, transactions[0].balance]).toEqual(['Эльвира М.', '-7416,00', '-54169,93'])
+  })
+
+  it('refuses the import when a dated row cannot be parsed (no silent loss)', () => {
+    const text = [
+      'ВЫПИСКА ПО КАРТЕ',
+      'Simbank',
+      'Период :  21-12-2025 - 21-06-2026',
+      'Номер карты клиента :  402183****0412',
+      'Остаток на конец периода :  100,00 KGS',
+      '21-12-2025',
+      '09:00:00',
+      'Some operation with no parsable amount column'
+    ].join('\n')
+    expect(() => parseStatementText(text)).toThrow()
+  })
+
+  it('takes the account balance from the latest transaction (own funds)', () => {
+    const text = [
+      'Simbank',
+      'Период :  21-12-2025 - 21-06-2026',
+      'Номер карты клиента :  402183****0412',
+      '21-12-2025',
+      '09:00:00',
+      'Grab -10,00 - 90,00',
+      '22-12-2025',
+      '09:00:00',
+      'Grab -40,00 - 50,00'
+    ].join('\n')
+    const { account } = parseStatementText(text)
+    expect(account.balance).toBe(50.00)
+  })
+
+  it('gives a row the same movement id regardless of description language', () => {
+    const make = (desc: string): string => [
+      'Simbank',
+      'Номер карты клиента :  402183****0412',
+      '21-12-2025',
+      '09:00:00',
+      `${desc} -100,00 - 90,00`
+    ].join('\n')
+    const ru = parseStatementText(make('Регулярный платеж "Пу-пу-пу"'))
+    const ky = parseStatementText(make('Туруктуу төлөм "Пу-пу-пу"'))
+    expect(ru.transactions[0].description).not.toBe(ky.transactions[0].description)
+    // ...but the dedup id matches, so importing the same statement in two languages
+    // doesn't double the transactions.
+    expect(ru.transactions[0].uid).toBe(ky.transactions[0].uid)
+  })
+
+  it('builds stable, unique movement ids', () => {
+    const { transactions } = parseStatementText(TEXT)
+    const uids = transactions.map(t => t.uid)
+    expect(new Set(uids).size).toBe(uids.length)
+    // Re-parsing the same text yields identical ids.
+    expect(parseStatementText(TEXT).transactions.map(t => t.uid)).toEqual(uids)
+  })
+
+  it('converts to ZenMoney account and transactions with correct signs', () => {
+    const { account, transactions } = parseStatementText(TEXT)
+    const zenAccount = convertAccount(account)
+    expect(zenAccount.syncIds).toEqual(['402183****0412'])
+    // Credit card: own funds = available - limit (negative = debt to bank).
+    expect(zenAccount.type).toBe(AccountType.ccard)
+    expect(zenAccount.balance).toBe(-1338.20)
+    expect(zenAccount.creditLimit).toBe(200000)
+    expect(zenAccount.totalAmountDue).toBe(1338.20)
+
+    const converted = convertTransactions(account.id, transactions)
+    const sums = converted.map(t => t.transaction.movements[0].sum)
+    expect(sums).toEqual([-579.48, -0.52, -100, 0.01, -2688.44, -6621])
+    // Real merchant vs service-row comment classification.
+    const merchant = converted[0].transaction.merchant
+    expect(merchant != null && 'fullTitle' in merchant ? merchant.fullTitle : null).toBe('SB061-BBCC (LALA P')
+    expect(converted[1].transaction.merchant).toBeNull()
+    expect(converted[1].transaction.comment).toBe('Simbank')
+    expect(converted[2].transaction.merchant).toBeNull()
+    expect(converted[2].transaction.comment).toBe('Регулярный платеж "Пу-пу-пу"')
+    expect(converted[4].transaction.movements[0].fee).toBe(0)
+  })
+})

--- a/src/plugins/simbank-kg/api.ts
+++ b/src/plugins/simbank-kg/api.ts
@@ -1,0 +1,61 @@
+import { TemporaryError } from '../../errors'
+import { parsePdf } from '../../common/pdfUtils'
+
+import { RawAccountAndTransactions } from './models'
+import { parseSimbankStatements } from './parser-pdf'
+
+const SUPPORTED_MIME_TYPES = ['application/pdf']
+
+export async function pickStatementDocuments (): Promise<Blob[]> {
+  const blobs = await ZenMoney.pickDocuments(SUPPORTED_MIME_TYPES, true)
+
+  if (blobs.length === 0) {
+    throw new TemporaryError('Выберите PDF-выписку Simbank. Получить её можно в приложении Simbank: настройки карты → «Выписка по карте».')
+  }
+  return blobs
+}
+
+export function validateDocuments (blobs: Blob[]): void {
+  for (const { size, type } of blobs) {
+    // Android pickers often report an empty MIME type — accept it and let the
+    // parser decide. Reject only clearly unsupported, non-empty types.
+    if (type !== '' && !SUPPORTED_MIME_TYPES.includes(type)) {
+      throw new TemporaryError('Файл должен быть в формате .pdf')
+    }
+    if (size >= 5 * 1000 * 1000) {
+      throw new TemporaryError('Максимальный размер файла — 5 МБ')
+    }
+  }
+}
+
+export async function readPdfTextsSequentially (
+  blobs: Blob[],
+  readPdf: typeof parsePdf = parsePdf
+): Promise<string[]> {
+  const texts: string[] = []
+  for (const blob of blobs) {
+    const { text } = await readPdf(blob)
+    texts.push(text)
+  }
+  return texts
+}
+
+export async function parseSimbankStatementFromFiles (
+  blobs: Blob[],
+  readPdf: typeof parsePdf = parsePdf
+): Promise<RawAccountAndTransactions | null> {
+  validateDocuments(blobs)
+
+  try {
+    const texts = await readPdfTextsSequentially(blobs, readPdf)
+    const statements = parseSimbankStatements(texts)
+    return statements.length > 0 ? statements : null
+  } catch (e) {
+    if (e instanceof TemporaryError) {
+      throw e
+    }
+    // Surface unreadable-PDF and parser ("not a Simbank statement", layout drift)
+    // failures to the user with their message, like mbank-kg / kaspi do.
+    throw new TemporaryError(e instanceof Error && e.message !== '' ? e.message : 'Не удалось обработать файл выписки Simbank')
+  }
+}

--- a/src/plugins/simbank-kg/converters.ts
+++ b/src/plugins/simbank-kg/converters.ts
@@ -1,0 +1,207 @@
+import { uniqBy } from 'lodash'
+
+import { Account, AccountOrCard, AccountType, NonParsedMerchant, Transaction } from '../../types/zenmoney'
+import { RawAccountAndTransactions, SimbankStatementAccount, SimbankStatementTransaction, TransactionWithId } from './models'
+import { assert } from './lib/assert'
+
+/**
+ * Parse a number printed in the KGS locale of the statement ("47 090,52" — space
+ * thousands, comma decimal). The leading sign (printed as "+"/"-") is preserved.
+ */
+export function parseFormattedNumber (value: string): number {
+  // Treat any minus-like glyph (ASCII "-", U+2212, en/em dashes) as a sign.
+  const normalized = value.replace(/[\u2012\u2013\u2014\u2015\u2212]/g, '-')
+  const negative = normalized.includes('-')
+  const cleaned = normalized
+    .trim()
+    .replace(/[^\d,.]/g, '') // strip everything except digits, dot, comma
+    .replace(/[.,](?=.*[.,])/g, '') // drop every thousands sep → leave last one as decimal
+    .replace(',', '.') // decimal comma → dot
+
+  if (cleaned === '' || cleaned === '.') {
+    return NaN
+  }
+  const n = parseFloat(cleaned)
+  return negative ? -n : n
+}
+
+/** "21-12-2025" + "09:49:14" → ISO local string. Either part may be omitted. */
+export function parseSimbankDate (date: string, time = ''): string {
+  const match = date.trim().match(/^(\d{2})-(\d{2})-(\d{4})$/)
+  assert(match !== null, 'Can\'t parse date from Simbank statement', date)
+  const [, dd, mm, yyyy] = match
+  const timeMatch = time.trim().match(/^(\d{2}):(\d{2}):(\d{2})$/)
+  const hh = timeMatch?.[1] ?? '00'
+  const mi = timeMatch?.[2] ?? '00'
+  const ss = timeMatch?.[3] ?? '00'
+  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}.000`
+}
+
+/**
+ * Deterministic, re-export-stable hash (cyrb53). Built from the RAW row so the
+ * id never changes when the merchant/comment parser changes.
+ */
+export function cyrb53 (str: string, seed = 0): number {
+  let h1 = 0xdeadbeef ^ seed
+  let h2 = 0x41c6ce57 ^ seed
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i)
+    h1 = Math.imul(h1 ^ ch, 2654435761)
+    h2 = Math.imul(h2 ^ ch, 1597334677)
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507)
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909)
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507)
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909)
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0)
+}
+
+export function makeTransactionUid (
+  accountId: string,
+  dateTime: string,
+  amount: string,
+  balance: string,
+  occurrence = 0
+): string {
+  // The running "Баланс после операции" is a near-unique per-row fingerprint, so the id
+  // is built from card + date-time + amount + balance and deliberately EXCLUDES the
+  // description — which the bank localizes (Russian/Kyrgyz/English). That keeps the same
+  // operation deduplicated even when the same statement is imported in two languages.
+  const parts = [accountId, dateTime, amount, balance]
+  // Disambiguate genuinely identical rows (same second/amount/balance) so uniqBy()
+  // doesn't collapse them. Order is deterministic, so the Nth duplicate keeps the same
+  // id across re-exports.
+  if (occurrence > 0) {
+    parts.push('#' + String(occurrence))
+  }
+  return `${accountId}#${cyrb53(parts.join('|')).toString(16)}`
+}
+
+/** The signed "Сумма" cell already carries its sign. */
+export function signedSum (amount: string): number {
+  const n = parseFormattedNumber(amount)
+  return isNaN(n) ? 0 : n
+}
+
+function makeMerchant (fullTitle: string): NonParsedMerchant {
+  return { fullTitle: fullTitle.trim(), mcc: null, location: null }
+}
+
+// Service / internal rows that are not a real merchant — kept as a comment.
+// Anchored at the start so a real merchant merely containing one of these phrases
+// isn't misclassified; "Simbank" must match the fee row exactly.
+const SERVICE_DESCRIPTION_REGEX = /^Simbank$|^(?:Регулярный платеж|Округление баланса|Процент на остаток)/i
+
+interface ParsedOperation {
+  merchant: NonParsedMerchant | null
+  comment: string | null
+}
+
+/** Classify the free-text "Детали операции" column. */
+export function parseOperation (description: string): ParsedOperation {
+  const desc = description.replace(/\s+/g, ' ').trim()
+  if (desc === '') {
+    return { merchant: null, comment: null }
+  }
+  if (SERVICE_DESCRIPTION_REGEX.test(desc)) {
+    return { merchant: null, comment: desc }
+  }
+  return { merchant: makeMerchant(desc), comment: null }
+}
+
+/** Round to 2 decimals, killing float noise from the limit subtraction. */
+function round2 (n: number): number {
+  return Math.round(n * 100) / 100
+}
+
+export function convertAccount (raw: SimbankStatementAccount): AccountOrCard {
+  // raw.balance is already the own-funds balance (negative = debt). When a credit
+  // limit is set, report it as a credit card so Zenmoney shows
+  // available = balance + creditLimit and the amount owed.
+  const isCredit = raw.creditLimit != null && raw.creditLimit > 0
+  const balance = round2(raw.balance)
+
+  // Amount owed: prefer the bank's "Сумма использованного лимита", else the debt
+  // implied by a negative own-funds balance. Only meaningful for a credit card.
+  const totalAmountDue = isCredit
+    ? round2(raw.usedLimit ?? Math.max(0, -balance))
+    : undefined
+
+  return {
+    id: raw.id,
+    type: isCredit ? AccountType.ccard : AccountType.checking,
+    title: raw.title,
+    instrument: raw.instrument,
+    balance,
+    creditLimit: isCredit ? raw.creditLimit : undefined,
+    totalAmountDue,
+    // Match on the full masked PAN, not just the last 4 — another card ending in the
+    // same 4 digits would otherwise be merged into this account.
+    syncIds: [raw.id]
+  }
+}
+
+export function convertTransaction (accountId: string, raw: SimbankStatementTransaction): TransactionWithId {
+  const sum = signedSum(raw.amount)
+  const { merchant, comment } = parseOperation(raw.description)
+
+  const transaction: Transaction = {
+    hold: false,
+    date: new Date(raw.date),
+    merchant,
+    comment,
+    movements: [
+      {
+        id: raw.uid,
+        account: { id: accountId },
+        invoice: null,
+        sum,
+        fee: 0
+      }
+    ]
+  }
+
+  return { uid: raw.uid, transaction }
+}
+
+export function convertTransactions (accountId: string, rawTransactions: SimbankStatementTransaction[]): TransactionWithId[] {
+  return rawTransactions.map(raw => convertTransaction(accountId, raw))
+}
+
+/**
+ * Merge parsed statements into the ZenMoney result.
+ *
+ * Several picked files may belong to the same account (e.g. overlapping
+ * periods), so accounts are merged by id (freshest balance wins) — emitting two
+ * accounts with the same id would crash the app. Pooled rows then dedup by their
+ * stable movement id, so re-importing the same or an overlapping file is safe.
+ */
+export function mergeStatements (statements: RawAccountAndTransactions | null): { accounts: Account[], transactions: Transaction[] } {
+  const accounts: Account[] = []
+  const transactions: TransactionWithId[] = []
+
+  if (statements !== null) {
+    const byAccountId = new Map<string, { account: SimbankStatementAccount, transactions: SimbankStatementTransaction[] }>()
+    for (const { account, transactions: rows } of statements) {
+      const existing = byAccountId.get(account.id)
+      if (existing == null) {
+        byAccountId.set(account.id, { account, transactions: [...rows] })
+      } else {
+        existing.transactions.push(...rows)
+        if (account.date > existing.account.date) {
+          existing.account = account
+        }
+      }
+    }
+
+    for (const { account: rawAccount, transactions: rawTransactions } of byAccountId.values()) {
+      accounts.push(convertAccount(rawAccount))
+      transactions.push(...convertTransactions(rawAccount.id, rawTransactions))
+    }
+  }
+
+  return {
+    accounts,
+    transactions: uniqBy(transactions, x => x.uid).map(x => x.transaction)
+  }
+}

--- a/src/plugins/simbank-kg/index.ts
+++ b/src/plugins/simbank-kg/index.ts
@@ -1,0 +1,14 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+
+import { Preferences } from './models'
+import { mergeStatements } from './converters'
+import { parseSimbankStatementFromFiles, pickStatementDocuments } from './api'
+
+export const scrape: ScrapeFunc<Preferences> = async () => {
+  const blobs = await pickStatementDocuments()
+  const statements = await parseSimbankStatementFromFiles(blobs)
+
+  // Manual file import: emit the whole picked statement(s) — no fromDate window,
+  // no first-run gate. The user picks the file once and gets exactly what is in it.
+  return mergeStatements(statements)
+}

--- a/src/plugins/simbank-kg/lib/assert.ts
+++ b/src/plugins/simbank-kg/lib/assert.ts
@@ -1,0 +1,11 @@
+export function assert (
+  condition: unknown,
+  message = 'Assertion failed',
+  ...ctx: unknown[]
+): asserts condition {
+  if (condition !== true) {
+    // Extra context lands in console but isn't string-coerced into the Error.
+    if (ctx.length > 0) console.error(message, ...ctx)
+    throw new Error(message)
+  }
+}

--- a/src/plugins/simbank-kg/models.ts
+++ b/src/plugins/simbank-kg/models.ts
@@ -1,0 +1,48 @@
+import { Transaction } from '../../types/zenmoney'
+
+export interface SimbankStatementAccount {
+  id: string
+  title: string
+  /**
+   * Own-funds balance = the "Баланс после операции" of the last transaction (negative
+   * = debt to the bank). Taken from the table, not a header label, so it's
+   * language-independent. available = balance + creditLimit (see convertAccount).
+   */
+  balance: number
+  /** Established credit/overdraft limit ("Сумма установленного лимита"), or null if none. */
+  creditLimit: number | null
+  /** Amount of the limit currently owed ("Сумма использованного лимита"), or null. */
+  usedLimit: number | null
+  instrument: string
+  /** Statement period-end date in ISO form (informational). */
+  date: string
+}
+
+export interface SimbankStatementTransaction {
+  /** ISO date-time, e.g. '2025-12-21T09:49:14.000' */
+  date: string
+  /** Raw "Сумма" cell as printed (already signed, e.g. '-579,48' or '+0,01'). */
+  amount: string
+  /** Raw "Баланс после операции" cell as printed (e.g. '47 090,52', '-1 232,84'). */
+  balance: string
+  /** Raw "Детали операции" text (may have spanned several lines in the PDF). */
+  description: string
+  /** Deterministic, re-export-stable id (hash of the raw row). */
+  uid: string
+  /** Raw row joined for debugging / hashing provenance. */
+  originString: string
+}
+
+export interface TransactionWithId {
+  transaction: Transaction
+  uid: string
+}
+
+export interface Preferences {
+  startDate: string
+}
+
+export type RawAccountAndTransactions = Array<{
+  account: SimbankStatementAccount
+  transactions: SimbankStatementTransaction[]
+}>

--- a/src/plugins/simbank-kg/parser-pdf.ts
+++ b/src/plugins/simbank-kg/parser-pdf.ts
@@ -1,0 +1,268 @@
+import { SimbankStatementAccount, SimbankStatementTransaction } from './models'
+import { makeTransactionUid, parseFormattedNumber, parseSimbankDate } from './converters'
+import { assert } from './lib/assert'
+
+const DATE_RE = /^\d{2}-\d{2}-\d{4}$/
+const TIME_RE = /^\d{2}:\d{2}:\d{2}$/
+
+/**
+ * The final line of a row is space-separated as
+ *   "<description> <signed Сумма> <Плата за кредит> <Баланс после операции>"
+ * "Плата за кредит" is usually "-" (no credit fee) but carries a number when the
+ * balance is in credit ("Эльвира М. -7 416,00 216,00 -54 169,93"). That fee does
+ * NOT move the running balance (balance = previous + Сумма), so it is informational.
+ * Balances may be negative. Amounts use space thousands separators.
+ *   "SB061-BBCC (LALA P -579,48 - 47 090,52" → desc, "-579,48", fee "-", "47 090,52"
+ *   "-100,00 - 46 520,01"                    → (no desc), "-100,00", fee "-", "46 520,01"
+ *
+ * The "Сумма" column is ALWAYS signed; requiring a leading sign on the amount group
+ * fixes the description→amount boundary even when the description itself contains a
+ * money-shaped token ("Fuel 35,50 -100,00 - 900,00" → desc "Fuel 35,50").
+ */
+const ROW_TAIL_RE = /^(.*?)([+-]\d[\d ]*,\d{2})\s+(-|[+-]?\d[\d ]*,\d{2})\s+([+-]?\d[\d ]*,\d{2})$/
+
+/**
+ * pdfjs emits exotic Unicode spaces \u2014 notably U+202F (narrow no-break space) as the
+ * thousands separator and U+00A0 \u2014 which simple ` `-based char classes miss. Fold
+ * them all to a plain space, and any minus-like glyph (U+2212 etc.) to ASCII "-", so the
+ * amount/balance regexes and sign detection are reliable (newlines preserved).
+ */
+function normalizeSpaces (text: string): string {
+  return text
+    .replace(/[\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/g, ' ')
+    .replace(/[\u2012\u2013\u2014\u2015\u2212]/g, '-')
+}
+
+// Repeated per-page table-header captions (split across lines by pdfjs) to ignore
+// while scanning rows — Russian and Kyrgyz column titles.
+const HEADER_NOISE_LINES = [
+  'Дата Детали операции Сумма', 'Плата за', 'кредит', 'Баланс после', 'операции', // ru
+  'Дата Операциянын деталдары Сумма', 'Кредит', 'үчүн', 'төлөм', 'Операциядан', 'кийинки', 'баланс' // ky
+]
+const HEADER_NOISE_RE = new RegExp(`^(?:${HEADER_NOISE_LINES.join('|')})$`)
+
+const WORD_GAP = '\uffff'
+
+/**
+ * pdfjs renders some glyph runs letter-spaced ("G r a b", "K G S"): every glyph is
+ * separated by a single space and the original word gaps become runs of 2+ spaces.
+ * Detect that shape and collapse it, while leaving normal text (single spaces
+ * between real words, e.g. "SB061-BBCC (LALA P") untouched.
+ */
+export function collapseLetterSpacing (raw: string): string {
+  const parts = raw.split(' ').filter(t => t !== '')
+  if (parts.length === 0) {
+    return ''
+  }
+  // Genuine letter-spacing splits EVERY glyph (word gaps become 2+ spaces, which drop
+  // out as empty tokens). So treat it as letter-spaced only when every token is a
+  // single character — otherwise it's normal text ("K F C BISHKEK" stays intact rather
+  // than collapsing to "KFCBISHKEK").
+  const letterSpaced = parts.every(t => t.length === 1)
+  if (!letterSpaced) {
+    return raw.replace(/\s+/g, ' ').trim()
+  }
+  return raw
+    .replace(/ {2,}/g, WORD_GAP) // original word gaps → marker
+    .replace(/ /g, '') // drop inter-glyph single spaces
+    .split(WORD_GAP).join(' ')
+    .trim()
+}
+
+/** Read the rest of the line printed after a "Label : value" prefix. */
+function findField (text: string, label: RegExp): string | null {
+  // Wrap the label in a non-capturing group: a multilingual label like "Валюта|Currency"
+  // is a top-level alternation, so without grouping the ":\s*(...)" binds to the last
+  // alternative only.
+  const m = text.match(new RegExp(`(?:${label.source})\\s*:\\s*([^\\n]+)`, label.flags))
+  return m != null ? m[1].trim() : null
+}
+
+/** Read a money amount printed after a header label, NaN if absent/unparsable. */
+function parseHeaderAmount (text: string, label: RegExp): number {
+  const field = (findField(text, label) ?? '').replace(/\s+/g, '')
+  const m = field.match(/-?\d[\d.,]*/)
+  return m != null ? parseFormattedNumber(m[0]) : NaN
+}
+
+// A masked card PAN ("402183****0412", also X/•/space-masked) — same shape in every
+// statement language.
+const MASKED_PAN_RE = /\d{4,6}\s*[*X•·]{2,}\s*\d{4}/i
+
+// Header labels, accepting Russian / Kyrgyz / English wording.
+const CARD_LABEL = /Номер карты клиента|Кардардын картасынын номери|Client's Card Number/i
+const CREDIT_LIMIT_LABEL = /Сумма установленного лимита|Белгиленген лимиттин суммасы|The amount of the set credit limit/i
+const USED_LIMIT_LABEL = /Сумма использованного лимита|Пайдаланылган лимиттин суммасы|The amount of the used credit limit/i
+const CURRENCY_LABEL = /Валюта|Currency/i
+const PERIOD_LABEL = /(?:Период|Мезгил|Period)/i
+
+export function looksLikeSimbankStatement (text: string): boolean {
+  // Identify by the bank brand (present in every language) plus a card number (masked
+  // PAN or the labeled card field), rather than the localized "ВЫПИСКА ПО КАРТЕ" title —
+  // so ru/ky/en all match.
+  const isSimbank = /Simbank/i.test(text) || /Дос-?Кредобанк|Dos-?Credobank/i.test(text)
+  return isSimbank && (MASKED_PAN_RE.test(text) || CARD_LABEL.test(text))
+}
+
+/**
+ * Prefer the labeled card field (avoids grabbing some other masked number, e.g. a
+ * sender card); fall back to the first masked-PAN-shaped token in the document.
+ */
+function parseMaskedPan (text: string): string {
+  const cardField = (findField(text, CARD_LABEL) ?? '').replace(/\s+/g, '')
+  const fromLabel = cardField.match(MASKED_PAN_RE)?.[0]?.replace(/\s+/g, '') ?? (cardField !== '' ? cardField : null)
+  const fromBody = text.match(MASKED_PAN_RE)?.[0]?.replace(/\s+/g, '')
+  return fromLabel ?? fromBody ?? ''
+}
+
+/**
+ * Scan the transaction table: a "DD-MM-YYYY" + "HH:MM:SS" pair starts a row; the
+ * lines that follow are its (possibly wrapped) description until the amount/balance
+ * tail line. A dated row whose tail can't be read is recorded and then asserted on,
+ * so a layout change aborts the import rather than silently dropping a transaction.
+ */
+function parseTransactionRows (lines: string[], maskedPan: string): SimbankStatementTransaction[] {
+  const transactions: SimbankStatementTransaction[] = []
+  const seen = new Map<string, number>()
+  const skipped: string[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!DATE_RE.test(lines[i]) || i + 1 >= lines.length || !TIME_RE.test(lines[i + 1])) {
+      continue
+    }
+    const date = lines[i]
+    const time = lines[i + 1]
+
+    const descParts: string[] = []
+    let tail: RegExpMatchArray | null = null
+    let j = i + 2
+    for (; j < lines.length; j++) {
+      const cur = lines[j]
+      if (HEADER_NOISE_RE.test(cur)) {
+        continue
+      }
+      // A new row started before we found a tail — give up on this malformed row.
+      if (DATE_RE.test(cur) && j + 1 < lines.length && TIME_RE.test(lines[j + 1])) {
+        break
+      }
+      const m = cur.match(ROW_TAIL_RE)
+      if (m != null) {
+        tail = m
+        const descTail = collapseLetterSpacing(m[1])
+        if (descTail !== '') {
+          descParts.push(descTail)
+        }
+        break
+      }
+      descParts.push(collapseLetterSpacing(cur))
+    }
+
+    if (tail == null) {
+      skipped.push(`${date} ${time}`)
+      continue
+    }
+
+    const amount = tail[2].replace(/\s+/g, '')
+    const balance = tail[4].replace(/\s+/g, '')
+    const description = descParts.filter(p => p !== '').join(' ')
+    const dateTime = `${date} ${time}`
+
+    // Dedup key excludes the description (the bank localizes it) so the same operation
+    // gets the same id across ru/ky/en statements.
+    const dupKey = `${dateTime}|${amount}|${balance}`
+    const occurrence = seen.get(dupKey) ?? 0
+    seen.set(dupKey, occurrence + 1)
+
+    transactions.push({
+      date: parseSimbankDate(date, time),
+      amount,
+      balance,
+      description,
+      uid: makeTransactionUid(maskedPan, dateTime, amount, balance, occurrence),
+      originString: `${dateTime} | ${description} | ${amount} | ${balance}`
+    })
+
+    i = j // resume scanning right after this row's tail line
+  }
+
+  assert(skipped.length === 0, `Не удалось разобрать ${skipped.length} операц. в выписке Simbank`, skipped)
+  assert(transactions.length > 0, 'В выписке Simbank не найдено ни одной операции')
+  return transactions
+}
+
+/**
+ * Own-funds balance = "Баланс после операции" of the latest transaction (that table
+ * column is own funds, negative = debt). Language-independent — no header label.
+ */
+function latestTransactionBalance (transactions: SimbankStatementTransaction[]): number {
+  let latest = transactions[0]
+  for (const t of transactions) {
+    if (t.date >= latest.date) latest = t
+  }
+  const balance = parseFormattedNumber(latest.balance)
+  assert(!isNaN(balance), 'Не удалось определить баланс счёта')
+  return balance
+}
+
+/**
+ * Pure parser: turns the extracted PDF text into an account and its transactions.
+ * Kept free of the `pdfjs` binary layer so it can be unit-tested with an inline
+ * fixture string.
+ */
+export function parseStatementText (rawText: string): { account: SimbankStatementAccount, transactions: SimbankStatementTransaction[] } {
+  const text = normalizeSpaces(rawText)
+  assert(looksLikeSimbankStatement(text), 'Похоже, это не выписка Simbank')
+
+  const maskedPan = parseMaskedPan(text)
+  assert(maskedPan !== '', 'Не удалось определить номер карты')
+
+  const instrument = (findField(text, CURRENCY_LABEL) ?? '').replace(/\s+/g, '').match(/[A-Za-z]{3}/)?.[0].toUpperCase() ?? 'KGS'
+
+  const limit = parseHeaderAmount(text, CREDIT_LIMIT_LABEL)
+  const creditLimit = !isNaN(limit) && limit > 0 ? limit : null
+  const used = parseHeaderAmount(text, USED_LIMIT_LABEL)
+  const usedLimit = !isNaN(used) ? used : null
+
+  const periodMatch = text.match(new RegExp(`${PERIOD_LABEL.source}\\s*:\\s*\\d{2}-\\d{2}-\\d{4}\\s*-\\s*(\\d{2}-\\d{2}-\\d{4})`, 'i'))
+  const statementDate = periodMatch != null ? parseSimbankDate(periodMatch[1]) : ''
+
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l !== '')
+  const transactions = parseTransactionRows(lines, maskedPan)
+
+  const account: SimbankStatementAccount = {
+    id: maskedPan,
+    title: 'Simbank *' + maskedPan.slice(-4),
+    balance: latestTransactionBalance(transactions),
+    creditLimit,
+    usedLimit,
+    instrument,
+    date: statementDate
+  }
+
+  return { account, transactions }
+}
+
+/** Parse one or more extracted PDF texts (one per picked file). */
+export function parseSimbankStatements (texts: string[]): Array<{ account: SimbankStatementAccount, transactions: SimbankStatementTransaction[] }> {
+  const out: Array<{ account: SimbankStatementAccount, transactions: SimbankStatementTransaction[] }> = []
+  let lastError: unknown = null
+  for (const text of texts) {
+    try {
+      out.push(parseStatementText(text))
+    } catch (e) {
+      // A file that IS a Simbank statement but failed to parse means we'd silently drop
+      // its transactions — fail the whole import loudly instead. Only tolerate files
+      // that simply aren't Simbank statements (so a stray PDF doesn't block the rest).
+      if (looksLikeSimbankStatement(normalizeSpaces(text))) {
+        throw e
+      }
+      console.error('[simbank-kg] skipping a file that is not a Simbank statement', e)
+      lastError = e
+    }
+  }
+  // If every file failed, surface the error (e.g. "not a Simbank statement").
+  if (out.length === 0 && lastError != null) {
+    throw lastError
+  }
+  return out
+}

--- a/src/plugins/simbank-kg/preferences.xml
+++ b/src/plugins/simbank-kg/preferences.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="From what date to load transactions"
+        dialogTitle="From what date to load transactions"
+        defaultValue="2024-01-01T00:00:00.000Z"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|startDate|{@s}">
+    </EditTextPreference>
+</PreferenceScreen>


### PR DESCRIPTION
## Summary

Adds a Simbank (Kyrgyzstan, brand of ОАО "Дос-Кредобанк") plugin that imports the bank's card-statement PDF and converts it into ZenMoney accounts and transactions. File-import only — runs entirely on-device, no network or credentials. The statement is exported from the Simbank mobile app: card settings → «Выписка по карте».

## Features

- Parses the Simbank card-statement PDF; statements in Russian, Kyrgyz and English are all supported, detected by content (not by file name)
- Models credit cards as `ccard` with credit limit and amount due; the own-funds balance (negative = debt) is read from the running-balance column
- Handles pdfjs text-extraction quirks: U+202F narrow-no-break-space thousands separators, letter-spaced glyph runs, and the credit-fee column
- Deduplicates re-imports and the same statement imported in different languages (stable per-row id)
- Fails loudly instead of silently dropping an unparsable row
- Supports selecting several statement files at once (merged per card)

## Testing

- `yarn test simbank-kg` — ts-standard + tsc + jest (43 tests), all pass
- Verified end-to-end against real ru/ky/en statements (one card → 628 transactions each, balances reconcile, ids unique; a second card → checking account). Real PDFs contain personal data and are not committed — tests use anonymized inline fixtures