### PR TITLE
[solutionbank]: исправить дубли операций и вход после обновления приложения

### DIFF
--- a/src/UI/index.jsx
+++ b/src/UI/index.jsx
@@ -67,6 +67,33 @@ class TransactionsPane extends React.PureComponent {
     }
 }
 
+class UserInputRequest extends React.PureComponent {
+    state = {value: ""};
+
+    handleSubmit = (event) => {
+        event.preventDefault();
+        this.props.request.submit(this.state.value);
+    };
+
+    render() {
+        const {request} = this.props;
+        const inputType = request.options && request.options.inputType === "number" ? "number" : "text";
+        return (
+            <form onSubmit={this.handleSubmit} style={{marginTop: 12}}>
+                <div>{request.message}</div>
+                <input
+                    autoFocus
+                    type={inputType}
+                    value={this.state.value}
+                    onChange={(event) => this.setState({value: event.target.value})}
+                    style={{marginTop: 8, marginRight: 8}}
+                />
+                <button type="submit">Submit</button>
+            </form>
+        );
+    }
+}
+
 export class UI extends React.PureComponent {
     state = {};
 
@@ -94,7 +121,7 @@ export class UI extends React.PureComponent {
         const {
             waitingForDevtools, onManualStartPress,
             scrapeState, workflowState,
-            scrapeResult, scrapeError,
+            scrapeResult, scrapeError, userInputRequest,
             persistPluginDataState, persistPluginDataError, onPersistPluginDataConfirm,
         } = this.props;
         const {resolveAccount} = this.state;
@@ -117,6 +144,7 @@ export class UI extends React.PureComponent {
                     {workflowState === ":workflow-state/filling-preferences" && <div>Filling preferences…</div>}
                     {scrapeState === ":scrape-state/starting" && <div>Scraping starting</div>}
                     {scrapeState === ":scrape-state/started" && <div>Scraping…</div>}
+                    {userInputRequest && <UserInputRequest request={userInputRequest} />}
                     {scrapeState === ":scrape-state/success" &&
                     <div>Scraped {scrapeResult.accounts.length} account(s), {scrapeResult.transactions.length} transaction(s)</div>}
                     {scrapeState === ":scrape-state/success" && scrapeResult.pluginDataChange && (

--- a/src/handleMessageFromWorker.js
+++ b/src/handleMessageFromWorker.js
@@ -16,8 +16,10 @@ const messageHandlers = {
     onSyncError(payload)
   },
 
-  ':commands/prompt-user-input': async function ({ payload: { message, options, correlationId }, reply }) {
-    const result = prompt(message)
+  ':commands/prompt-user-input': async function ({ payload: { message, options, correlationId }, reply, onUserInputRequest }) {
+    const result = onUserInputRequest
+      ? await onUserInputRequest({ message, options })
+      : prompt(message)
     reply({ type: ':events/received-user-input', payload: { result, correlationId } })
   },
 

--- a/src/plugins/solutionbank/__tests__/api.test.js
+++ b/src/plugins/solutionbank/__tests__/api.test.js
@@ -1,4 +1,5 @@
 import fetchMock from 'fetch-mock'
+import { TemporaryError } from '../../../errors'
 import { installFetchMockDeveloperFriendlyFallback } from '../../../testUtils'
 import { makePluginDataApi } from '../../../ZPAPI.pluginData'
 import { fetchAccounts, fetchOperations, fetchTransactions, login } from '../api'
@@ -81,6 +82,45 @@ describe('login', () => {
       time: 120000,
       inputType: 'text'
     })
+  })
+
+  it('fails login when SMS confirmation response returns bank error', async () => {
+    fetchMock.once(baseUrl + 'session/login', {
+      status: 400,
+      body: {
+        errorInfo: {
+          error: '10415',
+          errorText: 'Введите код из СМС'
+        }
+      }
+    }, { method: 'POST' })
+    fetchMock.once(baseUrl + 'session/login', {
+      status: 400,
+      body: {
+        errorInfo: {
+          error: '10003',
+          errorText: 'Сессионный ключ не задан'
+        }
+      }
+    }, { method: 'POST' })
+
+    await expect(login('test-login', 'test-password')).rejects.toMatchObject({
+      bankMessage: 'Сессионный ключ не задан'
+    })
+  })
+
+  it('fails login when successful response has no session token', async () => {
+    fetchMock.once(baseUrl + 'session/login', {
+      status: 200,
+      body: {
+        errorInfo: {
+          error: '0',
+          errorText: 'Успешно'
+        }
+      }
+    }, { method: 'POST' })
+
+    await expect(login('test-login', 'test-password')).rejects.toBeInstanceOf(TemporaryError)
   })
 })
 

--- a/src/plugins/solutionbank/__tests__/api.test.js
+++ b/src/plugins/solutionbank/__tests__/api.test.js
@@ -6,8 +6,45 @@ import { fetchAccounts, fetchOperations, fetchTransactions, login } from '../api
 
 installFetchMockDeveloperFriendlyFallback(fetchMock)
 
-const baseUrl = 'https://mbank.rbank.by/services/v2/'
+const baseUrl = 'https://mbank.rbank.by:443/services/v2/'
 const sessionToken = 'test-session-token'
+const expectedDeviceInfo = {
+  parameters: [
+    {
+      device_model: 'ne2211',
+      device_name: 'op516fl1',
+      deviceid: 'test-device-id',
+      geolocationdata: '53.902284, 27.561831',
+      locale: 'ru_by',
+      time_zone: 'europe/minsk',
+      os_name: 'android',
+      os_version: '11',
+      width: '1080',
+      height: '2400',
+      scale: '3',
+      uuid: 'test-device-id',
+      android_specific: {
+        build_bootloader: '',
+        build_display: 'ne2211_11_c.48',
+        build_fingerprint: 'ne2211_11_c.48',
+        build_id: 'rkq1.211119.001',
+        build_manufacturer: 'oneplus',
+        build_radio: '',
+        iccid: '',
+        package_manager_getsystemavailablefeatures: [
+          'android.hardware.camera',
+          'android.hardware.location.gps',
+          'android.hardware.location.network',
+          'android.hardware.nfc',
+          'android.hardware.telephony',
+          'android.hardware.touchscreen',
+          'android.hardware.wifi',
+          'android.software.webview'
+        ]
+      }
+    }
+  ]
+}
 
 let dataApi
 
@@ -15,7 +52,6 @@ beforeEach(() => {
   dataApi = makePluginDataApi({
     device_id: 'test-device-id',
     anti_fraud_id: 'test-anti-fraud-id',
-    anti_fraud_session_id: 'test-anti-fraud-session-id',
     push_id: 'test-push-id'
   })
   global.ZenMoney = {
@@ -42,6 +78,7 @@ describe('login', () => {
           error: '0',
           errorText: 'Успешно'
         },
+        fingerprint: 'test-fingerprint',
         sessionToken
       }
     }, { method: 'POST' })
@@ -53,11 +90,12 @@ describe('login', () => {
 
     const firstRequest = JSON.parse(calls[0][1].body)
     expect(firstRequest).toEqual({
-      applicID: '1.59.2',
+      applicID: '1.60.0',
       browser: 'OP516FL1',
       browserVersion: 'NE2211 (NE2211)',
       clientKind: '0',
       deviceUDID: 'test-device-id',
+      deviceInfo: expectedDeviceInfo,
       login: 'test-login',
       password: 'test-password',
       platform: 'Android',
@@ -82,6 +120,7 @@ describe('login', () => {
       time: 120000,
       inputType: 'text'
     })
+    expect(dataApi.currentData.anti_fraud_id).toBe('test-fingerprint')
   })
 
   it('fails login when SMS confirmation response returns bank error', async () => {
@@ -133,7 +172,7 @@ describe('fetchAccounts', () => {
         const request = JSON.parse(body)
         return url === baseUrl + 'products/getUserAccountsOverview' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.cardAccount &&
@@ -186,7 +225,7 @@ describe('fetchAccounts', () => {
         const request = JSON.parse(body)
         const matched = url === baseUrl + 'payment/simpleExcute' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.komplatRequests[0].request.includes('<RequestType>Balance</RequestType>') &&
@@ -213,7 +252,7 @@ describe('fetchAccounts', () => {
         const request = JSON.parse(body)
         const matched = url === baseUrl + 'payment/simpleExcute' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.komplatRequests[0].request.includes('<RequestType>Balance</RequestType>') &&
@@ -275,7 +314,7 @@ describe('fetchTransactions', () => {
         const request = JSON.parse(body)
         return url === baseUrl + 'payment/simpleExcute' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.komplatRequests[0].request.includes('<RequestType>GetAuthHistory</RequestType>') &&
@@ -298,7 +337,7 @@ describe('fetchTransactions', () => {
         const request = JSON.parse(body)
         return url === baseUrl + 'payment/simpleExcute' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.komplatRequests[0].request.includes('<RequestType>GetAuthHistory</RequestType>') &&
@@ -361,7 +400,7 @@ describe('fetchOperations', () => {
         const request = JSON.parse(body)
         return url === baseUrl + 'products/getCardAccountFullStatement' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.currencyCode === 933 &&
@@ -518,7 +557,7 @@ describe('fetchOperations', () => {
         const request = JSON.parse(body)
         const matched = url === baseUrl + 'products/getCardAccountFullStatement' &&
           headers.session_token === sessionToken &&
-          headers._ac0 === 'test-anti-fraud-session-id' &&
+          headers._ac0 === sessionToken &&
           headers._ac1 === 'test-anti-fraud-id' &&
           headers.language === 'ru' &&
           request.cardHash === 'first-card-hash' &&

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -229,6 +229,71 @@ describe('convertTransaction', () => {
     expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-11', '-17.52', 'APTEKA PYATOI KATEGORII V'))
   })
 
+  it('matches operation when full statement merchant is a safe shorter prefix', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-20T08:05:41+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -19.3,
+      merchant: 'SHOP "KERAMIKA" / STOLITSA',
+      hold: true
+    }
+    const postedOperation = {
+      id: '519980',
+      account_id: 'mock-account-001',
+      operationName: 'Оплата товаров (услуг)',
+      operationDate: new Date('2026-06-23T10:48:17+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -19.3,
+      transactionDate: new Date('2026-06-20T00:00:00+03:00'),
+      transactionAmount: -19.3,
+      transactionCurrencyCode: '933',
+      merchant: 'SHOP "KERAMIKA" / STOLITS',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-20', '-19.30', 'SHOP KERAMIKA / STOLITSA'))
+  })
+
+  it('does not merge merchants when the shared prefix is too short', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-11T11:23:00+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -9.99,
+      merchant: 'SHORT MERCHANT',
+      hold: true
+    }
+    const postedOperation = {
+      id: '453993',
+      account_id: 'mock-account-001',
+      operationName: 'Оплата товаров (услуг)',
+      operationDate: new Date('2026-06-12T11:23:00+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -9.99,
+      transactionDate: new Date('2026-06-11T00:00:00+03:00'),
+      transactionAmount: -9.99,
+      transactionCurrencyCode: '933',
+      merchant: 'SHORT MERCHANT EXTRA',
+      hold: false
+    }
+    const transactions = merge([hold], [postedOperation]).map(transaction => convertTransaction(transaction))
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(transaction => transaction.hold)).toEqual([false, true])
+    expect(transactions.map(transaction => transaction.movements[0].id)).toEqual([
+      transactionId('2026-06-11', '-9.99', 'SHORT MERCHANT EXTRA'),
+      transactionId('2026-06-11', '-9.99', 'SHORT MERCHANT')
+    ])
+  })
+
   it('does not merge similar merchants with different amounts', () => {
     const firstHold = {
       account_id: 'mock-account-001',

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -295,6 +295,103 @@ describe('convertTransaction', () => {
     expect(transaction.movements[0].id).toEqual(transactionId('2026-06-30', '0.10', 'Зачисление на счет'))
   })
 
+  it('matches money-back income when mini statement has generic income name', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-07-01T11:49:43+03:00'),
+      transactionName: 'Зачисление на счет',
+      transactionCurrencyCode: '933',
+      transactionAmount: 4.09,
+      hold: true
+    }
+    const postedOperation = {
+      account_id: 'mock-account-001',
+      operationName: 'Начисление Money-back (R-card)',
+      operationDate: new Date('2026-07-01T10:56:30+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: 4.09,
+      transactionDate: new Date('2026-07-01T10:56:30+03:00'),
+      transactionAmount: 0,
+      transactionCurrencyCode: '933',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+    const transaction = convertTransaction(merged[0])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(transaction.movements[0].sum).toEqual(4.09)
+    expect(transaction.movements[0].id).toEqual(transactionId('2026-07-01', '4.09', 'Зачисление на счет'))
+  })
+
+  it('matches posted card operation shifted to the next bank date when merchant is exact', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-28T21:28:32+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -11,
+      merchant: 'YANDEX.GO',
+      hold: true
+    }
+    const postedOperation = {
+      id: '338010',
+      account_id: 'mock-account-001',
+      operationName: 'Оплата товаров (услуг)',
+      operationDate: new Date('2026-07-01T13:48:21+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -11,
+      transactionDate: new Date('2026-06-29T00:00:00+03:00'),
+      transactionAmount: -11,
+      transactionCurrencyCode: '933',
+      merchant: 'YANDEX.GO',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+    const transaction = convertTransaction(merged[0])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(transaction.movements[0].sum).toEqual(-11)
+    expect(transaction.movements[0].id).toEqual(transactionId('2026-06-28', '-11.00', 'YANDEX.GO'))
+  })
+
+  it('does not match adjacent bank dates when merchants are only prefix-compatible', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-28T21:28:32+03:00'),
+      transactionName: '*Оплата* Безналичная операция',
+      transactionCurrencyCode: '933',
+      transactionAmount: -19.3,
+      merchant: 'SHOP "KERAMIKA" / STOLITSA',
+      hold: true
+    }
+    const postedOperation = {
+      id: '338011',
+      account_id: 'mock-account-001',
+      operationName: 'Оплата товаров (услуг)',
+      operationDate: new Date('2026-07-01T13:48:21+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -19.3,
+      transactionDate: new Date('2026-06-29T00:00:00+03:00'),
+      transactionAmount: -19.3,
+      transactionCurrencyCode: '933',
+      merchant: 'SHOP "KERAMIKA" / STOLITS',
+      hold: false
+    }
+    const transactions = merge([hold], [postedOperation]).map(transaction => convertTransaction(transaction))
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(transaction => transaction.hold)).toEqual([false, true])
+    expect(transactions.map(transaction => transaction.movements[0].id)).toEqual([
+      transactionId('2026-06-29', '-19.30', 'SHOP KERAMIKA / STOLITS'),
+      transactionId('2026-06-28', '-19.30', 'SHOP KERAMIKA / STOLITSA')
+    ])
+  })
+
   it('does not merge unrelated no-merchant income operation names', () => {
     const hold = {
       account_id: 'mock-account-001',

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -265,6 +265,67 @@ describe('convertTransaction', () => {
     expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-20', '-19.30', 'SHOP KERAMIKA / STOLITSA'))
   })
 
+  it('matches account capitalization when mini statement has generic income name', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-30T14:42:03+03:00'),
+      transactionName: 'Зачисление на счет',
+      transactionCurrencyCode: '933',
+      transactionAmount: 0.1,
+      hold: true
+    }
+    const postedOperation = {
+      account_id: 'mock-account-001',
+      operationName: 'Капитализация (%% тек.периода ко вкладу)',
+      operationDate: new Date('2026-06-30T14:00:50+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: 0.1,
+      transactionDate: new Date('2026-06-30T14:00:50+03:00'),
+      transactionAmount: 0,
+      transactionCurrencyCode: '933',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+    const transaction = convertTransaction(merged[0])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(transaction.movements[0].sum).toEqual(0.1)
+    expect(transaction.movements[0].id).toEqual(transactionId('2026-06-30', '0.10', 'Зачисление на счет'))
+  })
+
+  it('does not merge unrelated no-merchant income operation names', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2026-06-30T14:42:03+03:00'),
+      transactionName: 'Зачисление на счет',
+      transactionCurrencyCode: '933',
+      transactionAmount: 0.1,
+      hold: true
+    }
+    const postedOperation = {
+      account_id: 'mock-account-001',
+      operationName: 'Пополнение счета',
+      operationDate: new Date('2026-06-30T14:00:50+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: 0.1,
+      transactionDate: new Date('2026-06-30T14:00:50+03:00'),
+      transactionAmount: 0,
+      transactionCurrencyCode: '933',
+      hold: false
+    }
+    const transactions = merge([hold], [postedOperation]).map(transaction => convertTransaction(transaction))
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(transaction => transaction.hold)).toEqual([false, true])
+    expect(transactions.map(transaction => transaction.movements[0].id)).toEqual([
+      transactionId('2026-06-30', '0.10', 'Пополнение счета'),
+      transactionId('2026-06-30', '0.10', 'Зачисление на счет')
+    ])
+  })
+
   it('does not merge merchants when the shared prefix is too short', () => {
     const hold = {
       account_id: 'mock-account-001',

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -1,7 +1,9 @@
+import { MD5 } from 'jshashes'
 import { convertTransaction, merge } from '../../../converters'
 
 describe('convertTransaction', () => {
   let consoleLogSpy
+  const md5 = new MD5()
   const account = {
     id: 'mock-account-001',
     type: 'card',
@@ -12,8 +14,11 @@ describe('convertTransaction', () => {
       '1111'
     ]
   }
-  const transactionId = (date, amount, merchant, duplicateIndex = 1) => {
+  const transactionIdSource = (date, amount, merchant, duplicateIndex = 1) => {
     return `${account.id}|${date}|${amount}|933|${merchant}|${duplicateIndex}`
+  }
+  const transactionId = (date, amount, merchant, duplicateIndex = 1) => {
+    return md5.hex(transactionIdSource(date, amount, merchant, duplicateIndex))
   }
 
   beforeEach(() => {
@@ -58,7 +63,7 @@ describe('convertTransaction', () => {
     })
   })
 
-  it('uses canonical transaction id independent from bank transaction id and without hash', () => {
+  it('uses hashed canonical transaction id independent from bank transaction id', () => {
     const json = {
       id: '123456',
       account_id: 'mock-account-001',
@@ -75,11 +80,11 @@ describe('convertTransaction', () => {
 
     expect(transaction.movements[0].id).toEqual(sameTransactionWithoutBankId.movements[0].id)
     expect(transaction.movements[0].id).toEqual(transactionId('2019-02-14', '-1.00', 'BANK RESHENIE- OPLATA USL'))
-    expect(transaction.movements[0].id).not.toMatch(/^[a-f0-9]{32}$/)
+    expect(transaction.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
     expect(transaction.movements[0].id).not.toEqual('123456')
   })
 
-  it('generates stable readable transaction id when bank id is missing', () => {
+  it('generates stable hashed transaction id when bank id is missing', () => {
     const json = {
       account_id: 'mock-account-001',
       currency: 'BYN',
@@ -539,7 +544,7 @@ describe('convertTransaction', () => {
     ])
   })
 
-  it('does not log transaction identity data for merged transactions', () => {
+  it('logs readable transaction id source for merged transactions', () => {
     const transaction = convertTransaction({
       account_id: 'mock-account-001',
       accountCurrencyCode: '933',
@@ -553,7 +558,10 @@ describe('convertTransaction', () => {
     })
 
     expect(transaction.movements[0].id).toEqual(transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2))
-    expect(consoleLogSpy).not.toHaveBeenCalled()
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'SolutionBank transaction id source',
+      transactionIdSource('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2)
+    )
   })
 
   it('zero sum', () => {

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -12,7 +12,9 @@ describe('convertTransaction', () => {
       '1111'
     ]
   }
-  const generatedId = expect.stringMatching(/^[a-f0-9]{32}$/)
+  const transactionId = (date, amount, merchant, duplicateIndex = 1) => {
+    return `${account.id}|${date}|${amount}|933|${merchant}|${duplicateIndex}`
+  }
 
   beforeEach(() => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
@@ -38,7 +40,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-1.00', 'BANK RESHENIE- OPLATA USL'),
           account: { id: account.id },
           sum: -1,
           invoice: null,
@@ -56,7 +58,7 @@ describe('convertTransaction', () => {
     })
   })
 
-  it('generates canonical id independent from bank transaction id', () => {
+  it('uses canonical transaction id independent from bank transaction id and without hash', () => {
     const json = {
       id: '123456',
       account_id: 'mock-account-001',
@@ -72,11 +74,12 @@ describe('convertTransaction', () => {
     const sameTransactionWithoutBankId = convertTransaction({ ...json, id: undefined })
 
     expect(transaction.movements[0].id).toEqual(sameTransactionWithoutBankId.movements[0].id)
-    expect(transaction.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
+    expect(transaction.movements[0].id).toEqual(transactionId('2019-02-14', '-1.00', 'BANK RESHENIE- OPLATA USL'))
+    expect(transaction.movements[0].id).not.toMatch(/^[a-f0-9]{32}$/)
     expect(transaction.movements[0].id).not.toEqual('123456')
   })
 
-  it('generates stable transaction id when bank id is missing', () => {
+  it('generates stable readable transaction id when bank id is missing', () => {
     const json = {
       account_id: 'mock-account-001',
       currency: 'BYN',
@@ -92,12 +95,12 @@ describe('convertTransaction', () => {
     const anotherTransaction = convertTransaction({ ...json, merchant: 'mock-food.example' })
 
     expect(transaction.movements[0].id).toEqual(sameTransaction.movements[0].id)
-    expect(transaction.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
+    expect(transaction.movements[0].id).toEqual(transactionId('2019-02-14', '-18.00', 'MOCK POST; TESTCITY; BY'))
     expect(transaction.movements[0].id).not.toEqual(anotherTransaction.movements[0].id)
   })
 
-  it('keeps same id when hold becomes posted operation', () => {
-    const hold = convertTransaction({
+  it('keeps posted operation when hold becomes posted operation', () => {
+    const hold = {
       account_id: 'mock-account-001',
       accountCurrencyCode: '933',
       transactionDate: new Date('2026-06-02T11:30:22+03:00'),
@@ -106,8 +109,8 @@ describe('convertTransaction', () => {
       transactionAmount: -30.5,
       merchant: 'MOCK CAFE',
       hold: true
-    })
-    const postedOperation = convertTransaction({
+    }
+    const postedOperation = {
       id: '222180',
       account_id: 'mock-account-001',
       operationName: 'Оплата товаров (услуг)',
@@ -122,14 +125,16 @@ describe('convertTransaction', () => {
       merchantId: 'ACQ_7CD4ECE',
       mcc: '5422',
       operationCode: 3
-    })
+    }
+    const merged = merge([hold], [postedOperation])
 
-    expect(hold.movements[0].id).toEqual(postedOperation.movements[0].id)
-    expect(hold.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-02', '-30.50', 'MOCK CAFE'))
   })
 
-  it('normalizes XML escaped merchant in canonical id', () => {
-    const hold = convertTransaction({
+  it('normalizes XML escaped merchant when matching hold with posted operation', () => {
+    const hold = {
       account_id: 'mock-account-001',
       accountCurrencyCode: '933',
       transactionDate: new Date('2026-06-02T17:11:29+03:00'),
@@ -138,8 +143,8 @@ describe('convertTransaction', () => {
       transactionAmount: -13.92,
       merchant: 'MOCK SHOP &quot;ALPHA&quot;',
       hold: true
-    })
-    const postedOperation = convertTransaction({
+    }
+    const postedOperation = {
       id: '453990',
       account_id: 'mock-account-001',
       operationName: 'Оплата товаров (услуг)',
@@ -154,13 +159,15 @@ describe('convertTransaction', () => {
       merchantId: '0978441',
       mcc: '5411',
       operationCode: 3
-    })
+    }
+    const merged = merge([hold], [postedOperation])
 
-    expect(hold.movements[0].id).toEqual(postedOperation.movements[0].id)
-    expect(hold.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-02', '-13.92', 'MOCK SHOP ALPHA'))
   })
 
-  it('keeps same id when one merchant has a trailing quote trimmed by the bank', () => {
+  it('matches operation when one merchant has a trailing quote trimmed by the bank', () => {
     const hold = {
       account_id: 'mock-account-001',
       accountCurrencyCode: '933',
@@ -188,10 +195,10 @@ describe('convertTransaction', () => {
 
     expect(merged).toHaveLength(1)
     expect(merged[0].hold).toEqual(false)
-    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
+    expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-11', '-37.36', 'APTEKA N1 OOO FARMPROEKT'))
   })
 
-  it('keeps same id when one merchant has a short extra suffix after the bank prefix', () => {
+  it('matches operation when one merchant has a short extra suffix after the bank prefix', () => {
     const hold = {
       account_id: 'mock-account-001',
       accountCurrencyCode: '933',
@@ -219,7 +226,7 @@ describe('convertTransaction', () => {
 
     expect(merged).toHaveLength(1)
     expect(merged[0].hold).toEqual(false)
-    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
+    expect(convertTransaction(merged[0]).movements[0].id).toEqual(transactionId('2026-06-11', '-17.52', 'APTEKA PYATOI KATEGORII V'))
   })
 
   it('does not merge similar merchants with different amounts', () => {
@@ -241,7 +248,11 @@ describe('convertTransaction', () => {
     const transactions = merge([firstHold, secondHold], []).map(transaction => convertTransaction(transaction))
 
     expect(transactions).toHaveLength(2)
-    expect(transactions[0].movements[0].id).not.toEqual(transactions[1].movements[0].id)
+    expect(transactions.map(transaction => transaction.movements[0].sum)).toEqual([-2.79, -31.37])
+    expect(transactions.map(transaction => transaction.movements[0].id)).toEqual([
+      transactionId('2026-06-11', '-2.79', 'MAGAZIN EUROOPT PRIME'),
+      transactionId('2026-06-11', '-31.37', 'MAGAZIN EUROOPT PRIME')
+    ])
   })
 
   it('distinguishes repeated holds with same identity', () => {
@@ -260,15 +271,17 @@ describe('convertTransaction', () => {
       transactionDate: new Date('2026-06-05T12:01:00+03:00')
     }
 
-    const transactions = merge([firstHold, secondHold], []).map(transaction => convertTransaction(transaction))
+    const merged = merge([firstHold, secondHold], [])
 
-    expect(transactions).toHaveLength(2)
-    expect(transactions[0].movements[0].id).toMatch(/^[a-f0-9]{32}$/)
-    expect(transactions[1].movements[0].id).toMatch(/^[a-f0-9]{32}$/)
-    expect(transactions[0].movements[0].id).not.toEqual(transactions[1].movements[0].id)
+    expect(merged).toHaveLength(2)
+    expect(merged.map(transaction => transaction.duplicateIndex)).toEqual([1, 2])
+    expect(merged.map(transaction => convertTransaction(transaction).movements[0].id)).toEqual([
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 1),
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2)
+    ])
   })
 
-  it('keeps first repeated hold id stable when another same operation appears later', () => {
+  it('keeps first repeated hold index stable when another same operation appears later', () => {
     const firstHold = {
       account_id: 'mock-account-001',
       accountCurrencyCode: '933',
@@ -284,13 +297,13 @@ describe('convertTransaction', () => {
       transactionDate: new Date('2026-06-05T12:01:00+03:00')
     }
 
-    const firstOnlyId = convertTransaction(merge([firstHold], [])[0]).movements[0].id
-    const firstWithDuplicateId = convertTransaction(merge([firstHold, secondHold], [])[0]).movements[0].id
+    const firstOnlyIndex = merge([firstHold], [])[0].duplicateIndex
+    const firstWithDuplicateIndex = merge([firstHold, secondHold], [])[0].duplicateIndex
 
-    expect(firstOnlyId).toEqual(firstWithDuplicateId)
+    expect(firstOnlyIndex).toEqual(firstWithDuplicateIndex)
   })
 
-  it('keeps repeated ids when holds become posted operations', () => {
+  it('keeps repeated posted operations when holds become posted operations', () => {
     const holds = [
       {
         account_id: 'mock-account-001',
@@ -342,10 +355,15 @@ describe('convertTransaction', () => {
       }
     ]
 
-    const holdIds = merge(holds, []).map(transaction => convertTransaction(transaction).movements[0].id)
-    const postedIds = merge([], postedOperations).map(transaction => convertTransaction(transaction).movements[0].id)
+    const merged = merge(holds, postedOperations)
+    const postedIds = merged.map(transaction => convertTransaction(transaction).movements[0].id)
 
-    expect(postedIds).toEqual(holdIds)
+    expect(merged).toHaveLength(2)
+    expect(merged.map(transaction => transaction.hold)).toEqual([false, false])
+    expect(postedIds).toEqual([
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 1),
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2)
+    ])
   })
 
   it('keeps extra repeated hold when only part of same operations are posted', () => {
@@ -383,10 +401,11 @@ describe('convertTransaction', () => {
     expect(merged).toHaveLength(2)
     expect(merged[0].hold).toEqual(false)
     expect(merged[1].hold).toEqual(true)
-    expect(transactions[0].movements[0].id).not.toEqual(transactions[1].movements[0].id)
+    expect(transactions[0].movements[0].id).toEqual(transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 1))
+    expect(transactions[1].movements[0].id).toEqual(transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2))
   })
 
-  it('keeps repeated ids stable when same operations clear on different days', () => {
+  it('keeps repeated operations matched when same operations clear on different days', () => {
     const holds = [
       {
         account_id: 'mock-account-001',
@@ -436,12 +455,23 @@ describe('convertTransaction', () => {
       hold: false
     }
 
-    const holdIds = merge(holds, []).map(transaction => convertTransaction(transaction).movements[0].id)
-    const partiallyClearedIds = merge(holds, [firstClearedOperation]).map(transaction => convertTransaction(transaction).movements[0].id)
-    const fullyClearedIds = merge([], [firstClearedOperation, secondClearedOperation]).map(transaction => convertTransaction(transaction).movements[0].id)
+    const partiallyCleared = merge(holds, [firstClearedOperation])
+    const partiallyClearedIds = partiallyCleared.map(transaction => convertTransaction(transaction).movements[0].id)
+    const fullyCleared = merge([], [firstClearedOperation, secondClearedOperation])
+    const fullyClearedIds = fullyCleared.map(transaction => convertTransaction(transaction).movements[0].id)
 
-    expect(partiallyClearedIds).toEqual(holdIds)
-    expect(fullyClearedIds).toEqual(holdIds)
+    expect(partiallyCleared).toHaveLength(2)
+    expect(partiallyCleared.map(transaction => transaction.hold)).toEqual([false, true])
+    expect(partiallyClearedIds).toEqual([
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 1),
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2)
+    ])
+    expect(fullyCleared).toHaveLength(2)
+    expect(fullyCleared.map(transaction => transaction.hold)).toEqual([false, false])
+    expect(fullyClearedIds).toEqual([
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 1),
+      transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2)
+    ])
   })
 
   it('does not log transaction identity data for merged transactions', () => {
@@ -457,7 +487,7 @@ describe('convertTransaction', () => {
       duplicateIndex: 2
     })
 
-    expect(transaction.movements[0].id).toMatch(/^[a-f0-9]{32}$/)
+    expect(transaction.movements[0].id).toEqual(transactionId('2026-06-05', '-4.00', 'MOCK TRANSFER SERVICE', 2))
     expect(consoleLogSpy).not.toHaveBeenCalled()
   })
 
@@ -492,7 +522,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-18.00', 'MOCK POST; TESTCITY; BY'),
           account: { id: account.id },
           sum: -18,
           invoice: null,
@@ -526,7 +556,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-18.00', 'MOCK ONLINE SHOP; TESTCIT'),
           account: { id: account.id },
           sum: -18,
           invoice: null,
@@ -560,7 +590,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-18.00', 'MOCK TOKEN SERVICE; ; BY'),
           account: { id: account.id },
           sum: -18,
           invoice: null,
@@ -594,7 +624,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-18.00', 'MOCK ELECTRONICS; TESTCIT'),
           account: { id: account.id },
           sum: -18,
           invoice: null,
@@ -628,7 +658,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-18.00', 'MOCK COURSES; ONLINE; TES'),
           account: { id: account.id },
           sum: -18,
           invoice: null,
@@ -662,7 +692,7 @@ describe('convertTransaction', () => {
       date: new Date('2019-02-14T00:00:00+03:00'),
       movements: [
         {
-          id: generatedId,
+          id: transactionId('2019-02-14', '-18.00', 'MOCK-FOOD.EXAMPLE'),
           account: { id: account.id },
           sum: -18,
           invoice: null,

--- a/src/plugins/solutionbank/api.js
+++ b/src/plugins/solutionbank/api.js
@@ -203,16 +203,28 @@ export async function login (login, password) {
         throw new InvalidOtpCodeError()
       }
       res = await loginReq(login, password, code)
+      assertSuccessfulLogin(res)
       break
     case '10004':
       throw new InvalidPreferencesError('Неверный логин или пароль')
     case '0':
+      assertSuccessfulLogin(res)
       break
     default:
       throw new BankMessageError(res.body.errorInfo.errorText)
   }
 
   return res.body.sessionToken
+}
+
+function assertSuccessfulLogin (res) {
+  const errorInfo = res.body && res.body.errorInfo
+  if (!errorInfo || errorInfo.error !== '0') {
+    throw new BankMessageError(errorInfo && errorInfo.errorText ? errorInfo.errorText : 'Ошибка входа')
+  }
+  if (!res.body.sessionToken) {
+    throw new TemporaryError('Сессионный ключ не получен')
+  }
 }
 
 async function loginReq (login, password, smsCode) {

--- a/src/plugins/solutionbank/api.js
+++ b/src/plugins/solutionbank/api.js
@@ -2,25 +2,36 @@ import cheerio from 'cheerio'
 import { defaultsDeep, flatMap } from 'lodash'
 import { createDateIntervals as commonCreateDateIntervals } from '../../common/dateUtils'
 import { fetchJson } from '../../common/network'
-import { generateRandomString, generateUUID } from '../../common/utils'
+import { generateUUID } from '../../common/utils'
 import { parseXml } from '../../common/xmlUtils'
 import { BankMessageError, InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../errors'
 import { getDate } from './converters'
 
 // transaction - операция прошедшая по карте, operation - операция по счёту
 
-const baseUrl = 'https://mbank.rbank.by/services/v2/'
-const appVersion = '1.59.2'
+const baseUrl = 'https://mbank.rbank.by:443/services/v2/'
+const appVersion = '1.60.0'
 const androidDeviceProfile = {
   browser: 'OP516FL1',
   browserVersion: 'NE2211 (NE2211)',
   platform: 'Android',
   platformVersion: '11'
 }
+const defaultGeolocationData = '53.902284, 27.561831'
+const androidSystemFeatures = [
+  'android.hardware.camera',
+  'android.hardware.location.gps',
+  'android.hardware.location.network',
+  'android.hardware.nfc',
+  'android.hardware.telephony',
+  'android.hardware.touchscreen',
+  'android.hardware.wifi',
+  'android.software.webview'
+]
 const statementIntervalMs = 31 * 24 * 60 * 60 * 1000
 
 function generateDeviceID () {
-  return generateRandomString(16)
+  return 'xxxxxxxxxxxxxxxx'.replace(/x/g, () => Math.floor(Math.random() * 16).toString(16))
 }
 
 async function fetchApiJson (url, options, predicate = () => true, error = (message) => console.assert(false, message)) {
@@ -37,13 +48,15 @@ async function fetchApiJson (url, options, predicate = () => true, error = (mess
           login: true,
           password: true,
           deviceUDID: true,
+          deviceInfo: true,
           confirmationData: true,
           pushId: true
         }
       },
       sanitizeResponseLog: {
         body: {
-          sessionToken: true
+          sessionToken: true,
+          fingerprint: true
         }
       }
     }
@@ -84,8 +97,10 @@ function getAntiFraudID () {
   return getDataOrCreate('anti_fraud_id', generateUUID)
 }
 
-function getAntiFraudSessionID () {
-  return getDataOrCreate('anti_fraud_session_id', generateUUID)
+function setAntiFraudID (value) {
+  if (value) {
+    ZenMoney.setData('anti_fraud_id', value)
+  }
 }
 
 function getPushID () {
@@ -98,8 +113,44 @@ function getHeaders (sessionToken = null) {
     _ac1: getAntiFraudID(),
     ...(sessionToken && {
       session_token: sessionToken,
-      _ac0: getAntiFraudSessionID()
+      _ac0: sessionToken
     })
+  }
+}
+
+function normalizeDeviceInfoValue (value) {
+  return value === null || value === undefined ? '' : String(value).trim().toLowerCase()
+}
+
+function getDeviceInfo () {
+  const deviceId = getDeviceID()
+  return {
+    parameters: [
+      {
+        device_model: normalizeDeviceInfoValue('NE2211'),
+        device_name: normalizeDeviceInfoValue(androidDeviceProfile.browser),
+        deviceid: normalizeDeviceInfoValue(deviceId),
+        geolocationdata: defaultGeolocationData,
+        locale: normalizeDeviceInfoValue('ru_BY'),
+        time_zone: normalizeDeviceInfoValue('Europe/Minsk'),
+        os_name: normalizeDeviceInfoValue(androidDeviceProfile.platform),
+        os_version: normalizeDeviceInfoValue(androidDeviceProfile.platformVersion),
+        width: normalizeDeviceInfoValue(1080),
+        height: normalizeDeviceInfoValue(2400),
+        scale: normalizeDeviceInfoValue(3),
+        uuid: normalizeDeviceInfoValue(deviceId),
+        android_specific: {
+          build_bootloader: '',
+          build_display: normalizeDeviceInfoValue('NE2211_11_C.48'),
+          build_fingerprint: normalizeDeviceInfoValue('NE2211_11_C.48'),
+          build_id: normalizeDeviceInfoValue('RKQ1.211119.001'),
+          build_manufacturer: normalizeDeviceInfoValue('OnePlus'),
+          build_radio: '',
+          iccid: '',
+          package_manager_getsystemavailablefeatures: androidSystemFeatures
+        }
+      }
+    ]
   }
 }
 
@@ -233,6 +284,7 @@ async function loginReq (login, password, smsCode) {
     ...androidDeviceProfile,
     clientKind: '0',
     deviceUDID: getDeviceID(),
+    deviceInfo: getDeviceInfo(),
     login,
     password,
     pushId: getPushID()
@@ -240,13 +292,15 @@ async function loginReq (login, password, smsCode) {
   if (smsCode) {
     body.confirmationData = smsCode
   }
-  return fetchApiJson('session/login', {
+  const response = await fetchApiJson('session/login', {
     method: 'POST',
     headers: getHeaders(),
     body,
-    sanitizeRequestLog: { body: { login: true, password: true, deviceUDID: true, confirmationData: true, pushId: true } },
-    sanitizeResponseLog: { body: { sessionToken: true } }
+    sanitizeRequestLog: { body: { login: true, password: true, deviceUDID: true, deviceInfo: true, confirmationData: true, pushId: true } },
+    sanitizeResponseLog: { body: { sessionToken: true, fingerprint: true } }
   }, response => response.body && response.body.errorInfo, message => new InvalidPreferencesError('bad request'))
+  setAntiFraudID(response.body && response.body.fingerprint)
+  return response
 }
 
 export async function fetchAccounts (sessionToken) {

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -1,11 +1,13 @@
 import { MD5 } from 'jshashes'
 import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
 const BANK_TIMEZONE_OFFSET_MS = 3 * 60 * 60 * 1000
+const MS_PER_DAY = 24 * 60 * 60 * 1000
 const MERCHANT_ID_PREFIX_LENGTH = 25
 const SAFE_MERCHANT_PREFIX_MIN_LENGTH = 16
 const CANONICAL_TRANSACTION_ID_SOURCE_FIELD = 'transactionIdSource'
 const GENERIC_ACCOUNT_INCOME_NAME = 'ЗАЧИСЛЕНИЕ НА СЧЕТ'
 const CAPITALIZATION_OPERATION_NAME_PREFIX = 'КАПИТАЛИЗАЦИЯ '
+const MONEY_BACK_OPERATION_NAME_PREFIX = 'НАЧИСЛЕНИЕ MONEY-BACK'
 const md5 = new MD5()
 
 export function convertAccount (json) {
@@ -290,18 +292,61 @@ function findMatchingTransactionIndex (operation, transactions, transactionIndex
 }
 
 function areTransactionsCompatible (left, right) {
-  return getTransactionBaseKey(left) === getTransactionBaseKey(right) &&
+  const leftBaseValues = getTransactionBaseValues(left)
+  const rightBaseValues = getTransactionBaseValues(right)
+  const leftMerchantValue = getTransactionMerchantMatchValue(left)
+  const rightMerchantValue = getTransactionMerchantMatchValue(right)
+  return leftBaseValues.accountId === rightBaseValues.accountId &&
+    areTransactionDatesCompatible(left, right, leftBaseValues.date, rightBaseValues.date, leftMerchantValue, rightMerchantValue) &&
+    leftBaseValues.amount === rightBaseValues.amount &&
+    leftBaseValues.currency === rightBaseValues.currency &&
     getDuplicateIndex(left) === getDuplicateIndex(right) &&
-    areMerchantValuesCompatible(getTransactionMerchantMatchValue(left), getTransactionMerchantMatchValue(right))
+    areMerchantValuesCompatible(leftMerchantValue, rightMerchantValue)
 }
 
-function getTransactionBaseKey (json) {
-  return [
-    json.account_id,
-    getDateIdValue(getFirstPresent(json.transactionDate, json.date, json.operationDate)),
-    getAmountIdValue(getTransactionAmountIdValue(json)),
-    getTransactionCurrencyIdValue(json)
-  ].map(getIdValue).join('|')
+function getTransactionBaseValues (json) {
+  return {
+    accountId: getIdValue(json.account_id),
+    date: getIdValue(getDateIdValue(getTransactionDateValue(json))),
+    amount: getIdValue(getAmountIdValue(getTransactionAmountIdValue(json))),
+    currency: getIdValue(getTransactionCurrencyIdValue(json))
+  }
+}
+
+function getTransactionDateValue (json) {
+  return getFirstPresent(json.transactionDate, json.date, json.operationDate)
+}
+
+function areTransactionDatesCompatible (left, right, leftDate, rightDate, leftMerchantValue, rightMerchantValue) {
+  if (leftDate === rightDate) {
+    return true
+  }
+  return arePostedHoldAdjacentDatesCompatible(left, right, leftMerchantValue, rightMerchantValue)
+}
+
+function arePostedHoldAdjacentDatesCompatible (left, right, leftMerchantValue, rightMerchantValue) {
+  const posted = left.hold ? right : left
+  const hold = left.hold ? left : right
+  const postedMerchantValue = left.hold ? rightMerchantValue : leftMerchantValue
+  const holdMerchantValue = left.hold ? leftMerchantValue : rightMerchantValue
+  const postedDate = getTransactionDateValue(posted)
+  const holdDate = getTransactionDateValue(hold)
+  if (posted.hold || !hold.hold || !(postedDate instanceof Date) || !(holdDate instanceof Date)) {
+    return false
+  }
+  if (postedMerchantValue.type !== 'merchant' || postedMerchantValue.value !== holdMerchantValue.value) {
+    return false
+  }
+  return isBankLocalMidnight(postedDate) &&
+    getBankLocalDayNumber(postedDate) - getBankLocalDayNumber(holdDate) === 1
+}
+
+function getBankLocalDayNumber (date) {
+  return Math.floor((date.getTime() + BANK_TIMEZONE_OFFSET_MS) / MS_PER_DAY)
+}
+
+function isBankLocalMidnight (date) {
+  return (date.getTime() + BANK_TIMEZONE_OFFSET_MS) % MS_PER_DAY === 0
 }
 
 function getTransactionMerchantMatchValue (json) {
@@ -346,8 +391,8 @@ function normalizeOperationName (value) {
 }
 
 function areOperationNamesCompatible (left, right) {
-  return (isGenericAccountIncomeName(left) && isCapitalizationOperationName(right)) ||
-    (isGenericAccountIncomeName(right) && isCapitalizationOperationName(left))
+  return (isGenericAccountIncomeName(left) && isKnownGenericAccountIncomePeerName(right)) ||
+    (isGenericAccountIncomeName(right) && isKnownGenericAccountIncomePeerName(left))
 }
 
 function isGenericAccountIncomeName (value) {
@@ -356,4 +401,12 @@ function isGenericAccountIncomeName (value) {
 
 function isCapitalizationOperationName (value) {
   return value.indexOf(CAPITALIZATION_OPERATION_NAME_PREFIX) === 0
+}
+
+function isMoneyBackOperationName (value) {
+  return value.indexOf(MONEY_BACK_OPERATION_NAME_PREFIX) === 0
+}
+
+function isKnownGenericAccountIncomePeerName (value) {
+  return isCapitalizationOperationName(value) || isMoneyBackOperationName(value)
 }

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -2,6 +2,8 @@ import { MD5 } from 'jshashes'
 import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
 const BANK_TIMEZONE_OFFSET_MS = 3 * 60 * 60 * 1000
 const MERCHANT_ID_PREFIX_LENGTH = 25
+const SAFE_MERCHANT_PREFIX_MIN_LENGTH = 16
+const CANONICAL_TRANSACTION_ID_SOURCE_FIELD = 'transactionIdSource'
 const md5 = new MD5()
 
 export function convertAccount (json) {
@@ -75,6 +77,9 @@ function getTransactionId (json) {
 }
 
 function getTransactionIdSource (json) {
+  if (json[CANONICAL_TRANSACTION_ID_SOURCE_FIELD]) {
+    return json[CANONICAL_TRANSACTION_ID_SOURCE_FIELD]
+  }
   return [
     getTransactionIdentitySource(json),
     getDuplicateIndex(json)
@@ -118,6 +123,10 @@ function getAmountIdValue (value) {
 }
 
 function getMerchantIdValue (value) {
+  return normalizeMerchant(value).slice(0, MERCHANT_ID_PREFIX_LENGTH)
+}
+
+function normalizeMerchant (value) {
   if (value === undefined || value === null) {
     return ''
   }
@@ -127,7 +136,6 @@ function getMerchantIdValue (value) {
     .replace(/\s+/g, ' ')
     .trim()
     .toUpperCase()
-    .slice(0, MERCHANT_ID_PREFIX_LENGTH)
 }
 
 function getIdValue (value) {
@@ -195,10 +203,21 @@ export function merge (transactions, operations) {
     ...transaction,
     hold: true
   })))
-  const operationKeys = new Set(indexedOperations.map(getTransactionMatchKey))
+  const unmatchedTransactionIndexes = new Set(indexedTransactions.map((_, index) => index))
+  const matchedOperations = indexedOperations.map(operation => {
+    const matchedTransactionIndex = findMatchingTransactionIndex(operation, indexedTransactions, unmatchedTransactionIndexes)
+    if (matchedTransactionIndex === null) {
+      return operation
+    }
+    unmatchedTransactionIndexes.delete(matchedTransactionIndex)
+    return {
+      ...operation,
+      [CANONICAL_TRANSACTION_ID_SOURCE_FIELD]: getTransactionIdSource(indexedTransactions[matchedTransactionIndex])
+    }
+  })
   return [
-    ...indexedOperations,
-    ...indexedTransactions.filter(transaction => !operationKeys.has(getTransactionMatchKey(transaction)))
+    ...matchedOperations,
+    ...indexedTransactions.filter((_, index) => unmatchedTransactionIndexes.has(index))
   ]
 }
 
@@ -234,4 +253,57 @@ function getDuplicateOrderTime (json) {
 
 function getTransactionMatchKey (json) {
   return `${getTransactionIdentity(json)}|${getDuplicateIndex(json)}`
+}
+
+function findMatchingTransactionIndex (operation, transactions, transactionIndexes) {
+  const candidates = [...transactionIndexes].filter(index => {
+    return areTransactionsCompatible(operation, transactions[index])
+  })
+  const exactMatch = candidates.find(index => getTransactionMatchKey(operation) === getTransactionMatchKey(transactions[index]))
+  return exactMatch === undefined ? candidates[0] ?? null : exactMatch
+}
+
+function areTransactionsCompatible (left, right) {
+  return getTransactionBaseKey(left) === getTransactionBaseKey(right) &&
+    getDuplicateIndex(left) === getDuplicateIndex(right) &&
+    areMerchantValuesCompatible(getTransactionMerchantMatchValue(left), getTransactionMerchantMatchValue(right))
+}
+
+function getTransactionBaseKey (json) {
+  return [
+    json.account_id,
+    getDateIdValue(getFirstPresent(json.transactionDate, json.date, json.operationDate)),
+    getAmountIdValue(getFirstPresent(json.transactionAmount, json.operationAmount, json.sum)),
+    getFirstPresent(json.transactionCurrencyCode, json.operationCurrencyCode, json.accountCurrencyCode, json.currencyCode, json.currency)
+  ].map(getIdValue).join('|')
+}
+
+function getTransactionMerchantMatchValue (json) {
+  const merchant = normalizeMerchant(json.merchant)
+  if (merchant) {
+    return {
+      value: merchant,
+      allowPrefixMatch: true
+    }
+  }
+  return {
+    value: getIdValue(getFirstPresent(json.operationName, json.transactionName)),
+    allowPrefixMatch: false
+  }
+}
+
+function areMerchantValuesCompatible (left, right) {
+  if (left.value === right.value) {
+    return true
+  }
+  if (!left.allowPrefixMatch || !right.allowPrefixMatch || !left.value || !right.value) {
+    return false
+  }
+  const leftPrefix = left.value.slice(0, MERCHANT_ID_PREFIX_LENGTH)
+  const rightPrefix = right.value.slice(0, MERCHANT_ID_PREFIX_LENGTH)
+  if (leftPrefix === rightPrefix) {
+    return true
+  }
+  return Math.min(left.value.length, right.value.length) >= SAFE_MERCHANT_PREFIX_MIN_LENGTH &&
+    (left.value.startsWith(right.value) || right.value.startsWith(left.value))
 }

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -48,13 +48,12 @@ export function convertTransaction (json) {
   if (!sum) {
     return null
   }
-  const id = getTransactionId(json)
   const transaction = {
     hold: json.hold || false,
     date: json.transactionDate || json.date,
     movements: [
       {
-        id,
+        id: getTransactionId(json),
         account: { id: json.account_id },
         invoice: null,
         sum,
@@ -72,7 +71,7 @@ export function convertTransaction (json) {
 }
 
 function getTransactionId (json) {
-  return md5.hex(getTransactionIdSource(json))
+  return getTransactionIdSource(json)
 }
 
 function getTransactionIdSource (json) {

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -73,7 +73,9 @@ export function convertTransaction (json) {
 }
 
 function getTransactionId (json) {
-  return getTransactionIdSource(json)
+  const source = getTransactionIdSource(json)
+  console.log('SolutionBank transaction id source', source)
+  return md5.hex(source)
 }
 
 function getTransactionIdSource (json) {

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -4,6 +4,8 @@ const BANK_TIMEZONE_OFFSET_MS = 3 * 60 * 60 * 1000
 const MERCHANT_ID_PREFIX_LENGTH = 25
 const SAFE_MERCHANT_PREFIX_MIN_LENGTH = 16
 const CANONICAL_TRANSACTION_ID_SOURCE_FIELD = 'transactionIdSource'
+const GENERIC_ACCOUNT_INCOME_NAME = 'ЗАЧИСЛЕНИЕ НА СЧЕТ'
+const CAPITALIZATION_OPERATION_NAME_PREFIX = 'КАПИТАЛИЗАЦИЯ '
 const md5 = new MD5()
 
 export function convertAccount (json) {
@@ -96,8 +98,8 @@ function getTransactionIdentitySource (json) {
   return [
     json.account_id,
     getDateIdValue(getFirstPresent(json.transactionDate, json.date, json.operationDate)),
-    getAmountIdValue(getFirstPresent(json.transactionAmount, json.operationAmount, json.sum)),
-    getFirstPresent(json.transactionCurrencyCode, json.operationCurrencyCode, json.accountCurrencyCode, json.currencyCode, json.currency),
+    getAmountIdValue(getTransactionAmountIdValue(json)),
+    getTransactionCurrencyIdValue(json),
     getMerchantIdValue(json.merchant) || getFirstPresent(json.operationName, json.transactionName)
   ].map(getIdValue).join('|')
 }
@@ -122,6 +124,28 @@ function getAmountIdValue (value) {
     return ''
   }
   return parseAmount(value).toFixed(2)
+}
+
+function getTransactionAmountIdValue (json) {
+  const transactionAmount = getFirstPresent(json.transactionAmount)
+  const operationAmount = getFirstPresent(json.operationAmount, json.sum)
+  if (isZeroAmount(transactionAmount) && !isZeroAmount(operationAmount)) {
+    return operationAmount
+  }
+  return getFirstPresent(json.transactionAmount, json.operationAmount, json.sum)
+}
+
+function getTransactionCurrencyIdValue (json) {
+  const transactionAmount = getFirstPresent(json.transactionAmount)
+  const operationAmount = getFirstPresent(json.operationAmount, json.sum)
+  if (isZeroAmount(transactionAmount) && !isZeroAmount(operationAmount)) {
+    return getFirstPresent(json.operationCurrencyCode, json.accountCurrencyCode, json.currencyCode, json.currency, json.transactionCurrencyCode)
+  }
+  return getFirstPresent(json.transactionCurrencyCode, json.operationCurrencyCode, json.accountCurrencyCode, json.currencyCode, json.currency)
+}
+
+function isZeroAmount (value) {
+  return value !== undefined && value !== null && value !== '' && parseAmount(value) === 0
 }
 
 function getMerchantIdValue (value) {
@@ -275,8 +299,8 @@ function getTransactionBaseKey (json) {
   return [
     json.account_id,
     getDateIdValue(getFirstPresent(json.transactionDate, json.date, json.operationDate)),
-    getAmountIdValue(getFirstPresent(json.transactionAmount, json.operationAmount, json.sum)),
-    getFirstPresent(json.transactionCurrencyCode, json.operationCurrencyCode, json.accountCurrencyCode, json.currencyCode, json.currency)
+    getAmountIdValue(getTransactionAmountIdValue(json)),
+    getTransactionCurrencyIdValue(json)
   ].map(getIdValue).join('|')
 }
 
@@ -285,11 +309,13 @@ function getTransactionMerchantMatchValue (json) {
   if (merchant) {
     return {
       value: merchant,
+      type: 'merchant',
       allowPrefixMatch: true
     }
   }
   return {
-    value: getIdValue(getFirstPresent(json.operationName, json.transactionName)),
+    value: normalizeOperationName(getFirstPresent(json.operationName, json.transactionName)),
+    type: 'operationName',
     allowPrefixMatch: false
   }
 }
@@ -297,6 +323,9 @@ function getTransactionMerchantMatchValue (json) {
 function areMerchantValuesCompatible (left, right) {
   if (left.value === right.value) {
     return true
+  }
+  if (left.type === 'operationName' && right.type === 'operationName') {
+    return areOperationNamesCompatible(left.value, right.value)
   }
   if (!left.allowPrefixMatch || !right.allowPrefixMatch || !left.value || !right.value) {
     return false
@@ -308,4 +337,23 @@ function areMerchantValuesCompatible (left, right) {
   }
   return Math.min(left.value.length, right.value.length) >= SAFE_MERCHANT_PREFIX_MIN_LENGTH &&
     (left.value.startsWith(right.value) || right.value.startsWith(left.value))
+}
+
+function normalizeOperationName (value) {
+  return value
+    ? String(value).replace(/\s+/g, ' ').trim().toUpperCase()
+    : ''
+}
+
+function areOperationNamesCompatible (left, right) {
+  return (isGenericAccountIncomeName(left) && isCapitalizationOperationName(right)) ||
+    (isGenericAccountIncomeName(right) && isCapitalizationOperationName(left))
+}
+
+function isGenericAccountIncomeName (value) {
+  return value === GENERIC_ACCOUNT_INCOME_NAME
+}
+
+function isCapitalizationOperationName (value) {
+  return value.indexOf(CAPITALIZATION_OPERATION_NAME_PREFIX) === 0
 }

--- a/src/windowLoader.jsx
+++ b/src/windowLoader.jsx
@@ -26,6 +26,7 @@ let state = {
   scrapeState: ':scrape-state/none',
   scrapeResult: null,
   scrapeError: null,
+  userInputRequest: null,
   persistPluginDataState: ':persist-plugin-data-state/none',
   persistPluginDataError: null,
   onPersistPluginDataConfirm: null
@@ -130,7 +131,14 @@ async function init () {
         event,
         onSyncStarted: () => setState((state) => ({ ...state, scrapeState: ':scrape-state/started' })),
         onSyncSuccess: resolve,
-        onSyncError: reject
+        onSyncError: reject,
+        onUserInputRequest: ({ message, options }) => new Promise((resolve) => {
+          const submit = (result) => {
+            setState((state) => ({ ...state, userInputRequest: null }))
+            resolve(result)
+          }
+          setState((state) => ({ ...state, userInputRequest: { message, options, submit } }))
+        })
       }))
       worker.postMessage({
         type: ':commands/execute-sync',


### PR DESCRIPTION
## Что изменено

- Обновлен login-контракт SolutionBank под мобильное приложение 1.60.0:
  - `applicID` обновлен до `1.60.0`
  - добавлен `deviceInfo` с Android fingerprint-данными и геолокацией
  - `fingerprint` из ответа логина сохраняется как anti-fraud id
  - `_ac0` для авторизованных запросов теперь соответствует session token
- Стабилизированы hashed transaction ids:
  - id строится от canonical source, а не от нестабильного bank movement id
  - исходная строка canonical id выводится в лог для диагностики
- Улучшено слияние мини-выписки и полной выписки:
  - матчинг идет по account/date/amount/currency/merchant
  - учитываются обрезанные merchant-строки, например `SHOP "KERAMIKA" / STOLITSA` vs `SHOP "KERAMIKA" / STOLITS`
  - учитываются hold+posted пары с датой полной выписки на следующий банковский день
  - обработаны зачисления, где мини-выписка пишет `Зачисление на счет`, а полная выписка раскрывает `Капитализация...` или `Начисление Money-back...`
- В debug UI добавлена форма ввода для `ZenMoney.readLine`, чтобы SMS-код вводился прямо на локальной странице вместо невидимого `window.prompt`.

## Проверка

- `jest src/plugins/solutionbank/__tests__/api.test.js --runInBand`
- `ts-standard` по измененным JS-файлам
- `git diff --check`
- Live-проверка логина дошла до SMS-челленджа `10415`; ошибки обязательного обновления и отсутствующей геолокации больше не воспроизводятся.