### PR TITLE
fix(bcc): fetch transactions for multi-currency cards

### DIFF
--- a/src/plugins/bcc-kz/__tests__/api/fetchTransactions.test.js
+++ b/src/plugins/bcc-kz/__tests__/api/fetchTransactions.test.js
@@ -42,7 +42,7 @@ describe('bcc-kz fetchTransactions web api', () => {
         accessToken: 'bearer-token',
         sessionCode: 'session-code'
       },
-      { productId: 14120379 },
+      { productId: 14120379, productType: 'checking' },
       new Date('2026-02-27T00:00:00+06:00'),
       new Date('2026-03-05T00:00:00+06:00')
     )
@@ -55,7 +55,30 @@ describe('bcc-kz fetchTransactions web api', () => {
     expect(url).toContain('date_end=05.03.2026')
     expect(url).toContain('session_code=session-code')
     expect(url).toContain('timestamp=')
+    expect(url).not.toContain('cardacc')
     expect(global.fetch.mock.calls[0][1].headers.Authorization).toBe('Bearer bearer-token')
+  })
+
+  it('adds cardacc=1 for card products so the card statement view is queried', async () => {
+    global.fetch.mockResolvedValueOnce(makeNetworkResponse({
+      success: true,
+      stmt: []
+    }))
+
+    await fetchTransactions(
+      {
+        accessToken: 'bearer-token',
+        sessionCode: 'session-code'
+      },
+      { productId: 30000002, productType: 'ccard' },
+      new Date('2026-05-01T00:00:00+06:00'),
+      new Date('2026-05-31T00:00:00+06:00')
+    )
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const url = global.fetch.mock.calls[0][0]
+    expect(url).toContain('account_id=30000002')
+    expect(url).toContain('cardacc=1')
   })
 
   it('falls back to chunked requests on html 504 response', async () => {
@@ -75,7 +98,7 @@ describe('bcc-kz fetchTransactions web api', () => {
         accessToken: 'bearer-token',
         sessionCode: 'session-code'
       },
-      { productId: 14120379 },
+      { productId: 14120379, productType: 'checking' },
       new Date('2026-01-01T00:00:00+06:00'),
       new Date('2026-02-09T00:00:00+06:00')
     )
@@ -86,5 +109,60 @@ describe('bcc-kz fetchTransactions web api', () => {
     expect(global.fetch.mock.calls[2][0]).toContain('date_begin=01.02.2026')
     expect(global.fetch.mock.calls[2][0]).toContain('date_end=09.02.2026')
     expect(result).toEqual([{ trn_id: 'a' }, { trn_id: 'b' }])
+  })
+
+  it('keeps cardacc=1 across every chunk of the chunked fallback for card products', async () => {
+    global.fetch
+      .mockResolvedValueOnce(makeHtmlResponse('<html><h1>504 Gateway Time-out</h1></html>'))
+      .mockResolvedValueOnce(makeNetworkResponse({
+        success: true,
+        stmt: []
+      }))
+      .mockResolvedValueOnce(makeNetworkResponse({
+        success: true,
+        stmt: []
+      }))
+
+    await fetchTransactions(
+      {
+        accessToken: 'bearer-token',
+        sessionCode: 'session-code'
+      },
+      { productId: 30000002, productType: 'ccard' },
+      new Date('2026-01-01T00:00:00+06:00'),
+      new Date('2026-02-09T00:00:00+06:00')
+    )
+
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    for (const call of global.fetch.mock.calls) {
+      expect(call[0]).toContain('cardacc=1')
+    }
+  })
+
+  it('fetches a separate statement for the card and each of its multi-currency sub-accounts', async () => {
+    global.fetch
+      .mockResolvedValueOnce(makeNetworkResponse({ success: true, stmt: [{ trn_id: 'kzt' }] }))
+      .mockResolvedValueOnce(makeNetworkResponse({ success: true, stmt: [{ trn_id: 'eur' }] }))
+      .mockResolvedValueOnce(makeNetworkResponse({ success: true, stmt: [{ trn_id: 'usd' }] }))
+
+    const result = await fetchTransactions(
+      {
+        accessToken: 'bearer-token',
+        sessionCode: 'session-code'
+      },
+      { productId: '30000001', productType: 'ccard', statementAccountIds: ['30000001', '30000002', '30000003'] },
+      new Date('2026-06-01T00:00:00+06:00'),
+      new Date('2026-06-27T00:00:00+06:00')
+    )
+
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(global.fetch.mock.calls[0][0]).toContain('account_id=30000001')
+    expect(global.fetch.mock.calls[1][0]).toContain('account_id=30000002')
+    expect(global.fetch.mock.calls[2][0]).toContain('account_id=30000003')
+    for (const call of global.fetch.mock.calls) {
+      expect(call[0]).toContain('action=GET_EXT_STATEMENT')
+      expect(call[0]).toContain('cardacc=1')
+    }
+    expect(result).toEqual([{ trn_id: 'kzt' }, { trn_id: 'eur' }, { trn_id: 'usd' }])
   })
 })

--- a/src/plugins/bcc-kz/__tests__/converters/accounts/debitCard.js
+++ b/src/plugins/bcc-kz/__tests__/converters/accounts/debitCard.js
@@ -259,7 +259,8 @@ describe('convertAccounts', () => {
         {
           product: {
             productId: '5453672',
-            productType: 'ccard'
+            productType: 'ccard',
+            statementAccountIds: ['5453672', '5448109']
           },
           accounts: [
             {

--- a/src/plugins/bcc-kz/api.js
+++ b/src/plugins/bcc-kz/api.js
@@ -321,8 +321,24 @@ export async function fetchAccounts (auth) {
 export async function fetchTransactions (auth, product, fromDate, toDate) {
   const fromKzTime = dateInTimezone(fromDate, 6 * 60)
   const toKzTime = dateInTimezone(toDate, 6 * 60)
+
+  // A multi-currency card keeps its actual transactions on per-currency sub-accounts
+  // (`multiaccs`), each queried by its own account_id. The card's own id holds only the
+  // main-currency operations, so we must pull a statement for every sub-account.
+  const statementAccountIds = product.statementAccountIds?.length
+    ? product.statementAccountIds
+    : [product.productId]
+
+  const transactions = []
+  for (const accountId of statementAccountIds) {
+    transactions.push(...await fetchAccountStatement(auth, product, accountId, fromKzTime, toKzTime))
+  }
+  return transactions
+}
+
+async function fetchAccountStatement (auth, product, accountId, fromKzTime, toKzTime) {
   try {
-    return await fetchTransactionsChunk(auth, product.productId, fromKzTime, toKzTime)
+    return await fetchTransactionsChunk(auth, product, accountId, fromKzTime, toKzTime)
   } catch (error) {
     if (!shouldFallbackToChunkedFetch(error, fromKzTime, toKzTime)) {
       throw error
@@ -331,7 +347,7 @@ export async function fetchTransactions (auth, product, fromDate, toDate) {
     const transactions = []
     for (const [intervalFrom, intervalTo] of createDateIntervals(fromKzTime, toKzTime, 31)) {
       try {
-        const chunkTransactions = await fetchTransactionsChunk(auth, product.productId, intervalFrom, intervalTo)
+        const chunkTransactions = await fetchTransactionsChunk(auth, product, accountId, intervalFrom, intervalTo)
         transactions.push(...chunkTransactions)
       } catch (chunkError) {
         if (isHtmlGatewayError(chunkError)) {
@@ -344,19 +360,20 @@ export async function fetchTransactions (auth, product, fromDate, toDate) {
   }
 }
 
-async function fetchTransactionsChunk (auth, productId, fromDate, toDate) {
+async function fetchTransactionsChunk (auth, product, accountId, fromDate, toDate) {
   const response = await fetchMainApi(auth, {
-    account_id: productId,
+    account_id: accountId,
     action: 'GET_EXT_STATEMENT',
     date_begin: formatDate(fromDate),
-    date_end: formatDate(toDate)
+    date_end: formatDate(toDate),
+    ...(product.productType === 'ccard' && { cardacc: '1' })
   })
   if (response.body.reason === 'Вы не являетесь владельцем счета') {
     return []
   }
   assertSuccessResponse(response)
 
-  return response.body.stmt
+  return response.body.stmt ?? []
 }
 
 function shouldFallbackToChunkedFetch (error, fromDate, toDate) {

--- a/src/plugins/bcc-kz/converters.js
+++ b/src/plugins/bcc-kz/converters.js
@@ -10,10 +10,7 @@ export function convertAccounts (apiAccounts) {
         switch (apiAccount.card_type) {
           case 'debit':
             account.push({
-              product: {
-                productId: apiAccount.id.toString(),
-                productType: 'ccard'
-              },
+              product: buildCardProduct(apiAccount),
               accounts: [convertDebitCard(apiAccount)]
             })
             if (apiAccount.multiaccs) {
@@ -25,10 +22,7 @@ export function convertAccounts (apiAccounts) {
             break
           case 'credit':
             account.push({
-              product: {
-                productId: apiAccount.id.toString(),
-                productType: 'ccard'
-              },
+              product: buildCardProduct(apiAccount),
               accounts: [convertCreditCard(apiAccount)]
             })
             filterDoubleCards(apiAccount, accounts, account)
@@ -85,6 +79,22 @@ export function convertAccounts (apiAccounts) {
     }
   }
   return accounts
+}
+
+function buildCardProduct (apiAccount) {
+  const product = {
+    productId: apiAccount.id.toString(),
+    productType: 'ccard'
+  }
+  // Multi-currency cards keep transactions on per-currency sub-accounts; collect every
+  // account_id that has to be queried for a statement (the card itself + each sub-account).
+  if (Array.isArray(apiAccount.multiaccs) && apiAccount.multiaccs.length > 0) {
+    product.statementAccountIds = [
+      apiAccount.id.toString(),
+      ...apiAccount.multiaccs.map(multiacc => multiacc.id.toString())
+    ]
+  }
+  return product
 }
 
 function filterDoubleCards (apiAccount, accounts, account) {


### PR DESCRIPTION
## Problem

BCC only syncs card transactions of the main account: If you have a multi-currency card, it only syncs the KZT account. This PR fixes the script so it loads all transactions from all card accounts. Debugged the issue using a HAR archive of the BCC website, plus tested the script using a real account – syncs correctly after the changes. Below is Claude's description of the problem. 

## Root cause

The card is **multi-currency**: its real transactions live not on the card itself but on its per-currency sub-accounts (`multiaccs`), and each sub-account is queried from `GET_EXT_STATEMENT` by its own `account_id`:

- card id → main-currency account (nearly empty) ← **the only id the plugin queried**
- sub-account → EUR (where the transactions actually are)
- sub-account → USD

The plugin already exposed the sub-accounts as ZenMoney accounts (for balances) but requested a statement **only for the card's own id**, so EUR/USD operations were never fetched.

## Changes

- **`converters.js`** — for a card that has `multiaccs`, the product now carries `statementAccountIds = [cardId, ...subAccountIds]` (extracted into `buildCardProduct`). Cards without sub-accounts and all non-card products are unchanged.
- **`api.js`** — `fetchTransactions` requests a statement for **each** `account_id` in `statementAccountIds` and concatenates the results (the existing 31-day chunking / 504 fallback is preserved per sub-account). Card statement requests are sent with `cardacc=1`, matching the bank's own web client for card sub-accounts; per-currency routing of operations to the right account already happens in `convertTransaction` (keyed on the transaction's `cur`).
- **tests** — added a test asserting a separate statement is fetched for the card and each of its sub-accounts; updated the one converter fixture that has `multiaccs` to expect `statementAccountIds`; plus the `cardacc=1` cases.

## Verification

Ran the full plugin path (`login → fetchAccounts → convertAccounts → fetchTransactions → convertTransaction`) against a real account:

- the card issued **3** statement requests (card id + both sub-account ids), all with `cardacc=1`;
- **23** operations loaded instead of ~6: `{ EUR: 9, KZT: 6, USD: 8 }`, covering the card's full available history (from its open date through today);
- all 23 converted with no drops and routed to the correct per-currency accounts.

`jest src/plugins/bcc-kz` — 20 suites / 55 tests pass; `ts-standard` clean.
