### PR TITLE
Add Jupiter Card plugin

### DIFF
--- a/src/plugins/jupitercard/ZenmoneyManifest.xml
+++ b/src/plugins/jupitercard/ZenmoneyManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>jupitercard</id>
+    <company>0</company> <!-- internal zenmoney id, to be set during the merge -->
+    <description>Jupiter Card (global.jup.ag) — card account sync via email OTP.</description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+</provider>

--- a/src/plugins/jupitercard/__tests__/api/degenerateResponses.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/degenerateResponses.test.ts
@@ -1,0 +1,69 @@
+import { convertAccounts } from '../../converters'
+import { JupiterBalance } from '../../models'
+
+const mockSeedCookies = jest.fn()
+const mockCurrentAuth = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchBalance = jest.fn()
+const mockFetchTransactions = jest.fn()
+const mockSendCode = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  seedCookies: mockSeedCookies,
+  currentAuth: mockCurrentAuth,
+  fetchCards: mockFetchCards,
+  fetchBalance: mockFetchBalance,
+  fetchTransactions: mockFetchTransactions,
+  sendCode: mockSendCode
+}))
+
+const auth = { accessToken: 'AT', refreshToken: 'RT' }
+const preferences = { email: 'a@b.c' }
+const fromDate = new Date('2026-01-01T00:00:00Z')
+const balance: JupiterBalance = { currency: 'USD', spendableBalance: 100, withdrawableBalance: 100 }
+
+describe('degenerate Jupiter responses must not corrupt the ledger', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeJupiter } = require('../../api') as typeof import('../../api')
+
+  beforeEach(() => {
+    mockFetchBalance.mockResolvedValue(balance)
+    mockFetchTransactions.mockResolvedValue([])
+    mockSeedCookies.mockResolvedValue(undefined)
+    mockCurrentAuth.mockResolvedValue(auth)
+    global.ZenMoney = { isAccountSkipped: jest.fn(() => false) } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('an empty cards list produces NO account — never a phantom duplicate', () => {
+    // inventing an account here would give it a different id from the real one,
+    // and ZenMoney would create a second "Jupiter Card" account alongside it
+    expect(convertAccounts([], balance)).toEqual([])
+  })
+
+  it('a transient empty cards response reports nothing rather than a phantom account', async () => {
+    mockFetchCards.mockResolvedValue([])
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts).toEqual([])
+    expect(result.transactions).toEqual([])
+    expect(mockFetchTransactions).not.toHaveBeenCalled() // nothing to attach them to
+  })
+
+  it('an empty balance body does not crash (would have been undefined.currency)', async () => {
+    mockFetchCards.mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+    mockFetchBalance.mockResolvedValue({}) // what fetchBalance now returns for a garbage body
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts).toHaveLength(1)
+    expect(result.accounts[0].instrument).toBe('USD') // safe default
+    expect(result.accounts[0].balance).toBeNull() // honestly unknown, not NaN
+  })
+
+  it('a card without an id still yields an account keyed by its card account', async () => {
+    mockFetchCards.mockResolvedValue([{ cardAccountId: 'acct_1', last4: '1234' }])
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts).toHaveLength(1)
+    expect(result.accounts[0].id).toBe('acct_1')
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/multiAccount.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/multiAccount.test.ts
@@ -1,0 +1,78 @@
+import { Auth, JupiterTransaction } from '../../models'
+
+const mockSeedCookies = jest.fn()
+const mockCurrentAuth = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchBalance = jest.fn()
+const mockFetchTransactions = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  seedCookies: mockSeedCookies,
+  currentAuth: mockCurrentAuth,
+  fetchCards: mockFetchCards,
+  fetchBalance: mockFetchBalance,
+  fetchTransactions: mockFetchTransactions
+}))
+
+const auth: Auth = { accessToken: 'AT', refreshToken: 'RT' }
+const preferences = { email: 'a@b.c' }
+const fromDate = new Date('2026-01-01T00:00:00Z')
+
+function tx (id: string, cardId: string | null): JupiterTransaction {
+  return {
+    id,
+    cardId,
+    type: 'CARD',
+    direction: 'DEBIT',
+    settlementCurrency: 'USD',
+    settlementAmount: '10.00',
+    transactionCurrency: 'USD',
+    transactionAmount: '10.00',
+    onchainSignature: null,
+    transactionTimestamp: '2026-02-01T12:00:00.000Z',
+    card: { merchantName: 'SHOP', merchantCategoryCode: '5814', settlementTimestamp: '2026-02-01T12:01:00.000Z' }
+  }
+}
+
+describe('scrapeJupiter — several card accounts', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeJupiter } = require('../../api') as typeof import('../../api')
+
+  beforeEach(() => {
+    mockFetchCards.mockResolvedValue([
+      { id: 'card_1', cardAccountId: 'acct_1', last4: '1111' },
+      { id: 'card_2', cardAccountId: 'acct_2', last4: '2222' }
+    ])
+    mockFetchBalance.mockResolvedValue({ currency: 'USD', spendableBalance: 10, withdrawableBalance: 10 })
+    mockSeedCookies.mockResolvedValue(undefined)
+    mockCurrentAuth.mockResolvedValue(auth)
+    global.ZenMoney = { isAccountSkipped: jest.fn(() => false) } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('routes each transaction to the account of the card it was made with', async () => {
+    mockFetchTransactions.mockResolvedValue([tx('a', 'card_1'), tx('b', 'card_2')])
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts.map((a) => a.id)).toEqual(['acct_1', 'acct_2'])
+    const byId = new Map(result.transactions.map((t) => [t.movements[0].id, t.movements[0].account]))
+    expect(byId.get('a')).toEqual({ id: 'acct_1' })
+    expect(byId.get('b')).toEqual({ id: 'acct_2' })
+  })
+
+  it('falls back to the primary account when a transaction has no cardId (e.g. a deposit)', async () => {
+    mockFetchTransactions.mockResolvedValue([tx('deposit', null)])
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.transactions[0].movements[0].account).toEqual({ id: 'acct_1' })
+  })
+
+  it('drops transactions of a skipped account but keeps the others', async () => {
+    const skipped = ZenMoney.isAccountSkipped as jest.Mock
+    skipped.mockImplementation((id: string) => id === 'acct_2')
+    mockFetchTransactions.mockResolvedValue([tx('a', 'card_1'), tx('b', 'card_2')])
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts).toHaveLength(2) // both still reported
+    expect(result.transactions.map((t) => t.movements[0].id)).toEqual(['a'])
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/reloginOnlyWhenDead.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/reloginOnlyWhenDead.test.ts
@@ -1,0 +1,68 @@
+import { TemporaryError } from '../../../../errors'
+import { Auth } from '../../models'
+
+const mockSeedCookies = jest.fn()
+const mockCurrentAuth = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchBalance = jest.fn()
+const mockFetchTransactions = jest.fn()
+const mockSendCode = jest.fn()
+const mockVerifyCode = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  seedCookies: mockSeedCookies,
+  currentAuth: mockCurrentAuth,
+  fetchCards: mockFetchCards,
+  fetchBalance: mockFetchBalance,
+  fetchTransactions: mockFetchTransactions,
+  sendCode: mockSendCode,
+  verifyCode: mockVerifyCode
+}))
+
+const auth: Auth = { accessToken: 'AT', refreshToken: 'RT' }
+const preferences = { email: 'a@b.c' }
+const fromDate = new Date('2026-01-01T00:00:00Z')
+
+describe('scrapeJupiter — re-login only when the session is really dead', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeJupiter } = require('../../api') as typeof import('../../api')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { SessionExpiredError } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  beforeEach(() => {
+    mockFetchBalance.mockResolvedValue({ currency: 'USD', spendableBalance: 10, withdrawableBalance: 10 })
+    mockFetchTransactions.mockResolvedValue([])
+    mockSeedCookies.mockResolvedValue(undefined)
+    mockCurrentAuth.mockResolvedValue(auth)
+    mockVerifyCode.mockResolvedValue(auth)
+    global.ZenMoney = {
+      isAccountSkipped: jest.fn(() => false),
+      readLine: jest.fn(async () => '123456'),
+      setData: jest.fn(),
+      saveData: jest.fn()
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('does NOT send a new OTP when Jupiter fails transiently', async () => {
+    mockFetchCards.mockRejectedValue(new TemporaryError('Jupiter 503 for /api/proxy/cards'))
+    // NB: toThrow() can't be used — ZPAPIError does not extend Error at runtime
+    await expect(scrapeJupiter(preferences, fromDate, auth)).rejects.toBeInstanceOf(TemporaryError)
+    // the whole point: a 5xx must not email the user a code
+    expect(mockSendCode).not.toHaveBeenCalled()
+    expect(ZenMoney.readLine).not.toHaveBeenCalled()
+  })
+
+  it('re-logins (new OTP) only when the session is expired', async () => {
+    mockFetchCards
+      .mockRejectedValueOnce(new SessionExpiredError())
+      .mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(mockSendCode).toHaveBeenCalledWith('a@b.c')
+    expect(ZenMoney.readLine).toHaveBeenCalled()
+    expect(mockVerifyCode).toHaveBeenCalledWith('a@b.c', '123456')
+    expect(result.accounts).toHaveLength(1)
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/sessionDurability.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/sessionDurability.test.ts
@@ -1,0 +1,61 @@
+import { TemporaryError } from '../../../../errors'
+
+const mockSeedCookies = jest.fn()
+const mockCurrentAuth = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchBalance = jest.fn()
+const mockFetchTransactions = jest.fn()
+const mockSendCode = jest.fn()
+const mockVerifyCode = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  seedCookies: mockSeedCookies,
+  currentAuth: mockCurrentAuth,
+  fetchCards: mockFetchCards,
+  fetchBalance: mockFetchBalance,
+  fetchTransactions: mockFetchTransactions,
+  sendCode: mockSendCode,
+  verifyCode: mockVerifyCode
+}))
+
+const freshAuth = { accessToken: 'NEW', refreshToken: 'NEW_R' }
+const preferences = { email: 'a@b.c' }
+const fromDate = new Date('2026-01-01T00:00:00Z')
+
+describe('a session the user paid an OTP for is never discarded', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeJupiter } = require('../../api') as typeof import('../../api')
+
+  beforeEach(() => {
+    mockFetchBalance.mockResolvedValue({ currency: 'USD', spendableBalance: 10, withdrawableBalance: 10 })
+    mockFetchTransactions.mockResolvedValue([])
+    mockSeedCookies.mockResolvedValue(undefined)
+    mockCurrentAuth.mockResolvedValue(freshAuth)
+    mockVerifyCode.mockResolvedValue(freshAuth)
+    global.ZenMoney = {
+      isAccountSkipped: jest.fn(() => false),
+      readLine: jest.fn(async () => '123456'),
+      setData: jest.fn(),
+      saveData: jest.fn()
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('persists the new session IMMEDIATELY after login, before fetching', async () => {
+    mockFetchCards.mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+    await scrapeJupiter(preferences, fromDate, undefined)
+    expect(ZenMoney.setData).toHaveBeenCalledWith('auth', freshAuth)
+    expect(ZenMoney.saveData).toHaveBeenCalled()
+  })
+
+  it('keeps the session even when the fetch fails right after login (no second OTP next run)', async () => {
+    // login succeeds → then Jupiter wobbles. The session must survive, otherwise
+    // the next sync would demand another code for a session we already have.
+    mockFetchCards.mockRejectedValue(new TemporaryError('Jupiter 503'))
+    await expect(scrapeJupiter(preferences, fromDate, undefined)).rejects.toBeInstanceOf(TemporaryError)
+    expect(ZenMoney.setData).toHaveBeenCalledWith('auth', freshAuth)
+    expect(ZenMoney.saveData).toHaveBeenCalled()
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/skippedAccount.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/skippedAccount.test.ts
@@ -1,0 +1,53 @@
+import { Auth } from '../../models'
+
+const mockSeedCookies = jest.fn()
+const mockCurrentAuth = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchBalance = jest.fn()
+const mockFetchTransactions = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  seedCookies: mockSeedCookies,
+  currentAuth: mockCurrentAuth,
+  fetchCards: mockFetchCards,
+  fetchBalance: mockFetchBalance,
+  fetchTransactions: mockFetchTransactions
+}))
+
+const auth: Auth = { accessToken: 'AT', refreshToken: 'RT' }
+const preferences = { email: 'a@b.c' }
+const fromDate = new Date('2026-01-01T00:00:00Z')
+
+describe('scrapeJupiter — account skipping', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeJupiter } = require('../../api') as typeof import('../../api')
+
+  beforeEach(() => {
+    mockFetchCards.mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+    mockFetchBalance.mockResolvedValue({ currency: 'USD', spendableBalance: 10, withdrawableBalance: 10 })
+    mockFetchTransactions.mockResolvedValue([])
+    mockSeedCookies.mockResolvedValue(undefined)
+    mockCurrentAuth.mockResolvedValue(auth)
+    global.ZenMoney = { isAccountSkipped: jest.fn(() => false) } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('fetches transactions when the account is not skipped', async () => {
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts).toHaveLength(1)
+    expect(ZenMoney.isAccountSkipped).toHaveBeenCalledWith('acct_1')
+    expect(mockFetchTransactions).toHaveBeenCalled()
+  })
+
+  it('still reports the account but skips fetching transactions when the user disabled it', async () => {
+    const skipped = ZenMoney.isAccountSkipped as jest.Mock
+    skipped.mockReturnValue(true)
+    const result = await scrapeJupiter(preferences, fromDate, auth)
+    expect(result.accounts).toHaveLength(1)
+    expect(result.accounts[0].id).toBe('acct_1')
+    expect(result.transactions).toEqual([])
+    expect(mockFetchTransactions).not.toHaveBeenCalled()
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/untrustedState.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/untrustedState.test.ts
@@ -1,0 +1,136 @@
+import { InvalidPreferencesError } from '../../../../errors'
+
+const mockSeedCookies = jest.fn()
+const mockCurrentAuth = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchBalance = jest.fn()
+const mockFetchTransactions = jest.fn()
+const mockSendCode = jest.fn()
+const mockVerifyCode = jest.fn()
+
+jest.mock('../../fetchApi', () => ({
+  ...jest.requireActual('../../fetchApi'),
+  seedCookies: mockSeedCookies,
+  currentAuth: mockCurrentAuth,
+  fetchCards: mockFetchCards,
+  fetchBalance: mockFetchBalance,
+  fetchTransactions: mockFetchTransactions,
+  sendCode: mockSendCode,
+  verifyCode: mockVerifyCode
+}))
+
+const auth = { accessToken: 'AT', refreshToken: 'RT' }
+const preferences = { email: 'a@b.c' }
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+
+describe('scrapeJupiter — untrusted inputs', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeJupiter } = require('../../api') as typeof import('../../api')
+
+  beforeEach(() => {
+    mockFetchCards.mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+    mockFetchBalance.mockResolvedValue({ currency: 'USD', spendableBalance: 10, withdrawableBalance: 10 })
+    mockFetchTransactions.mockResolvedValue([])
+    mockSeedCookies.mockResolvedValue(undefined)
+    mockCurrentAuth.mockResolvedValue(auth)
+    mockVerifyCode.mockResolvedValue(auth)
+    global.ZenMoney = {
+      isAccountSkipped: jest.fn(() => false),
+      readLine: jest.fn(async () => '123456'),
+      setData: jest.fn(),
+      saveData: jest.fn()
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  describe('persisted auth is validated, not trusted', () => {
+    const fromDate = new Date('2026-01-01T00:00:00Z')
+
+    it.each([
+      ['corrupted object', { accessToken: undefined, refreshToken: 'R' }],
+      ['empty tokens', { accessToken: '', refreshToken: '' }],
+      ['wrong shape', { token: 'x' }],
+      ['a string', 'garbage'],
+      ['null', null],
+      ['undefined', undefined]
+    ])('re-logins cleanly instead of poisoning the cookie jar: %s', async (_label, stored) => {
+      await scrapeJupiter(preferences, fromDate, stored)
+      // a bad blob must NOT be seeded into setCookie (undefined = delete cookie)
+      expect(mockSeedCookies).not.toHaveBeenCalled()
+      expect(mockSendCode).toHaveBeenCalledWith('a@b.c')
+    })
+
+    it('uses a well-formed stored session without asking for a code', async () => {
+      await scrapeJupiter(preferences, fromDate, auth)
+      expect(mockSeedCookies).toHaveBeenCalledWith(auth)
+      expect(mockSendCode).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('year range is bounded and boundary-safe', () => {
+    const yearsFetched = (): number[] => mockFetchTransactions.mock.calls.map((c) => c[0] as number)
+
+    it('a far-past startDate never crawls years before the card existed (2025)', async () => {
+      const thisYear = new Date().getUTCFullYear()
+      // naively, 1990 would be ~36 years of paginated crawls per sync
+      await scrapeJupiter(preferences, new Date('1990-01-01T00:00:00Z'), auth)
+      expect(Math.min(...yearsFetched())).toBe(2025) // Jupiter Card launch year
+      expect(Math.max(...yearsFetched())).toBe(thisYear)
+    })
+
+    it('queries one year BEFORE fromDate, so a New-Year transaction cannot be missed', async () => {
+      const thisYear = new Date().getUTCFullYear()
+      // Jupiter's `year` bucket may not be UTC: a Jan-1 transaction can be filed
+      // under the previous year, so querying only fromDate's year would lose it.
+      await scrapeJupiter(preferences, new Date(`${thisYear}-06-01T00:00:00Z`), auth)
+      expect(yearsFetched()).toContain(thisYear - 1)
+      expect(yearsFetched()).toContain(thisYear)
+    })
+  })
+
+  describe('a malformed email is rejected up front, not sent to Jupiter', () => {
+    const fromDate = new Date('2026-01-01T00:00:00Z')
+
+    it.each([
+      ['not an email at all', 'notanemail'],
+      ['no domain', 'user@'],
+      ['no local part', '@example.com'],
+      ['no TLD', 'user@localhost'],
+      ['contains a space', 'user name@example.com'],
+      ['empty', '']
+    ])('%s → InvalidPreferencesError (fatal → settings screen), no request spent', async (_label, email) => {
+      const error = await scrapeJupiter({ email }, fromDate, undefined).catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(InvalidPreferencesError)
+      // fatal is what makes ZenMoney send the user back to fix it, rather than
+      // retrying a hopeless address forever
+      expect((error as InvalidPreferencesError).fatal).toBe(true)
+      // and we never asked Jupiter about it, nor prompted for a code that can't come
+      expect(mockSendCode).not.toHaveBeenCalled()
+      expect(ZenMoney.readLine).not.toHaveBeenCalled()
+    })
+
+    it('accepts a normal address (including plus-addressing)', async () => {
+      mockFetchCards.mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+      await scrapeJupiter({ email: 'user+jupiter@example.co.uk' }, fromDate, undefined)
+      expect(mockSendCode).toHaveBeenCalledWith('user+jupiter@example.co.uk')
+    })
+  })
+
+  describe('an unusable startDate fails loudly, never silently', () => {
+    it('an invalid fromDate → InvalidPreferencesError, not a silent zero-transaction sync', async () => {
+      // NaN year → Math.max(NaN, …) is NaN → the year loop never runs → 0 transactions
+      // with no error, which is indistinguishable from "you have no transactions".
+      const error = await scrapeJupiter(preferences, new Date('not-a-date'), auth).catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(InvalidPreferencesError)
+      expect((error as InvalidPreferencesError).fatal).toBe(true)
+      expect(mockFetchTransactions).not.toHaveBeenCalled()
+    })
+
+    it('a normal past date works', async () => {
+      mockFetchCards.mockResolvedValue([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }])
+      const result = await scrapeJupiter(preferences, new Date('2026-01-01T00:00:00Z'), auth)
+      expect(result.accounts).toHaveLength(1)
+    })
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/userFacingErrors.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/userFacingErrors.test.ts
@@ -1,0 +1,65 @@
+import { InvalidOtpCodeError, InvalidPreferencesError, TemporaryError, ZPAPIError } from '../../../../errors'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+const reply = (status: number, body: unknown = {}): unknown => ({ status, url: '', headers: {}, body })
+
+describe('every error the user can see is a renderable ZenMoney error', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { sendCode, verifyCode } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  beforeEach(() => {
+    global.ZenMoney = {
+      setCookie: jest.fn(async () => {}),
+      getCookies: jest.fn(async () => []),
+      setData: jest.fn(),
+      saveData: jest.fn()
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  describe('a rejected email must send the user to settings, not retry forever', () => {
+    it.each([[400], [404], [422]])('status %i → InvalidPreferencesError (fatal → settings screen)', async (status) => {
+      mockFetchJson.mockResolvedValue(reply(status))
+      const error = await sendCode('nope@nowhere.tld').catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(InvalidPreferencesError)
+      // fatal=true is what makes ZenMoney redirect to preferences instead of
+      // silently retrying an address Jupiter will never accept
+      expect((error as ZPAPIError).fatal).toBe(true)
+    })
+
+    it.each([[429], [500], [503]])('status %i → TemporaryError (retry later, NOT a settings problem)', async (status) => {
+      mockFetchJson.mockResolvedValue(reply(status))
+      const error = await sendCode('a@b.c').catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(TemporaryError)
+      expect((error as ZPAPIError).fatal).toBe(false)
+    })
+  })
+
+  describe('verifyCode', () => {
+    it('a genuinely wrong code → InvalidOtpCodeError (non-fatal, re-prompt)', async () => {
+      mockFetchJson.mockResolvedValue(reply(400, { error: 'bad code' }))
+      const error = await verifyCode('a@b.c', '000000').catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(InvalidOtpCodeError)
+      expect((error as ZPAPIError).fatal).toBe(false)
+    })
+
+    it('an outage is NOT reported as a wrong code', async () => {
+      mockFetchJson.mockResolvedValue(reply(503))
+      const error = await verifyCode('a@b.c', '123456').catch((e: unknown) => e)
+      expect(error).toBeInstanceOf(TemporaryError)
+      expect(error).not.toBeInstanceOf(InvalidOtpCodeError)
+    })
+  })
+
+  it('data-fetch failures surface as ZPAPIError, never a raw Error', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { fetchCards } = require('../../fetchApi') as typeof import('../../fetchApi')
+    mockFetchJson.mockResolvedValue(reply(500))
+    const error = await fetchCards().catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(ZPAPIError)
+  })
+})

--- a/src/plugins/jupitercard/__tests__/api/yearRange.test.ts
+++ b/src/plugins/jupitercard/__tests__/api/yearRange.test.ts
@@ -1,0 +1,27 @@
+import { firstYearToQuery } from '../../api'
+
+/**
+ * Pure, clock-free coverage of the year window. The interesting cases are years in
+ * the future, which is exactly where clock mocking is brittle — so pass the year in.
+ */
+describe('firstYearToQuery', () => {
+  it('floors at the card launch year, so a 1990 start date is not a decades-long crawl', () => {
+    expect(firstYearToQuery(new Date('1990-01-01T00:00:00Z'), 2026)).toBe(2025)
+  })
+
+  it('YEARS LATER it still reaches the launch year — no silent history truncation', () => {
+    // A "max 5 years back" cap would return 2026 here (2031 - 5) and silently drop
+    // the user's 2025 transactions from their first import. Only the launch year
+    // may floor the range.
+    expect(firstYearToQuery(new Date('2025-06-01T00:00:00Z'), 2031)).toBe(2025)
+    expect(firstYearToQuery(new Date('1990-01-01T00:00:00Z'), 2040)).toBe(2025)
+  })
+
+  it('starts one year before fromDate, so a New-Year transaction filed under the previous year is still found', () => {
+    expect(firstYearToQuery(new Date('2027-01-01T00:00:00Z'), 2027)).toBe(2026)
+  })
+
+  it('never starts after the current year', () => {
+    expect(firstYearToQuery(new Date('2030-06-01T00:00:00Z'), 2026)).toBe(2026)
+  })
+})

--- a/src/plugins/jupitercard/__tests__/converters/account.test.ts
+++ b/src/plugins/jupitercard/__tests__/converters/account.test.ts
@@ -1,0 +1,69 @@
+import { convertAccounts } from '../../converters'
+import { JupiterBalance, JupiterCard } from '../../models'
+
+const balance: JupiterBalance = { currency: 'USD', spendableBalance: 100.5, withdrawableBalance: 100.5 }
+
+describe('convertAccounts', () => {
+  it('maps the Jupiter card account to a single ccard USD account', () => {
+    const cards: JupiterCard[] = [{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }]
+    expect(convertAccounts(cards, balance)).toEqual([{
+      id: 'acct_1',
+      type: 'ccard',
+      title: 'Jupiter •1234',
+      instrument: 'USD',
+      balance: 100.5,
+      syncIds: ['1234'],
+      savings: false
+    }])
+  })
+
+  it('groups several cards sharing one card account into ONE account', () => {
+    const cards: JupiterCard[] = [
+      { id: 'card_1', cardAccountId: 'acct_1', last4: '1111' },
+      { id: 'card_2', cardAccountId: 'acct_1', last4: '2222' }
+    ]
+    const accounts = convertAccounts(cards, balance)
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0].id).toBe('acct_1')
+    expect(accounts[0].syncIds).toEqual(['1111', '2222'])
+    expect(accounts[0].title).toBe('Jupiter •1111/2222')
+  })
+
+  it('emits one account per distinct card account; balance only on the primary', () => {
+    const cards: JupiterCard[] = [
+      { id: 'card_1', cardAccountId: 'acct_1', last4: '1111' },
+      { id: 'card_2', cardAccountId: 'acct_2', last4: '2222' }
+    ]
+    const accounts = convertAccounts(cards, balance)
+    expect(accounts).toHaveLength(2)
+    expect(accounts.map((a) => a.id)).toEqual(['acct_1', 'acct_2'])
+    // the balance endpoint is global, so it can't be attributed to the second one
+    expect(accounts[0].balance).toBe(100.5)
+    expect(accounts[1].balance).toBeNull()
+    expect(accounts[1].syncIds).toEqual(['2222'])
+  })
+
+  it('NEVER invents an id from another field when cardAccountId is missing', () => {
+    // the account id is ZenMoney's primary key: deriving it from card.id instead
+    // would change the account's identity and duplicate it in the ledger forever
+    expect(convertAccounts([{ id: 'card_1', last4: '1234' }], balance)).toEqual([])
+  })
+
+  it('keeps the account id stable even if some cards lack cardAccountId', () => {
+    const accounts = convertAccounts([
+      { id: 'card_1', cardAccountId: 'acct_1', last4: '1111' },
+      { id: 'card_2', last4: '2222' }
+    ], balance)
+    expect(accounts).toHaveLength(1)
+    expect(accounts[0].id).toBe('acct_1')
+  })
+
+  it('defaults the instrument to USD when the balance currency is empty', () => {
+    const accounts = convertAccounts([{ id: 'card_1', cardAccountId: 'acct_1', last4: '1234' }], {
+      currency: '',
+      spendableBalance: 0,
+      withdrawableBalance: 0
+    })
+    expect(accounts[0].instrument).toBe('USD')
+  })
+})

--- a/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
+++ b/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
@@ -1,0 +1,115 @@
+import { Transaction } from '../../../../types/zenmoney'
+import { convertTransaction } from '../../converters'
+import { JupiterTransaction } from '../../models'
+
+// convertTransaction returns null for unusable records; these cases expect a value
+function convert (t: JupiterTransaction, accountId = 'acct_1'): Transaction {
+  const result = convertTransaction(t, accountId)
+  if (result == null) {
+    throw new Error('expected a transaction, got null')
+  }
+  return result
+}
+
+function tx (overrides: Partial<JupiterTransaction> = {}): JupiterTransaction {
+  return {
+    id: 'tx_1',
+    type: 'CARD',
+    direction: 'DEBIT',
+    settlementCurrency: 'USD',
+    settlementAmount: '10.00',
+    transactionCurrency: 'USD',
+    transactionAmount: '10.00',
+    onchainSignature: null,
+    transactionTimestamp: '2026-07-01T12:00:00.000Z',
+    card: { merchantName: 'COFFEE SHOP', merchantCategoryCode: '5814', settlementTimestamp: '2026-07-01T12:01:00.000Z' },
+    ...overrides
+  }
+}
+
+describe('convertTransaction', () => {
+  it('DEBIT purchase → negative movement with merchant, no comment', () => {
+    const transaction = convert(tx(), 'acct_1')
+    expect(transaction.movements[0]).toEqual({ id: 'tx_1', account: { id: 'acct_1' }, invoice: null, sum: -10, fee: 0 })
+    expect(transaction.merchant).toEqual({ fullTitle: 'COFFEE SHOP', mcc: 5814, location: null })
+    expect(transaction.hold).toBe(false)
+    expect(transaction.comment).toBeNull()
+    expect(transaction.date).toEqual(new Date('2026-07-01T12:00:00.000Z'))
+  })
+
+  it('CREDIT → positive sum', () => {
+    expect(convert(tx({ direction: 'CREDIT', settlementAmount: '5.00' }), 'a').movements[0].sum).toBe(5)
+  })
+
+  it('foreign-currency purchase carries an invoice in the original currency', () => {
+    const transaction = convert(
+      tx({ settlementAmount: '11.00', transactionCurrency: 'EUR', transactionAmount: '10.00' }),
+      'a'
+    )
+    expect(transaction.movements[0].sum).toBe(-11)
+    expect(transaction.movements[0].invoice).toEqual({ sum: -10, instrument: 'EUR' })
+  })
+
+  it('pending card auth (no settlement) → hold true', () => {
+    const transaction = convert(
+      tx({ card: { merchantName: 'X', merchantCategoryCode: '5814', settlementTimestamp: null } }),
+      'a'
+    )
+    expect(transaction.hold).toBe(true)
+  })
+
+  it('USDC deposit → income, no merchant, on-chain signature in the comment', () => {
+    const transaction = convert(
+      tx({ type: 'DEPOSIT', direction: 'CREDIT', settlementAmount: '500.00', onchainSignature: '5xSig', card: null }),
+      'a'
+    )
+    expect(transaction.movements[0].sum).toBe(500)
+    expect(transaction.merchant).toBeNull()
+    expect(transaction.hold).toBe(false)
+    expect(transaction.comment).toContain('deposit')
+    expect(transaction.comment).toContain('5xSig')
+  })
+
+  describe('refuses to write corrupt records into the ledger', () => {
+    it('skips a transaction with an unparseable timestamp (would become an Invalid Date)', () => {
+      expect(convertTransaction(tx({ transactionTimestamp: 'not-a-date' }), 'a')).toBeNull()
+    })
+
+    it('skips a transaction with a malformed amount (would silently become 0)', () => {
+      expect(convertTransaction(tx({ settlementAmount: 'abc' }), 'a')).toBeNull()
+      expect(convertTransaction(tx({ settlementAmount: '' }), 'a')).not.toBeNull() // '' → 0 is a real zero
+    })
+
+    it('a missing id becomes null (a valid dedup key), never the string "undefined"', () => {
+      const transaction = convert(tx({ id: undefined }), 'a')
+      expect(transaction.movements[0].id).toBeNull()
+    })
+
+    it('ignores a malformed original-currency amount instead of inventing an invoice', () => {
+      const transaction = convert(tx({ transactionCurrency: 'EUR', transactionAmount: 'oops' }), 'a')
+      expect(transaction.movements[0].invoice).toBeNull()
+    })
+  })
+
+  describe('never guesses money it cannot classify', () => {
+    it.each([
+      ['missing', undefined],
+      ['null', null],
+      ['empty', ''],
+      ['an unknown value', 'REFUND'],
+      ['wrong case', 'credit']
+    ])('skips a transaction whose direction is %s (guessing would flip income into an expense)', (_label, direction) => {
+      expect(convertTransaction(tx({ direction, settlementAmount: '500.00' }), 'a')).toBeNull()
+    })
+
+    it('does not crash when `type` is missing (a TypeError would kill the whole sync)', () => {
+      const transaction = convert(tx({ type: undefined, card: null, onchainSignature: 'sig1' }), 'a')
+      expect(transaction.comment).toBe('sig:sig1')
+    })
+
+    it('still converts a well-formed CREDIT as income', () => {
+      const transaction = convert(tx({ direction: 'CREDIT', settlementAmount: '500.00' }), 'a')
+      expect(transaction.movements[0].sum).toBe(500)
+    })
+  })
+})

--- a/src/plugins/jupitercard/__tests__/fetchApi/auth.test.ts
+++ b/src/plugins/jupitercard/__tests__/fetchApi/auth.test.ts
@@ -1,0 +1,101 @@
+import { InvalidOtpCodeError, TemporaryError } from '../../../../errors'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+function cookie (name: string, value: string, domain: string): unknown {
+  return { name, value, domain, path: '/', persistent: true, secure: null, expires: null }
+}
+
+describe('fetchApi — auth hardening', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { sendCode, verifyCode, currentAuth } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  let cookies: unknown[] = []
+
+  beforeEach(() => {
+    cookies = []
+    global.ZenMoney = {
+      setCookie: jest.fn(async () => {}),
+      getCookies: jest.fn(async () => cookies)
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  describe('currentAuth — cookie domain validation', () => {
+    it('reads the session from jup.ag and its subdomains', async () => {
+      cookies = [cookie('access_token', 'A', 'global.jup.ag'), cookie('refresh_token', 'R', '.jup.ag')]
+      expect(await currentAuth()).toEqual({ accessToken: 'A', refreshToken: 'R' })
+    })
+
+    it('IGNORES a lookalike domain (jup.ag.evil.com) — must not be mistaken for our session', async () => {
+      cookies = [
+        cookie('access_token', 'EVIL', 'jup.ag.evil.com'),
+        cookie('refresh_token', 'EVIL', 'jup.ag.evil.com')
+      ]
+      expect(await currentAuth()).toBeNull()
+    })
+
+    it('IGNORES a suffix-lookalike domain (notjup.ag)', async () => {
+      cookies = [cookie('access_token', 'EVIL', 'notjup.ag'), cookie('refresh_token', 'EVIL', 'notjup.ag')]
+      expect(await currentAuth()).toBeNull()
+    })
+
+    it('survives a host-only cookie whose domain is null (the real jar has these)', async () => {
+      // The ZenMoney d.ts declares domain as `string`, but the runtime returns
+      // tough-cookie's nullable domain. This crashed the live plugin.
+      cookies = [
+        { name: 'session', value: 'x', domain: null, path: '/', persistent: true, secure: null, expires: null },
+        cookie('access_token', 'A', 'global.jup.ag'),
+        cookie('refresh_token', 'R', 'global.jup.ag')
+      ]
+      expect(await currentAuth()).toEqual({ accessToken: 'A', refreshToken: 'R' })
+    })
+
+    it('a null-domain cookie is never mistaken for our session', async () => {
+      cookies = [
+        { name: 'access_token', value: 'EVIL', domain: null, path: '/', persistent: true, secure: null, expires: null },
+        { name: 'refresh_token', value: 'EVIL', domain: null, path: '/', persistent: true, secure: null, expires: null }
+      ]
+      expect(await currentAuth()).toBeNull()
+    })
+  })
+
+  describe('sendCode', () => {
+    it('fails loudly when Jupiter did not actually send a code (e.g. rate-limited)', async () => {
+      mockFetchJson.mockResolvedValue({ status: 429, url: '', headers: {}, body: {} })
+      await expect(sendCode('a@b.c')).rejects.toBeInstanceOf(TemporaryError)
+    })
+
+    it('succeeds on 200', async () => {
+      mockFetchJson.mockResolvedValue({ status: 200, url: '', headers: {}, body: {} })
+      await expect(sendCode('a@b.c')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('verifyCode', () => {
+    it('reports a rate-limit as transient, NOT as a wrong code', async () => {
+      mockFetchJson.mockResolvedValue({ status: 429, url: '', headers: {}, body: {} })
+      await expect(verifyCode('a@b.c', '123456')).rejects.toBeInstanceOf(TemporaryError)
+    })
+
+    it('reports an outage as transient, NOT as a wrong code', async () => {
+      mockFetchJson.mockResolvedValue({ status: 503, url: '', headers: {}, body: {} })
+      await expect(verifyCode('a@b.c', '123456')).rejects.toBeInstanceOf(TemporaryError)
+    })
+
+    it('reports a genuinely wrong code as InvalidOtpCodeError', async () => {
+      mockFetchJson.mockResolvedValue({ status: 400, url: '', headers: {}, body: { error: 'bad code' } })
+      await expect(verifyCode('a@b.c', '000000')).rejects.toBeInstanceOf(InvalidOtpCodeError)
+    })
+
+    it('returns the session on success', async () => {
+      mockFetchJson.mockResolvedValue({
+        status: 200, url: '', headers: {}, body: { accessToken: 'A', refreshToken: 'R' }
+      })
+      expect(await verifyCode('a@b.c', '123456')).toEqual({ accessToken: 'A', refreshToken: 'R' })
+    })
+  })
+})

--- a/src/plugins/jupitercard/__tests__/fetchApi/pagination.test.ts
+++ b/src/plugins/jupitercard/__tests__/fetchApi/pagination.test.ts
@@ -1,0 +1,62 @@
+import { JupiterTransaction } from '../../models'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+function tx (id: string, day: string): JupiterTransaction {
+  return {
+    id,
+    type: 'CARD',
+    direction: 'DEBIT',
+    settlementCurrency: 'USD',
+    settlementAmount: '10.00',
+    transactionCurrency: 'USD',
+    transactionAmount: '10.00',
+    onchainSignature: null,
+    transactionTimestamp: `2026-03-${day}T12:00:00.000Z`,
+    card: null
+  }
+}
+
+const page = (data: JupiterTransaction[], totalPages: number): unknown => ({
+  status: 200, url: '', headers: {}, body: { data, meta: { totalPages } }
+})
+
+describe('fetchTransactions — pagination', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchTransactions } = require('../../fetchApi') as typeof import('../../fetchApi')
+  const fromDate = new Date('2026-01-01T00:00:00Z')
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('drops a record returned twice by the page-shift race', async () => {
+    // A transaction arriving mid-crawl shifts every later page down, so the record
+    // on a page boundary comes back on BOTH pages. Emitting it twice would put a
+    // duplicate transaction in the ledger (ZenMoney only dedups by a non-null id).
+    const a = tx('a', '03')
+    const b = tx('b', '02')
+    const c = tx('c', '01')
+    mockFetchJson
+      .mockResolvedValueOnce(page([a, b], 2))
+      .mockResolvedValueOnce(page([b, c], 2)) // b repeated
+
+    const result = await fetchTransactions(2026, fromDate)
+    expect(result.map((t) => t.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('still returns every distinct transaction across pages', async () => {
+    mockFetchJson
+      .mockResolvedValueOnce(page([tx('a', '03')], 2))
+      .mockResolvedValueOnce(page([tx('b', '02')], 2))
+    const result = await fetchTransactions(2026, fromDate)
+    expect(result.map((t) => t.id)).toEqual(['a', 'b'])
+  })
+
+  it('stops at the page cap instead of crawling forever', async () => {
+    // an API that never reports totalPages and always returns a full page
+    mockFetchJson.mockImplementation(async () => page([tx(String(Math.random()), '01')], 0))
+    await fetchTransactions(2026, fromDate)
+    expect(mockFetchJson.mock.calls.length).toBeLessThanOrEqual(100)
+  })
+})

--- a/src/plugins/jupitercard/__tests__/fetchApi/pagination.test.ts
+++ b/src/plugins/jupitercard/__tests__/fetchApi/pagination.test.ts
@@ -53,6 +53,22 @@ describe('fetchTransactions — pagination', () => {
     expect(result.map((t) => t.id)).toEqual(['a', 'b'])
   })
 
+  it('keeps paging past a page that ends before fromDate', async () => {
+    // Jupiter does NOT guarantee newest-first ordering. Stopping as soon as a page ends
+    // older than fromDate — as this used to — truncates everything behind it the moment
+    // one row lands out of order. Here page 1 ends with an out-of-window record while
+    // page 2 still holds a wanted one.
+    const wanted = tx('wanted', '20')
+    const older = { ...tx('older', '01'), transactionTimestamp: '2025-06-01T00:00:00.000Z' }
+    mockFetchJson
+      .mockResolvedValueOnce(page([tx('a', '25'), older], 2))
+      .mockResolvedValueOnce(page([wanted], 2))
+
+    const result = await fetchTransactions(2026, new Date('2026-03-01T00:00:00Z'))
+    expect(result.map((t) => t.id)).toContain('wanted')
+    expect(mockFetchJson).toHaveBeenCalledTimes(2)
+  })
+
   it('stops at the page cap instead of crawling forever', async () => {
     // an API that never reports totalPages and always returns a full page
     mockFetchJson.mockImplementation(async () => page([tx(String(Math.random()), '01')], 0))

--- a/src/plugins/jupitercard/__tests__/fetchApi/redaction.test.ts
+++ b/src/plugins/jupitercard/__tests__/fetchApi/redaction.test.ts
@@ -1,0 +1,59 @@
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+const EXPECTED_REQUEST_REDACTION = { headers: { Cookie: true }, body: { email: true, code: true } }
+const EXPECTED_RESPONSE_REDACTION = {
+  headers: { 'set-cookie': true },
+  body: { accessToken: true, refreshToken: true }
+}
+
+describe('fetchApi — credentials are never written to the logs', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { sendCode, verifyCode, fetchCards } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  beforeEach(() => {
+    global.ZenMoney = {
+      setCookie: jest.fn(async () => {}),
+      getCookies: jest.fn(async () => [])
+    } as unknown as typeof ZenMoney
+    mockFetchJson.mockResolvedValue({
+      status: 200,
+      url: '',
+      headers: {},
+      body: { accessToken: 'A', refreshToken: 'R', cards: [] }
+    })
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('redacts the email on send-code', async () => {
+    await sendCode('a@b.c')
+    const options = mockFetchJson.mock.calls[0][1]
+    expect(options.sanitizeRequestLog).toEqual(EXPECTED_REQUEST_REDACTION)
+    expect(options.sanitizeResponseLog).toEqual(EXPECTED_RESPONSE_REDACTION)
+  })
+
+  it('redacts the OTP code and the returned tokens on verify-code', async () => {
+    await verifyCode('a@b.c', '123456')
+    const options = mockFetchJson.mock.calls[0][1]
+    // the code + email are in the request body, the tokens in the response body
+    expect(options.body).toEqual({ email: 'a@b.c', code: '123456', type: 'LOGIN' })
+    expect(options.sanitizeRequestLog).toEqual(EXPECTED_REQUEST_REDACTION)
+    expect(options.sanitizeResponseLog).toEqual(EXPECTED_RESPONSE_REDACTION)
+  })
+
+  it('redacts cookies on authed data requests too', async () => {
+    await fetchCards()
+    const options = mockFetchJson.mock.calls[0][1]
+    expect(options.sanitizeRequestLog).toEqual(EXPECTED_REQUEST_REDACTION)
+    expect(options.sanitizeResponseLog).toEqual(EXPECTED_RESPONSE_REDACTION)
+  })
+
+  it('never puts the session in a request header (the sandbox cookie jar owns it)', async () => {
+    await fetchCards()
+    const options = mockFetchJson.mock.calls[0][1]
+    expect(Object.keys(options.headers as Record<string, string>)).not.toContain('Cookie')
+    expect(JSON.stringify(options.headers)).not.toContain('access_token')
+  })
+})

--- a/src/plugins/jupitercard/__tests__/fetchApi/redactionIsReal.test.ts
+++ b/src/plugins/jupitercard/__tests__/fetchApi/redactionIsReal.test.ts
@@ -1,0 +1,42 @@
+import { sanitize } from '../../../../common/sanitize'
+
+/**
+ * The other redaction test only asserts that the sanitize OPTIONS are passed.
+ * That is a proxy: if the mask shape were wrong, credentials would still be
+ * logged and that test would happily pass. This one runs the REAL sanitizer over
+ * a real payload and proves the secrets actually disappear.
+ */
+describe('credential redaction actually redacts (real sanitizer)', () => {
+  const requestMask = { headers: { Cookie: true }, body: { email: true, code: true } }
+  const responseMask = { headers: { 'set-cookie': true }, body: { accessToken: true, refreshToken: true } }
+
+  it('scrubs the OTP code and the email from a logged verify-code request', () => {
+    const logged = sanitize({
+      url: 'https://global.jup.ag/api/proxy/auth/email/verify-code',
+      method: 'POST',
+      headers: { Cookie: 'access_token=SECRET', 'User-Agent': 'Mozilla/5.0' },
+      body: { email: 'victim@example.com', code: '123456', type: 'LOGIN' }
+    }, requestMask)
+
+    const dump = JSON.stringify(logged)
+    expect(dump).not.toContain('victim@example.com')
+    expect(dump).not.toContain('123456')
+    expect(dump).not.toContain('SECRET')
+    // non-secrets must survive, or the logs become useless for debugging
+    expect(dump).toContain('LOGIN')
+    expect(dump).toContain('verify-code')
+  })
+
+  it('scrubs the tokens from a logged verify-code response', () => {
+    const logged = sanitize({
+      status: 200,
+      headers: { 'set-cookie': ['access_token=SECRET_A', 'refresh_token=SECRET_R'] },
+      body: { accessToken: 'SECRET_A', refreshToken: 'SECRET_R' }
+    }, responseMask)
+
+    const dump = JSON.stringify(logged)
+    expect(dump).not.toContain('SECRET_A')
+    expect(dump).not.toContain('SECRET_R')
+    expect(dump).toContain('200')
+  })
+})

--- a/src/plugins/jupitercard/api.ts
+++ b/src/plugins/jupitercard/api.ts
@@ -1,0 +1,170 @@
+import { InvalidPreferencesError, TemporaryError, UserInteractionError } from '../../errors'
+import { Account, Transaction } from '../../types/zenmoney'
+import { accountIdFor, convertAccounts, convertTransaction } from './converters'
+import {
+  SessionExpiredError,
+  currentAuth,
+  fetchBalance,
+  fetchCards,
+  fetchTransactions,
+  seedCookies,
+  sendCode,
+  verifyCode
+} from './fetchApi'
+import { Auth, JupiterCard, Preferences, isAuth } from './models'
+
+// The card launched in 2025, so nothing can predate it. This floor alone bounds the
+// crawl; a "max years back" cap on top would eventually become the binding floor and
+// silently truncate the user's oldest transactions.
+const CARD_LAUNCH_YEAR = 2025
+
+const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export interface ScrapeOutput {
+  accounts: Account[]
+  transactions: Transaction[]
+  auth: Auth
+}
+
+// ZenMoney does not validate the email — `inputType` is only a keyboard hint — and an
+// API that answered 200 to send-code would leave the user waiting for a code that can
+// never arrive. InvalidPreferencesError is the only error that reopens the settings.
+function assertLooksLikeEmail (email: string): void {
+  if (!EMAIL_REGEXP.test(email)) {
+    throw new InvalidPreferencesError('That is not a valid email address. Check the email in the plugin settings.')
+  }
+}
+
+// A NaN date makes the year loop skip every iteration: zero transactions and no error,
+// indistinguishable from an empty account.
+function assertUsableFromDate (fromDate: Date): void {
+  if (Number.isNaN(fromDate.getTime())) {
+    throw new InvalidPreferencesError('The start date is not a valid date. Check it in the plugin settings.')
+  }
+}
+
+async function login (email: string): Promise<Auth> {
+  assertLooksLikeEmail(email)
+  await sendCode(email)
+  const code = await ZenMoney.readLine(`Enter the login code sent to ${email}`, { inputType: 'number' })
+  // null means cancelled or timed out — not a wrong code.
+  if (code == null || code.trim() === '') {
+    throw new UserInteractionError()
+  }
+  const auth = await verifyCode(email, code.trim())
+  // Persist at once: the user paid an OTP for this session, so a later failure in this
+  // run must not discard it and demand another code next time.
+  ZenMoney.setData('auth', auth)
+  ZenMoney.saveData()
+  return auth
+}
+
+// Jupiter's `year` filter may not bucket by UTC, so a transaction in the opening hours
+// of a year can be filed under the previous one. Start a year early and let the
+// fromDate comparison drop whatever is genuinely too old.
+export function firstYearToQuery (fromDate: Date, thisYear: number): number {
+  return Math.min(Math.max(fromDate.getUTCFullYear() - 1, CARD_LAUNCH_YEAR), thisYear)
+}
+
+async function loadAccounts (): Promise<{ accounts: Account[], cards: JupiterCard[] }> {
+  const [cards, balance] = await Promise.all([fetchCards(), fetchBalance()])
+  const accounts = convertAccounts(cards, balance)
+  if (accounts.length === 0 && cards.length > 0) {
+    // Keying the account off any other field would change its identity and duplicate it
+    // in ZenMoney permanently. Retry rather than corrupt.
+    throw new TemporaryError('Jupiter returned cards without a card account id')
+  }
+  return { accounts, cards }
+}
+
+function accountIdByCardId (cards: JupiterCard[]): Map<string, string> {
+  const byCardId = new Map<string, string>()
+  for (const card of cards) {
+    const accountId = accountIdFor(card)
+    if (card.id != null && card.id !== '' && accountId != null) {
+      byCardId.set(card.id, accountId)
+    }
+  }
+  return byCardId
+}
+
+async function loadTransactions (fromDate: Date, accounts: Account[], cards: JupiterCard[]): Promise<Transaction[]> {
+  // Jupiter's transactions endpoint is not per-account, so a disabled account can only
+  // be filtered afterwards — the fetch is skippable only when every account is disabled.
+  const activeAccountIds = new Set(accounts.filter((a) => !ZenMoney.isAccountSkipped(a.id)).map((a) => a.id))
+  if (activeAccountIds.size === 0) {
+    return []
+  }
+
+  const routeToAccount = accountIdByCardId(cards)
+  const primaryAccountId = accounts[0].id
+  const transactions: Transaction[] = []
+  const seenIds = new Set<string>() // year buckets overlap by design (see firstYearToQuery)
+  const thisYear = new Date().getUTCFullYear()
+
+  for (let year = firstYearToQuery(fromDate, thisYear); year <= thisYear; year++) {
+    for (const tx of await fetchTransactions(year, fromDate)) {
+      const id = tx.id
+      if (id != null && id !== '') {
+        if (seenIds.has(id)) {
+          continue
+        }
+        seenIds.add(id)
+      }
+      const accountId = (tx.cardId != null ? routeToAccount.get(tx.cardId) : undefined) ?? primaryAccountId
+      if (!activeAccountIds.has(accountId)) {
+        continue
+      }
+      const transaction = convertTransaction(tx, accountId)
+      if (transaction != null) {
+        transactions.push(transaction)
+      }
+    }
+  }
+  return transactions
+}
+
+// `storedAuth` is whatever ZenMoney persisted last run, hence `unknown`.
+export async function scrapeJupiter (preferences: Preferences, fromDate: Date, storedAuth: unknown): Promise<ScrapeOutput> {
+  assertUsableFromDate(fromDate)
+  const email = preferences.email
+
+  const run = async (): Promise<{ accounts: Account[], transactions: Transaction[] }> => {
+    const { accounts, cards } = await loadAccounts()
+    if (accounts.length === 0) {
+      return { accounts: [], transactions: [] }
+    }
+    return { accounts, transactions: await loadTransactions(fromDate, accounts, cards) }
+  }
+
+  // A corrupted blob would feed undefined tokens to setCookie, which deletes them.
+  let auth = isAuth(storedAuth) ? storedAuth : undefined
+  if (auth != null) {
+    await seedCookies(auth)
+  } else {
+    auth = await login(email)
+  }
+
+  let result: { accounts: Account[], transactions: Transaction[] }
+  try {
+    result = await run()
+  } catch (e) {
+    // Re-login only for a genuinely dead session: it emails the user a new code, so
+    // doing it on any error would spam them and hammer send-code.
+    if (!(e instanceof SessionExpiredError)) {
+      throw e
+    }
+    auth = await login(email)
+    try {
+      result = await run()
+    } catch (retryError) {
+      // SessionExpiredError is internal control flow; only ZPAPIError subclasses render.
+      if (retryError instanceof SessionExpiredError) {
+        throw new TemporaryError('Jupiter rejected a freshly issued session. Please try again later.')
+      }
+      throw retryError
+    }
+  }
+
+  return { ...result, auth: (await currentAuth()) ?? auth }
+}

--- a/src/plugins/jupitercard/converters.ts
+++ b/src/plugins/jupitercard/converters.ts
@@ -1,0 +1,133 @@
+import { Account, AccountType, Amount, Merchant, NonParsedMerchant, Transaction } from '../../types/zenmoney'
+import { JupiterBalance, JupiterCard, JupiterTransaction } from './models'
+
+function num (value: string | number | null | undefined): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+// ZenMoney identifies an account by this id forever, so it must be derived from the
+// one stable key. Falling back to another field would change the account's identity
+// and leave a duplicate in the ledger permanently.
+export function accountIdFor (card: JupiterCard): string | null {
+  const id = card.cardAccountId
+  return id != null && id !== '' ? id : null
+}
+
+// One account per distinct card account. Jupiter exposes only one today (the balance
+// endpoint takes no account parameter), but grouping keeps a second one's transactions
+// from silently landing on the first.
+export function convertAccounts (cards: JupiterCard[], balance: JupiterBalance): Account[] {
+  const groups = new Map<string, JupiterCard[]>()
+  for (const card of cards) {
+    const id = accountIdFor(card)
+    if (id == null) {
+      continue
+    }
+    const group = groups.get(id)
+    if (group != null) {
+      group.push(card)
+    } else {
+      groups.set(id, [card])
+    }
+  }
+  // No cards: report nothing. A synthetic account would carry a different id from the
+  // real one and appear alongside it as a phantom duplicate.
+  if (groups.size === 0) {
+    return []
+  }
+
+  const instrument = balance.currency != null && balance.currency !== '' ? balance.currency : 'USD'
+  const spendable = typeof balance.spendableBalance === 'number' && Number.isFinite(balance.spendableBalance)
+    ? balance.spendableBalance
+    : null
+
+  return [...groups.entries()].map(([id, groupCards], index) => {
+    const last4s = groupCards.map((c) => c.last4).filter((x): x is string => x != null && x !== '')
+    return {
+      id,
+      type: AccountType.ccard,
+      title: last4s.length > 0 ? `Jupiter •${last4s.join('/')}` : 'Jupiter Card',
+      instrument,
+      // The balance endpoint is global, so it can only belong to the primary account;
+      // null means "not determinable", which ZenMoney accepts.
+      balance: index === 0 ? spendable : null,
+      syncIds: last4s,
+      savings: false
+    }
+  })
+}
+
+function commentFor (tx: JupiterTransaction): string | null {
+  const type = typeof tx.type === 'string' ? tx.type : ''
+  if (type === 'CARD') {
+    return null
+  }
+  const parts: string[] = []
+  if (type !== '') {
+    parts.push(type.toLowerCase())
+  }
+  if (tx.onchainSignature != null && tx.onchainSignature !== '') {
+    parts.push(`sig:${tx.onchainSignature}`)
+  }
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
+// Returns null for a record we cannot represent honestly. Emitting one anyway would put
+// a corrupt entry in the ledger: a malformed amount silently becomes 0 and misstates the
+// balance, and a malformed timestamp becomes an Invalid Date.
+export function convertTransaction (tx: JupiterTransaction, accountId: string): Transaction | null {
+  const date = new Date(tx.transactionTimestamp ?? '') // missing → Invalid Date → skipped below
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  const settlement = Number(tx.settlementAmount)
+  if (!Number.isFinite(settlement)) {
+    return null
+  }
+  // Never guess the direction of money: treating anything-not-CREDIT as a debit would
+  // book income as an expense if the field were missing or gained a new value.
+  if (tx.direction !== 'DEBIT' && tx.direction !== 'CREDIT') {
+    return null
+  }
+
+  const sign = tx.direction === 'CREDIT' ? 1 : -1
+  const sum = sign * settlement
+
+  const original = Number(tx.transactionAmount)
+  const originalCurrency = tx.transactionCurrency
+  const invoice: Amount | null =
+    typeof originalCurrency === 'string' &&
+    originalCurrency !== '' &&
+    originalCurrency !== tx.settlementCurrency &&
+    Number.isFinite(original)
+      ? { sum: sign * original, instrument: originalCurrency }
+      : null
+
+  let merchant: NonParsedMerchant | Merchant | null = null
+  const merchantName = tx.card?.merchantName
+  if (merchantName != null && merchantName !== '') {
+    const mcc = num(tx.card?.merchantCategoryCode)
+    merchant = { fullTitle: merchantName, mcc: mcc !== 0 ? mcc : null, location: null }
+  }
+
+  // A card authorisation that has not settled is a hold; non-card movements are not.
+  const hold = tx.card != null ? tx.card.settlementTimestamp == null : false
+
+  return {
+    hold,
+    date,
+    movements: [
+      {
+        // ZenMoney's dedup key; null is valid (it then matches on the other fields).
+        id: tx.id ?? null,
+        account: { id: accountId },
+        invoice,
+        sum,
+        fee: 0
+      }
+    ],
+    merchant,
+    comment: commentFor(tx)
+  }
+}

--- a/src/plugins/jupitercard/fetchApi.ts
+++ b/src/plugins/jupitercard/fetchApi.ts
@@ -190,12 +190,12 @@ export async function fetchTransactions (year: number, fromDate: Date): Promise<
       }
     }
 
+    // Every page of the year is walked. Stopping as soon as a page ends older than
+    // fromDate would be faster, but it assumes the API sorts newest-first, and that
+    // ordering is not guaranteed — one out-of-order row on a page boundary would end
+    // the crawl early and silently truncate the history behind it.
     const totalPages = body?.meta?.totalPages
     if (data.length === 0 || (totalPages != null && page >= totalPages)) {
-      break
-    }
-    const last = data[data.length - 1]
-    if (last != null && new Date(last.transactionTimestamp ?? '') < fromDate) {
       break
     }
     page += 1

--- a/src/plugins/jupitercard/fetchApi.ts
+++ b/src/plugins/jupitercard/fetchApi.ts
@@ -1,0 +1,204 @@
+import { FetchOptions, FetchResponse, fetchJson } from '../../common/network'
+import { InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../errors'
+import {
+  AUTH_FLOW,
+  Auth,
+  ENDPOINTS,
+  JUP_BASE,
+  JUP_DOMAIN,
+  JUP_HOST,
+  JupiterBalance,
+  JupiterCard,
+  JupiterTransaction,
+  Paginated,
+  USER_AGENT
+} from './models'
+
+const COOKIE_PARAMS = { path: '/' }
+
+// 100 pages x 50 is far beyond a year of card activity; it only guards a runaway loop
+// should the API stop reporting totalPages while returning full pages.
+const MAX_PAGES = 100
+
+// Jupiter fronts its API with Cloudflare and authorises /api/proxy/* via
+// `x-auth-flow: legacy` plus the session cookie, which the sandbox jar attaches.
+function browserHeaders (): Record<string, string> {
+  return {
+    'User-Agent': USER_AGENT,
+    'x-auth-flow': AUTH_FLOW,
+    Origin: JUP_BASE,
+    Referer: `${JUP_BASE}/`
+  }
+}
+
+// All traffic goes through here so credentials stay out of the logs: the shared fetch
+// logs every request and response, which would otherwise record the OTP code, the email
+// and the access/refresh tokens (including the rotated ones in Set-Cookie).
+async function request (url: string, options: FetchOptions = {}): Promise<FetchResponse> {
+  const headers = { ...browserHeaders(), ...(options.headers as Record<string, string> | undefined) }
+  return await fetchJson(url, {
+    ...options,
+    headers,
+    sanitizeRequestLog: { headers: { Cookie: true }, body: { email: true, code: true } },
+    sanitizeResponseLog: { headers: { 'set-cookie': true }, body: { accessToken: true, refreshToken: true } }
+  })
+}
+
+// Seed the sandbox cookie jar. It then attaches the session to every request and
+// captures the refresh rotation, so no request builds a Cookie header by hand.
+export async function seedCookies (auth: Auth): Promise<void> {
+  await ZenMoney.setCookie(JUP_HOST, 'access_token', auth.accessToken, COOKIE_PARAMS)
+  await ZenMoney.setCookie(JUP_HOST, 'refresh_token', auth.refreshToken, COOKIE_PARAMS)
+  await ZenMoney.setCookie(JUP_HOST, 'oauth_flow', 'login', COOKIE_PARAMS)
+}
+
+// A substring test would also match a lookalike host such as jup.ag.evil.com, letting a
+// foreign cookie named access_token in the shared jar pass for our session. The domain
+// is nullable at runtime for host-only cookies, whatever the ZenMoney types say.
+function isJupiterDomain (domain: string | null | undefined): boolean {
+  if (typeof domain !== 'string' || domain === '') {
+    return false
+  }
+  const host = domain.replace(/^\./, '').toLowerCase()
+  return host === JUP_DOMAIN || host.endsWith(`.${JUP_DOMAIN}`)
+}
+
+export async function currentAuth (): Promise<Auth | null> {
+  const cookies = await ZenMoney.getCookies() as Array<{ name: string, value: string, domain: string | null }>
+  const find = (name: string): string | undefined =>
+    cookies.find((c) => c.name === name && isJupiterDomain(c.domain))?.value
+  const accessToken = find('access_token')
+  const refreshToken = find('refresh_token')
+  return accessToken != null && refreshToken != null ? { accessToken, refreshToken } : null
+}
+
+export async function sendCode (email: string): Promise<void> {
+  const response = await request(`${JUP_BASE}${ENDPOINTS.sendCode}`, { method: 'POST', body: { email } })
+  if (response.status === 429 || response.status >= 500) {
+    throw new TemporaryError(`Jupiter ${response.status} when sending the login code`)
+  }
+  // Jupiter rejected the address itself. A TemporaryError would retry it on every
+  // schedule forever without ever telling the user; InvalidPreferencesError is fatal and
+  // reopens the settings screen.
+  if (response.status >= 400) {
+    throw new InvalidPreferencesError(
+      'Jupiter did not accept this email address. Check the email in the plugin settings.'
+    )
+  }
+}
+
+export async function verifyCode (email: string, code: string): Promise<Auth> {
+  const response = await request(`${JUP_BASE}${ENDPOINTS.verifyCode}`, {
+    method: 'POST',
+    body: { email, code, type: 'LOGIN' }
+  })
+  // A rate limit or outage is not a wrong code; saying it is makes the user retype a
+  // valid one and burn further send-code calls.
+  if (response.status === 429 || response.status >= 500) {
+    throw new TemporaryError(`Jupiter ${response.status} when verifying the login code`)
+  }
+  const body = response.body as { accessToken?: string, refreshToken?: string } | undefined
+  if (body?.accessToken == null || body.refreshToken == null) {
+    throw new InvalidOtpCodeError()
+  }
+  const auth: Auth = { accessToken: body.accessToken, refreshToken: body.refreshToken }
+  await seedCookies(auth)
+  return auth
+}
+
+// Only a new email OTP can recover the session. Kept distinct from TemporaryError
+// because a re-login emails the user a code: it must never fire for a transient failure.
+export class SessionExpiredError extends Error {
+  constructor () {
+    super('Jupiter session expired — re-login required')
+    this.name = 'SessionExpiredError'
+  }
+}
+
+// POST /api/auth/refresh answers 204 with rotated tokens in Set-Cookie, which the jar
+// captures; the retried request then carries the fresh cookie.
+async function refreshSession (): Promise<void> {
+  const response = await request(`${JUP_BASE}${ENDPOINTS.refresh}`, { method: 'POST' })
+  if (response.status === 401 || response.status === 403) {
+    throw new SessionExpiredError()
+  }
+  if (response.status >= 400) {
+    throw new TemporaryError(`Jupiter ${response.status} on session refresh`)
+  }
+  // The rotation invalidates the previous refresh token, so persist the new pair now: a
+  // later failure in this run must not leave the dead one stored and force a new OTP.
+  const rotated = await currentAuth()
+  if (rotated != null) {
+    ZenMoney.setData('auth', rotated)
+    ZenMoney.saveData()
+  }
+}
+
+async function authedGet (path: string, query?: Record<string, string | number>): Promise<unknown> {
+  const qs = query != null
+    ? '?' + Object.entries(query).map(([k, v]) => `${k}=${encodeURIComponent(String(v))}`).join('&')
+    : ''
+  const url = `${JUP_BASE}${path}${qs}`
+  let response = await request(url)
+  if (response.status === 401) {
+    await refreshSession()
+    response = await request(url)
+    if (response.status === 401) {
+      throw new SessionExpiredError()
+    }
+  }
+  if (response.status >= 400) {
+    throw new TemporaryError(`Jupiter ${response.status} for ${path}`)
+  }
+  return response.body
+}
+
+export async function fetchCards (): Promise<JupiterCard[]> {
+  const body = await authedGet(ENDPOINTS.cards) as { cards?: unknown } | undefined
+  const cards = body?.cards
+  return Array.isArray(cards) ? cards as JupiterCard[] : []
+}
+
+export async function fetchBalance (): Promise<JupiterBalance> {
+  const body = await authedGet(ENDPOINTS.balance)
+  // An empty or non-object body must not reach the converter as undefined.currency.
+  return (body != null && typeof body === 'object' ? body : {}) as JupiterBalance
+}
+
+export async function fetchTransactions (year: number, fromDate: Date): Promise<JupiterTransaction[]> {
+  const out: JupiterTransaction[] = []
+  // Page-based paging is racy: a transaction arriving mid-crawl shifts the later pages
+  // down, so the record on a boundary comes back twice.
+  const seenIds = new Set<string>()
+  let page = 1
+
+  while (page <= MAX_PAGES) {
+    const body = await authedGet(ENDPOINTS.transactions, { page, limit: 50, year }) as Paginated<JupiterTransaction> | undefined
+    const rows = body?.data
+    const data: JupiterTransaction[] = Array.isArray(rows) ? rows : []
+
+    for (const tx of data) {
+      if (new Date(tx.transactionTimestamp ?? '') >= fromDate) {
+        const id = tx.id
+        if (id != null && id !== '') {
+          if (seenIds.has(id)) {
+            continue
+          }
+          seenIds.add(id)
+        }
+        out.push(tx)
+      }
+    }
+
+    const totalPages = body?.meta?.totalPages
+    if (data.length === 0 || (totalPages != null && page >= totalPages)) {
+      break
+    }
+    const last = data[data.length - 1]
+    if (last != null && new Date(last.transactionTimestamp ?? '') < fromDate) {
+      break
+    }
+    page += 1
+  }
+  return out
+}

--- a/src/plugins/jupitercard/index.ts
+++ b/src/plugins/jupitercard/index.ts
@@ -1,0 +1,12 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { scrapeJupiter } from './api'
+import { Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate }) => {
+  ZenMoney.locale = 'en'
+  // pass the persisted blob through as-is; scrapeJupiter validates it
+  const { accounts, transactions, auth } = await scrapeJupiter(preferences, fromDate, ZenMoney.getData('auth'))
+  ZenMoney.setData('auth', auth)
+  ZenMoney.saveData()
+  return { accounts, transactions }
+}

--- a/src/plugins/jupitercard/models.ts
+++ b/src/plugins/jupitercard/models.ts
@@ -1,0 +1,81 @@
+// User-configured settings; see preferences.xml.
+export interface Preferences {
+  email: string
+}
+
+// Persisted between runs via ZenMoney.setData/getData.
+export interface Auth {
+  accessToken: string
+  refreshToken: string
+}
+
+// Persisted data may be corrupted or from an older schema. Casting it straight to Auth
+// would let undefined tokens reach setCookie, which deletes the cookie and silently
+// breaks authentication.
+export function isAuth (value: unknown): value is Auth {
+  if (value == null || typeof value !== 'object') {
+    return false
+  }
+  const auth = value as Partial<Auth>
+  return typeof auth.accessToken === 'string' && auth.accessToken !== '' &&
+    typeof auth.refreshToken === 'string' && auth.refreshToken !== ''
+}
+
+export const JUP_BASE = 'https://global.jup.ag'
+export const JUP_HOST = 'global.jup.ag'
+// Registrable domain, used to tell our cookies from a lookalike host's.
+export const JUP_DOMAIN = 'jup.ag'
+export const AUTH_FLOW = 'legacy'
+export const USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+export const ENDPOINTS = {
+  sendCode: '/api/proxy/auth/email/send-code',
+  verifyCode: '/api/proxy/auth/email/verify-code',
+  refresh: '/api/auth/refresh',
+  cards: '/api/proxy/cards',
+  balance: '/api/proxy/cards/balance',
+  transactions: '/api/proxy/transactions'
+}
+
+// Jupiter API responses. Every field is optional on purpose: these are unvalidated, and
+// declaring them as required would let TypeScript hide the very bugs that arise when a
+// field is absent.
+export interface JupiterCard {
+  id?: string | null
+  cardAccountId?: string | null
+  last4?: string | null
+}
+
+export interface JupiterBalance {
+  currency?: string | null
+  spendableBalance?: number | null
+  withdrawableBalance?: number | null
+}
+
+export interface JupiterCardDetail {
+  merchantName?: string | null
+  merchantCategoryCode?: string | null
+  settlementTimestamp?: string | null
+}
+
+export interface JupiterTransaction {
+  id?: string | null
+  cardId?: string | null
+  type?: string | null
+  // Not narrowed to 'DEBIT' | 'CREDIT': the converter must decide what to do with an
+  // unexpected value rather than have the types pretend it cannot happen.
+  direction?: string | null
+  settlementCurrency?: string | null
+  settlementAmount?: string | null
+  transactionCurrency?: string | null
+  transactionAmount?: string | null
+  onchainSignature?: string | null
+  transactionTimestamp?: string | null
+  card?: JupiterCardDetail | null
+}
+
+export interface Paginated<T> {
+  data: T[]
+  meta?: { totalPages?: number | null } | null
+}

--- a/src/plugins/jupitercard/preferences.xml
+++ b/src/plugins/jupitercard/preferences.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="email"
+        obligatory="true"
+        inputType="textEmailAddress"
+        title="Jupiter account email"
+        dialogTitle="Jupiter account email"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="||{@s}">
+    </EditTextPreference>
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="From what date to load transactions"
+        defaultValue="2026-01-01T00:00:00.000Z"
+        dialogTitle="From what date to load transactions"
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
Adds a plugin for [Jupiter Card](https://jup.ag) (`global.jup.ag`) — a Solana-backed debit card. It imports the card account and its transactions.

`<company>` is left at `0` per `docs/ZenmoneyManifest.xml.md`.

### How it works

Sign-in is an email one-time code: the plugin calls send-code, asks for the code with `ZenMoney.readLine`, and stores the resulting session with `ZenMoney.setData`. Later runs reuse it — the session is seeded into the cookie jar, refreshed via `/api/auth/refresh` when a request 401s, and the rotated tokens are persisted as soon as they arrive. A new code is requested only when the session is genuinely dead, so a rate limit or an outage never makes the user retype anything.

Transactions are fetched per year (the API filters by `year`), starting one year before `fromDate` since the year buckets do not appear to split on UTC midnight. The surplus records are dropped by the `fromDate` comparison and de-duplicated by id.

### Notes for review

- **Credentials stay out of the logs.** All traffic goes through a single `request()` helper that sets `sanitizeRequestLog`/`sanitizeResponseLog`, so the OTP code, the email, and the access/refresh tokens (including rotated ones in `Set-Cookie`) are redacted.
- **Unparseable records are skipped, not guessed.** A transaction with a malformed amount or timestamp, or a `direction` that is neither `DEBIT` nor `CREDIT`, is dropped rather than booked — guessing the direction would post income as an expense.
- **The account id is derived only from `cardAccountId`.** Falling back to another field would change the account identity and leave a permanent duplicate in the ledger.
- An invalid email or start date raises `InvalidPreferencesError`, so the settings screen reopens instead of the sync failing silently on every schedule.

### Tests

86 unit tests covering the converters, the auth and session flow, pagination, log redaction, and degenerate API responses. `ts-standard` and `tsc --noEmit` are clean.
