### PR TITLE
[altabanka-rs] fix card operation duplication and import pending foreign-currency card authorizations

### DIFF
--- a/src/plugins/altabanka-rs/__tests__/api/parsers.test.ts
+++ b/src/plugins/altabanka-rs/__tests__/api/parsers.test.ts
@@ -1,5 +1,12 @@
 import moment from 'moment'
-import { parseAccountInfo, parseCards, parseCardTurnover, parseEnvironment, parseReservedFunds, parseTransactions } from '../../parsers'
+import { canonicalTransactionReference, parseAccountInfo, parseCards, parseCardTurnover, parseEnvironment, parseReservedFunds, parseTransactions } from '../../parsers'
+
+describe('canonicalTransactionReference', () => {
+  it('strips the CC- prefix so reserved and card share one id stem', () => {
+    expect(canonicalTransactionReference('CC-20000001R')).toBe('20000001R')
+    expect(canonicalTransactionReference('20000001R')).toBe('20000001R')
+  })
+})
 
 describe('parseEnvironment', () => {
   it('extracts request token and authentication state after login', () => {
@@ -205,7 +212,7 @@ describe('parseCardTurnover', () => {
 
     expect(parseCardTurnover(body, fromDate)).toEqual([
       {
-        id: 'id_CC-10000001E',
+        id: 'id_10000001E',
         date: moment('18.06.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
         address: 'STUDIO3 - B6 BEOGRAD',
         amount: -2380,
@@ -213,7 +220,7 @@ describe('parseCardTurnover', () => {
         description: ''
       },
       {
-        id: 'id_CC-10000002E',
+        id: 'id_10000002E',
         date: moment('20.06.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
         address: 'DELHAIZE SERBIA DOO BE BEOGRAD',
         amount: 208.99,
@@ -221,7 +228,7 @@ describe('parseCardTurnover', () => {
         description: ''
       },
       {
-        id: 'id_CC-10000003E',
+        id: 'id_10000003E',
         date: moment('03.06.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
         address: 'Shell Yverdon Yverdon-les-B',
         amount: -4985.39,
@@ -230,6 +237,68 @@ describe('parseCardTurnover', () => {
         invoice: { sum: -42.47, instrument: 'EUR' }
       }
     ])
+  })
+
+  it('skips unconfirmed card rows (placeholder date 01.01.0001)', () => {
+    const body = [[
+      ['', '', ''],
+      [
+        cardRow({
+          debit: '340.97',
+          credit: '0',
+          originalCurrency: 'RSD',
+          reference: 'CC-20000001R',
+          description: 'Visa Electron potrošnja Wallet: GALEN PHARM&gt; RS',
+          transactionDate: '01.01.0001 00:00:00',
+          domesticAmount: '340.97',
+          accountCurrency: 'RSD'
+        }),
+        cardRow({
+          debit: '2380.00',
+          credit: '0',
+          originalCurrency: 'RSD',
+          reference: 'CC-10000001E',
+          description: 'Visa Electron potrošnja - POS druge banke u zemlji Wallet: STUDIO3 - B6                BEOGRAD',
+          transactionDate: '18.06.2026 00:00:00',
+          domesticAmount: '2380.00',
+          accountCurrency: 'RSD'
+        })
+      ]
+    ]]
+
+    expect(parseCardTurnover(body, fromDate)).toEqual([
+      {
+        id: 'id_10000001E',
+        date: moment('18.06.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
+        address: 'STUDIO3 - B6 BEOGRAD',
+        amount: -2380,
+        currency: 'RSD',
+        description: ''
+      }
+    ])
+  })
+
+  it('decodes HTML entities in merchant address', () => {
+    const body = [[
+      ['', '', ''],
+      [
+        cardRow({
+          debit: '100.00',
+          credit: '0',
+          originalCurrency: 'RSD',
+          reference: 'CC-20000001R',
+          description: 'Visa Electron Wallet: GALEN PHARM&gt; RS',
+          transactionDate: '13.07.2026 00:00:00',
+          domesticAmount: '100.00',
+          accountCurrency: 'RSD'
+        })
+      ]
+    ]]
+
+    expect(parseCardTurnover(body, fromDate)[0]).toMatchObject({
+      id: 'id_20000001R',
+      address: 'GALEN PHARM> RS'
+    })
   })
 
   it('does not build a foreign invoice for a zero original amount (foreign refund edge case)', () => {
@@ -242,7 +311,7 @@ describe('parseCardTurnover', () => {
 
     expect(parseCardTurnover(body, fromDate)).toEqual([
       {
-        id: 'id_CC-10000004E',
+        id: 'id_10000004E',
         date: moment('10.06.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
         address: 'REFUND MERCHANT PARIS',
         amount: 500,
@@ -269,8 +338,8 @@ describe('parseReservedFunds', () => {
         DebitAmountDomestic: 340.97,
         CreditAmountDomestic: null,
         CurrencyCode: 'RSD',
-        Description: 'KRALJA MILANA 28>BEOGRAD              RS',
-        Reference: '10000001R',
+        Description: 'KRALJA MILANA 28&gt;BEOGRAD              RS',
+        Reference: '20000001R',
         ValueDate: '2026-06-23T00:00:00'
       },
       {
@@ -288,7 +357,7 @@ describe('parseReservedFunds', () => {
 
     expect(parseReservedFunds(body, fromDate)).toEqual([
       {
-        id: 'id_10000001R',
+        id: 'id_20000001R',
         date: new Date('2026-06-23T00:00:00'),
         address: 'KRALJA MILANA 28>BEOGRAD RS',
         amount: -340.97,
@@ -304,6 +373,32 @@ describe('parseReservedFunds', () => {
         description: ''
       }
     ])
+  })
+
+  it('uses the same movement id stem as card turnover for a shared reference', () => {
+    const reserved = parseReservedFunds([{
+      Status: 'p',
+      Category: 'd',
+      AmountTotal: 100,
+      CurrencyCode: 'RSD',
+      Description: 'GALEN PHARM> RS',
+      Reference: '20000001R',
+      ValueDate: '2026-07-13T00:00:00'
+    }], fromDate)
+
+    const cardRow = new Array<string>(29).fill('0')
+    cardRow[9] = '100.00'
+    cardRow[11] = 'RSD'
+    cardRow[14] = 'CC-20000001R'
+    cardRow[17] = 'Visa Electron Wallet: OTHER MERCHANT BEOGRAD'
+    cardRow[24] = '14.07.2026 00:00:00'
+    cardRow[25] = '100.00'
+    cardRow[28] = 'RSD'
+
+    const card = parseCardTurnover([[['', '', ''], [cardRow]]], fromDate)
+
+    expect(reserved[0].id).toBe('id_20000001R')
+    expect(card[0].id).toBe('id_20000001R')
   })
 
   it('keeps zero-amount released holds for the converter to drop', () => {

--- a/src/plugins/altabanka-rs/__tests__/api/parsers.test.ts
+++ b/src/plugins/altabanka-rs/__tests__/api/parsers.test.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { canonicalTransactionReference, parseAccountInfo, parseCards, parseCardTurnover, parseEnvironment, parseReservedFunds, parseTransactions } from '../../parsers'
+import { canonicalTransactionReference, parseAccountInfo, parseCardReservedFunds, parseCards, parseCardTurnover, parseEnvironment, parseReservedFunds, parseTransactions } from '../../parsers'
 
 describe('canonicalTransactionReference', () => {
   it('strips the CC- prefix so reserved and card share one id stem', () => {
@@ -424,5 +424,147 @@ describe('parseReservedFunds', () => {
         description: ''
       }
     ])
+  })
+
+  it('skips card authorizations (Source === crd) fetched from the card reserved endpoint', () => {
+    const body = [
+      {
+        Status: 'p',
+        Category: 'd',
+        AmountTotal: 340.97,
+        CurrencyCode: 'RSD',
+        Description: 'KRALJA MILANA 28&gt;BEOGRAD RS',
+        Reference: '20000001R',
+        Source: 'crd',
+        ValueDate: '2026-06-23T00:00:00'
+      },
+      {
+        Status: 'p',
+        Category: 'd',
+        AmountTotal: 5000,
+        CurrencyCode: 'RSD',
+        Description: 'Pending transfer',
+        Reference: '20000009P',
+        Source: 'pmt',
+        ValueDate: '2026-06-24T00:00:00'
+      }
+    ]
+
+    expect(parseReservedFunds(body, fromDate)).toEqual([
+      {
+        id: 'id_20000009P',
+        date: new Date('2026-06-24T00:00:00'),
+        address: 'Pending transfer',
+        amount: -5000,
+        currency: 'RSD',
+        description: ''
+      }
+    ])
+  })
+})
+
+describe('parseCardReservedFunds', () => {
+  const fromDate = new Date('2026-07-01T00:00:00')
+
+  function cardReservedRow (fields: {
+    account: string
+    currency: string
+    valueDate: string
+    reference: string
+    description: string
+    originalAmount: string
+    direction: string
+    domesticAmount: string
+  }): string[] {
+    const row = new Array<string>(66).fill('')
+    row[3] = fields.account
+    row[7] = fields.currency
+    row[9] = fields.valueDate
+    row[12] = fields.reference
+    row[13] = fields.description
+    row[17] = fields.originalAmount
+    row[32] = fields.direction
+    row[42] = 'p'
+    row[51] = fields.domesticAmount
+    row[62] = '01.01.0001 00:00:00'
+    row[65] = 'crd'
+    return row
+  }
+
+  it('parses a domestic (RSD) pending card authorization without invoice', () => {
+    const body = [
+      cardReservedRow({
+        account: '0001000000001',
+        currency: 'RSD',
+        valueDate: '19.07.2026 00:00:00',
+        reference: 'CC-20000001R',
+        description: 'KRALJA MILANA 28&gt;BEOGRAD              RS',
+        originalAmount: '573.10',
+        direction: 'd',
+        domesticAmount: '573.10'
+      })
+    ]
+
+    expect(parseCardReservedFunds(body, 'RSD', fromDate)).toEqual([
+      {
+        id: 'id_20000001R',
+        date: moment('19.07.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
+        address: 'KRALJA MILANA 28>BEOGRAD RS',
+        amount: -573.1,
+        currency: 'RSD',
+        description: ''
+      }
+    ])
+  })
+
+  it('parses a foreign (HUF) pending card authorization with domestic sum and original invoice', () => {
+    const body = [
+      cardReservedRow({
+        account: '0001000000001',
+        currency: 'HUF',
+        valueDate: '19.07.2026 00:00:00',
+        reference: 'CC-20000002R',
+        description: 'AUCHAN SOROKSAR&gt;BUDAPEST              HU',
+        originalAmount: '31874.00',
+        direction: 'd',
+        domesticAmount: '10393.57'
+      })
+    ]
+
+    expect(parseCardReservedFunds(body, 'RSD', fromDate)).toEqual([
+      {
+        id: 'id_20000002R',
+        date: moment('19.07.2026 00:00:00', 'DD.MM.YYYY HH:mm:ss').toDate(),
+        address: 'AUCHAN SOROKSAR>BUDAPEST HU',
+        amount: -10393.57,
+        currency: 'RSD',
+        description: '',
+        invoice: { sum: -31874, instrument: 'HUF' }
+      }
+    ])
+  })
+
+  it('handles a credit (refund) authorization', () => {
+    const body = [
+      cardReservedRow({
+        account: '0001000000001',
+        currency: 'RSD',
+        valueDate: '20.07.2026 00:00:00',
+        reference: 'CC-20000003R',
+        description: 'REFUND MERCHANT&gt;BEOGRAD RS',
+        originalAmount: '500.00',
+        direction: 'c',
+        domesticAmount: '500.00'
+      })
+    ]
+
+    expect(parseCardReservedFunds(body, 'RSD', fromDate)[0]).toMatchObject({
+      id: 'id_20000003R',
+      amount: 500
+    })
+  })
+
+  it('returns empty array when the response is an error object instead of an array', () => {
+    expect(parseCardReservedFunds({ ErrorCode: 'Err_0', Message: 'error' }, 'RSD', fromDate)).toEqual([])
   })
 })

--- a/src/plugins/altabanka-rs/__tests__/converters/transactions/card.test.ts
+++ b/src/plugins/altabanka-rs/__tests__/converters/transactions/card.test.ts
@@ -13,7 +13,7 @@ describe('convertTransaction (card turnover)', () => {
 
   it('keeps domestic sum and the original-currency invoice for a foreign purchase', () => {
     const cardTransaction: AccountTransaction = {
-      id: 'id_CC-10000003E',
+      id: 'id_10000003E',
       date: new Date('2026-06-03T00:00:00'),
       address: 'Shell Yverdon Yverdon-les-B',
       amount: -4985.39,
@@ -27,7 +27,7 @@ describe('convertTransaction (card turnover)', () => {
       date: new Date('2026-06-03T00:00:00'),
       movements: [
         {
-          id: 'id_CC-10000003E',
+          id: 'id_10000003E',
           account: { id: '190000100000000001' },
           sum: -4985.39,
           fee: 0,
@@ -45,7 +45,7 @@ describe('convertTransaction (card turnover)', () => {
 
   it('keeps a plain domestic card purchase without invoice', () => {
     const cardTransaction: AccountTransaction = {
-      id: 'id_CC-10000001E',
+      id: 'id_10000001E',
       date: new Date('2026-06-18T00:00:00'),
       address: 'STUDIO3 - B6 BEOGRAD',
       amount: -2380,
@@ -58,7 +58,7 @@ describe('convertTransaction (card turnover)', () => {
       date: new Date('2026-06-18T00:00:00'),
       movements: [
         {
-          id: 'id_CC-10000001E',
+          id: 'id_10000001E',
           account: { id: '190000100000000001' },
           sum: -2380,
           fee: 0,

--- a/src/plugins/altabanka-rs/__tests__/converters/transactions/deduplicateTransactions.test.ts
+++ b/src/plugins/altabanka-rs/__tests__/converters/transactions/deduplicateTransactions.test.ts
@@ -1,74 +1,144 @@
 import { deduplicateTransactions } from '../../../converters'
 
-describe('convertTransaction', () => {
-  it.each([
-    [
-      // different movements id
-      [
-        {
-          hold: false,
-          date: new Date('2026-04-20T00:00:00+03:00'),
-          movements: [
-            {
-              id: 'id_7cWphlX3tccaSRuyJBJ%2FkOeBphfT%2BQT0jeil5wQLjq3SbJYHJufNuQ4xOKCs1NLcjDw7gJ6bbt18CEy8fwYHelJtPWruc1kZ',
-              account: { id: '0001000384425' },
-              sum: -1471.4,
-              fee: 0,
-              invoice: null
-            }
-          ],
-          merchant: {
-            fullTitle: 'Wolt doo>972546560588 RS',
-            mcc: null,
-            location: null
-          },
-          comment: null
+describe('deduplicateTransactions', () => {
+  it('merges soft-key duplicates with different movement ids and clears hold', () => {
+    const apiTransactions = [
+      {
+        hold: false,
+        date: new Date('2026-04-20T00:00:00+03:00'),
+        movements: [
+          {
+            id: 'id_7cWphlX3tccaSRuyJBJ%2FkOeBphfT%2BQT0jeil5wQLjq3SbJYHJufNuQ4xOKCs1NLcjDw7gJ6bbt18CEy8fwYHelJtPWruc1kZ',
+            account: { id: '0001000384425' },
+            sum: -1471.4,
+            fee: 0,
+            invoice: null
+          }
+        ],
+        merchant: {
+          fullTitle: 'Wolt doo>972546560588 RS',
+          mcc: null,
+          location: null
         },
-        {
-          hold: true,
-          date: new Date('2026-04-20T00:00:00+03:00'),
-          movements: [
-            {
-              id: 'id_7cWphlX3tcfNgM88h%2Fi2lkwoHJVMrVNj9D5iK%2By2VrS7xybcfLabrxaHHsoqjgwgxD%2BlOh8kvuNMeIJPJZarf%2BkHrZrNINt8',
-              account: { id: '0001000384425' },
-              sum: -1471.4,
-              fee: 0,
-              invoice: null
-            }
-          ],
-          merchant: {
-            fullTitle: 'Wolt doo>972546560588 RS',
-            mcc: null,
-            location: null
-          },
-          comment: null
-        }
-      ],
-      [
-        {
-          hold: false,
-          date: new Date('2026-04-20T00:00:00+03:00'),
-          movements: [
-            {
-              id: 'id_7cWphlX3tccaSRuyJBJ%2FkOeBphfT%2BQT0jeil5wQLjq3SbJYHJufNuQ4xOKCs1NLcjDw7gJ6bbt18CEy8fwYHelJtPWruc1kZ',
-              account: { id: '0001000384425' },
-              sum: -1471.4,
-              fee: 0,
-              invoice: null
-            }
-          ],
-          merchant: {
-            fullTitle: 'Wolt doo>972546560588 RS',
-            mcc: null,
-            location: null
-          },
-          comment: null
-        }
-      ]
+        comment: null
+      },
+      {
+        hold: true,
+        date: new Date('2026-04-20T00:00:00+03:00'),
+        movements: [
+          {
+            id: 'id_7cWphlX3tcfNgM88h%2Fi2lkwoHJVMrVNj9D5iK%2By2VrS7xybcfLabrxaHHsoqjgwgxD%2BlOh8kvuNMeIJPJZarf%2BkHrZrNINt8',
+            account: { id: '0001000384425' },
+            sum: -1471.4,
+            fee: 0,
+            invoice: null
+          }
+        ],
+        merchant: {
+          fullTitle: 'Wolt doo>972546560588 RS',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      }
     ]
-  ])('converts income transactions', (apiTransactions, transactions) => {
+    const transactions = [
+      {
+        hold: false,
+        date: new Date('2026-04-20T00:00:00+03:00'),
+        movements: [
+          {
+            id: 'id_7cWphlX3tccaSRuyJBJ%2FkOeBphfT%2BQT0jeil5wQLjq3SbJYHJufNuQ4xOKCs1NLcjDw7gJ6bbt18CEy8fwYHelJtPWruc1kZ',
+            account: { id: '0001000384425' },
+            sum: -1471.4,
+            fee: 0,
+            invoice: null
+          }
+        ],
+        merchant: {
+          fullTitle: 'Wolt doo>972546560588 RS',
+          mcc: null,
+          location: null
+        },
+        comment: null
+      }
+    ]
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     expect(deduplicateTransactions(apiTransactions)).toEqual(transactions)
+  })
+
+  it('prefers posted when hold and posted share the canonical reference id', () => {
+    const hold = {
+      hold: true,
+      date: new Date('2026-07-13T00:00:00'),
+      movements: [
+        {
+          id: 'id_20000001R',
+          account: { id: '190000100000000001' },
+          sum: -100,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: {
+        fullTitle: 'GALEN PHARM> RS',
+        mcc: null,
+        location: null
+      },
+      comment: null
+    }
+    const posted = {
+      hold: false,
+      date: new Date('2026-07-14T00:00:00'),
+      movements: [
+        {
+          id: 'id_20000001R',
+          account: { id: '190000100000000001' },
+          sum: -100,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: {
+        fullTitle: 'MP333 LONDON BG BEOGRAD',
+        mcc: null,
+        location: null
+      },
+      comment: null
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(deduplicateTransactions([hold, posted])).toEqual([posted])
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(deduplicateTransactions([posted, hold])).toEqual([posted])
+  })
+
+  it('does not crash on foreign-currency transactions with null movement sum', () => {
+    const foreign = {
+      hold: false,
+      date: new Date('2026-07-13T00:00:00'),
+      movements: [
+        {
+          id: 'id_20000002E',
+          account: { id: '190000100000000001' },
+          sum: null,
+          fee: 0,
+          invoice: { sum: -10, instrument: 'EUR' }
+        }
+      ],
+      merchant: {
+        fullTitle: 'SOME MERCHANT PARIS',
+        mcc: null,
+        location: null
+      },
+      comment: null
+    }
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(deduplicateTransactions([foreign])).toEqual([foreign])
   })
 })

--- a/src/plugins/altabanka-rs/__tests__/converters/transactions/innerTransfer.test.ts
+++ b/src/plugins/altabanka-rs/__tests__/converters/transactions/innerTransfer.test.ts
@@ -32,11 +32,7 @@ describe('convertTransaction', () => {
           }
         ],
         merchant: null,
-        comment: 'Interni transfer - Isplata DS',
-        groupKeys: [
-          '2025-09-15_RSD_40000',
-          'id_wt7rXfmUMmVgroIlNmVEvMfHyEX8Ldq4A6ZxYgnIfCIjdZ8FtfOJSQCtD%2FmrjSgj1zHjx%2Btw4sQ%3D'
-        ]
+        comment: 'Interni transfer - Isplata DS'
       }
     ],
     [
@@ -69,11 +65,7 @@ describe('convertTransaction', () => {
           }
         ],
         merchant: null,
-        comment: 'Interni transfer - Uplata TR',
-        groupKeys: [
-          '2025-09-15_RSD_40000',
-          'id_wt7rXfmUMmVgroIlNmVEvMfHyEX8Ldq41DLFWmga94nrZNHdx0JxXiC5bJi8cVub5jCblKRgIp4%3D'
-        ]
+        comment: 'Interni transfer - Uplata TR'
       }
     ]
   ])('converts inner transfer', (apiTransaction, account, transaction) => {
@@ -111,11 +103,7 @@ describe('convertTransaction', () => {
           }
         ],
         merchant: null,
-        comment: 'Kupovina deviza',
-        groupKeys: [
-          '2025-12-06_RSD_58957',
-          'id_viqYbg6BsBuDFJFg3r77%2ByeZvsYr6X7fmRAo6AuNYQYBfY2cH7MAJ8g8iCUfQ3Yie6bTzJdpehE%3D'
-        ]
+        comment: 'Kupovina deviza'
       }
     ],
     [
@@ -148,11 +136,7 @@ describe('convertTransaction', () => {
           }
         ],
         merchant: null,
-        comment: 'Kupovina deviza',
-        groupKeys: [
-          '2025-12-06_EUR_500',
-          'id_viqYbg6BsBuDFJFg3r77%2ByeZvsYr6X7f4nRf9PIIC9Mess7n7trIZFF4KADMvYR2ivh%2BXrHnFI4%3D'
-        ]
+        comment: 'Kupovina deviza'
       }
     ]
   ])('converts inner currency transfer', (apiTransaction, account, transaction) => {

--- a/src/plugins/altabanka-rs/api.ts
+++ b/src/plugins/altabanka-rs/api.ts
@@ -2,6 +2,7 @@ import { InvalidOtpCodeError } from '../../errors'
 import {
   fetchAccountTurnover,
   fetchAccounts as fetchAccountsApi,
+  fetchCardReservedFunds,
   fetchCardTurnover,
   fetchCards as fetchCardsApi,
   fetchEnvironment,
@@ -59,6 +60,14 @@ export async function fetchReservedTransactions (
 
 export async function fetchCards (session: Session): Promise<Card[]> {
   return await fetchCardsApi(session.requestToken)
+}
+
+export async function fetchCardReservedTransactions (
+  session: Session,
+  card: Card,
+  fromDate: Date
+): Promise<AccountTransaction[]> {
+  return await fetchCardReservedFunds(session.requestToken, card.primaryCardID, card.currency, fromDate)
 }
 
 export async function fetchCardTransactions (

--- a/src/plugins/altabanka-rs/converters.ts
+++ b/src/plugins/altabanka-rs/converters.ts
@@ -1,7 +1,6 @@
 import { AccountOrCard, AccountType, ExtendedTransaction, Transaction } from '../../types/zenmoney'
 import { AccountInfo, AccountTransaction } from './models'
-import { toISODateString, dateInTimezone } from '../../common/dateUtils'
-import { getNumber, getString } from '../../types/get'
+import { getOptNumber, getOptString } from '../../types/get'
 
 export function convertAccounts (apiAccounts: AccountInfo[]): AccountOrCard[] {
   return apiAccounts.map(apiAccount => {
@@ -94,10 +93,6 @@ function parseInnerTransfer (transaction: ExtendedTransaction, accountTransactio
     /Interni transfer/i,
     /Kupovina deviza/i
   ].some(regex => regex.test(accountTransaction.address))) {
-    transaction.groupKeys = [
-      `${toISODateString(dateInTimezone(transaction.date, 180)).slice(0, 10)}_${invoice.instrument}_${Math.abs(invoice.sum)}`,
-      accountTransaction.id
-    ]
     transaction.merchant = null
     transaction.comment = accountTransaction.address
 
@@ -123,10 +118,33 @@ function parsePayeeAndComment (transaction: ExtendedTransaction, accountTransact
 }
 
 export function deduplicateTransactions (transactions: Transaction[]): Transaction[] {
-  const result = transactions.concat()
+  // Prefer posted when hold and posted share the same movement id (canonical card reference).
+  const byId = new Map<string, Transaction>()
+  const withoutId: Transaction[] = []
+
+  for (const transaction of transactions) {
+    const id = transaction.movements[0]?.id
+    if (typeof id !== 'string') {
+      withoutId.push(transaction)
+      continue
+    }
+    const existing = byId.get(id)
+    if (existing == null) {
+      byId.set(id, transaction)
+      continue
+    }
+    if (existing.hold === true && transaction.hold !== true) {
+      byId.set(id, transaction)
+    }
+  }
+
+  const result = [...byId.values(), ...withoutId]
+  // Soft fallback for pairs that still use different movement ids.
   for (let i = 0; i < result.length; ++i) {
     for (let j = i + 1; j < result.length; ++j) {
-      if (getDeduplicationKey(result[i]) === getDeduplicationKey(result[j])) {
+      const leftKey = getDeduplicationKey(result[i])
+      const rightKey = getDeduplicationKey(result[j])
+      if (leftKey !== null && leftKey === rightKey) {
         result[i].hold = false
         result.splice(j--, 1)
       }
@@ -140,9 +158,9 @@ function getDeduplicationKey (transaction: Transaction): string | null {
     return null
   }
   const movement = transaction.movements[0]
-  const accountId = getString(movement.account, 'id')
-  const sum = getNumber(movement, 'sum')
-  if (accountId === null || sum === null) {
+  const accountId = getOptString(movement.account, 'id')
+  const sum = getOptNumber(movement, 'sum')
+  if (accountId === undefined || sum === undefined) {
     return null
   }
   return JSON.stringify({

--- a/src/plugins/altabanka-rs/fetchApi.ts
+++ b/src/plugins/altabanka-rs/fetchApi.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import { fetch, fetchJson, FetchOptions, FetchResponse } from '../../common/network'
-import { parseAccountInfo, parseCards, parseCardTurnover, parseEnvironment, parseReservedFunds, parseTransactions } from './parsers'
+import { parseAccountInfo, parseCardReservedFunds, parseCards, parseCardTurnover, parseEnvironment, parseReservedFunds, parseTransactions } from './parsers'
 import { AccountInfo, AccountTransaction, Card, Environment } from './models'
 
 const baseUrl = 'https://online.altabanka.rs/Retail/Protected/Services/'
@@ -115,4 +115,16 @@ export async function fetchReservedFunds (
     body: { accountNumber, gridName: null }
   })
   return parseReservedFunds(response.body, fromDate)
+}
+
+export async function fetchCardReservedFunds (
+  token: string,
+  cardId: string,
+  accountCurrency: string,
+  fromDate: Date
+): Promise<AccountTransaction[]> {
+  const response = await fetchApi('DataService.svc/GetCardReservedFundsALTA', token, {
+    body: { cardId, gridName: 'RetailCardReservedFunds' }
+  })
+  return parseCardReservedFunds(response.body, accountCurrency, fromDate)
 }

--- a/src/plugins/altabanka-rs/index.ts
+++ b/src/plugins/altabanka-rs/index.ts
@@ -2,7 +2,7 @@ import { Account, ScrapeFunc, Transaction } from '../../types/zenmoney'
 import { UserInteractionError } from '../../errors'
 import { AccountInfo, Preferences } from './models'
 import { convertAccounts, convertTransaction, deduplicateTransactions } from './converters'
-import { fetchAccounts, fetchCardTransactions, fetchCards, fetchReservedTransactions, fetchTransactions, login } from './api'
+import { fetchAccounts, fetchCardReservedTransactions, fetchCardTransactions, fetchCards, fetchReservedTransactions, fetchTransactions, login } from './api'
 
 export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate, isInBackground }) => {
   if (isInBackground) {
@@ -51,6 +51,13 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
     const apiTransactions = await fetchCardTransactions(session, card, currencies, fromDate, toDate ?? new Date())
     transactions.push(...apiTransactions
       .map(t => convertTransaction(t, account))
+      .filter((tx): tx is Transaction => tx !== null))
+
+    // Pending card authorizations (all currencies, incl. foreign like HUF) live in a
+    // card-specific reserved funds endpoint.
+    const reservedCardTransactions = await fetchCardReservedTransactions(session, card, fromDate)
+    transactions.push(...reservedCardTransactions
+      .map(t => convertTransaction(t, account, true))
       .filter((tx): tx is Transaction => tx !== null))
   }))
 

--- a/src/plugins/altabanka-rs/parsers.ts
+++ b/src/plugins/altabanka-rs/parsers.ts
@@ -1,14 +1,30 @@
 import moment from 'moment'
 import { isValidDate } from '../../common/dateUtils'
+import { decodeHtmlSpecialCharacters } from '../../common/stringUtils'
 import { getOptBoolean, getOptNumber, getOptString, getString } from '../../types/get'
 import { AccountInfo, AccountTransaction, Card, Environment } from './models'
 
 const exchangeRateRegex = /\d+\.\d+ \w{3} Kurs:.+/
+// Card turnover uses this placeholder until the authorization is posted.
+const UNCONFIRMED_CARD_DATE = '01.01.0001'
 
 function asArray (value: unknown): unknown[] {
   // Some endpoints return an error object (e.g. for an unsupported AccountType)
   // instead of an array, so we tolerate non-arrays instead of throwing.
   return Array.isArray(value) ? value : []
+}
+
+// ReservedFunds Reference `19633484R` and CardTurnover `CC-19633484R` are the same auth.
+export function canonicalTransactionReference (reference: string): string {
+  return reference.replace(/^CC-/i, '')
+}
+
+function movementIdFromReference (reference: string): string {
+  return 'id_' + canonicalTransactionReference(reference)
+}
+
+function normalizeAddress (text: string): string {
+  return decodeHtmlSpecialCharacters(text.replace(/\s+/g, ' ').trim())
 }
 
 export function parseEnvironment (body: unknown): Environment {
@@ -63,7 +79,7 @@ export function parseTransactions (body: unknown, fromDate: Date): AccountTransa
     const date = moment(getString(row, '7'), 'DD.MM.YYYY HH:mm:ss').toDate()
     const rawCurrency = getString(row, '30')
 
-    let text = getString(row, '15').replace(/\s+/g, ' ').trim().replace('Kartica: ', '')
+    let text = normalizeAddress(getString(row, '15')).replace('Kartica: ', '')
     const description = text.match(exchangeRateRegex)?.[0] ?? ''
     text = text.replace(description, '').trim()
 
@@ -101,24 +117,30 @@ export function parseCardTurnover (body: unknown, fromDate: Date): AccountTransa
   const inner = asArray(outer[0])
   const transactionRows = inner.length > 1 ? asArray(inner[1]) : []
 
-  return transactionRows.map(row => {
+  return transactionRows.flatMap(row => {
+    const dateRaw = getString(row, '24')
+    // Unconfirmed authorizations duplicate ReservedFunds; import holds from reserved only.
+    if (dateRaw.startsWith(UNCONFIRMED_CARD_DATE)) {
+      return []
+    }
+
     // Empty columns arrive as '0' (not ''), so detect a debit by a non-zero amount.
     const debit = getString(row, '9')
     const sign = debit !== '' && parseFloat(debit) !== 0 ? -1 : 1
     const domesticAmount = sign * parseFloat(getString(row, '25'))
     const accountCurrency = getString(row, '28')
     const originalCurrency = getString(row, '11')
-    const date = moment(getString(row, '24'), 'DD.MM.YYYY HH:mm:ss').toDate()
+    const date = moment(dateRaw, 'DD.MM.YYYY HH:mm:ss').toDate()
 
-    const address = getString(row, '17')
-      .split(': ').slice(1).join(': ')
-      .replace(/\s+/g, ' ')
-      .trim()
+    const address = normalizeAddress(
+      getString(row, '17')
+        .split(': ').slice(1).join(': ')
+    )
 
     const result: AccountTransaction = {
-      id: 'id_' + getString(row, '14'),
+      id: movementIdFromReference(getString(row, '14')),
       date: isValidDate(date) ? date : fromDate,
-      address: address === '' ? getString(row, '17').replace(/\s+/g, ' ').trim() : address,
+      address: address === '' ? normalizeAddress(getString(row, '17')) : address,
       amount: domesticAmount,
       currency: accountCurrency === '' ? undefined : accountCurrency,
       description: ''
@@ -129,7 +151,7 @@ export function parseCardTurnover (body: unknown, fromDate: Date): AccountTransa
       result.invoice = { sum: originalAmount, instrument: originalCurrency }
     }
 
-    return result
+    return [result]
   })
 }
 
@@ -142,9 +164,9 @@ export function parseReservedFunds (body: unknown, fromDate: Date): AccountTrans
     const currency = getOptString(row, 'CurrencyCode') ?? ''
 
     return {
-      id: 'id_' + (getOptString(row, 'Reference') ?? ''),
+      id: movementIdFromReference(getOptString(row, 'Reference') ?? ''),
       date: isValidDate(date) ? date : fromDate,
-      address: (getOptString(row, 'Description') ?? '').replace(/\s+/g, ' ').trim(),
+      address: normalizeAddress(getOptString(row, 'Description') ?? ''),
       amount: getOptString(row, 'Category') === 'c' ? amount : -amount,
       currency: currency === '' ? undefined : currency,
       description: ''

--- a/src/plugins/altabanka-rs/parsers.ts
+++ b/src/plugins/altabanka-rs/parsers.ts
@@ -158,18 +158,48 @@ export function parseCardTurnover (body: unknown, fromDate: Date): AccountTransa
 export function parseReservedFunds (body: unknown, fromDate: Date): AccountTransaction[] {
   const rows = asArray(body)
 
-  return rows.map(row => {
-    const amount = getOptNumber(row, 'AmountTotal') ?? 0
-    const date = moment(getOptString(row, 'ValueDate') ?? '').toDate()
-    const currency = getOptString(row, 'CurrencyCode') ?? ''
+  return rows
+    // Card authorizations are fetched per card from GetCardReservedFundsALTA (all currencies);
+    // the account-level endpoint only returns them in the account currency, so skip them here.
+    .filter(row => getOptString(row, 'Source') !== 'crd')
+    .map(row => {
+      const amount = getOptNumber(row, 'AmountTotal') ?? 0
+      const date = moment(getOptString(row, 'ValueDate') ?? '').toDate()
+      const currency = getOptString(row, 'CurrencyCode') ?? ''
 
-    return {
-      id: movementIdFromReference(getOptString(row, 'Reference') ?? ''),
+      return {
+        id: movementIdFromReference(getOptString(row, 'Reference') ?? ''),
+        date: isValidDate(date) ? date : fromDate,
+        address: normalizeAddress(getOptString(row, 'Description') ?? ''),
+        amount: getOptString(row, 'Category') === 'c' ? amount : -amount,
+        currency: currency === '' ? undefined : currency,
+        description: ''
+      }
+    })
+}
+
+export function parseCardReservedFunds (body: unknown, accountCurrency: string, fromDate: Date): AccountTransaction[] {
+  const rows = asArray(body)
+
+  return rows.map(row => {
+    const sign = getString(row, '32') === 'c' ? 1 : -1
+    const originalCurrency = getString(row, '7')
+    const date = moment(getString(row, '9'), 'DD.MM.YYYY HH:mm:ss').toDate()
+
+    const result: AccountTransaction = {
+      id: movementIdFromReference(getString(row, '12')),
       date: isValidDate(date) ? date : fromDate,
-      address: normalizeAddress(getOptString(row, 'Description') ?? ''),
-      amount: getOptString(row, 'Category') === 'c' ? amount : -amount,
-      currency: currency === '' ? undefined : currency,
+      address: normalizeAddress(getString(row, '13')),
+      amount: sign * parseFloat(getString(row, '51')),
+      currency: accountCurrency === '' ? undefined : accountCurrency,
       description: ''
     }
+
+    const originalAmount = sign * parseFloat(getString(row, '17'))
+    if (originalCurrency !== '' && originalCurrency !== accountCurrency && originalAmount !== 0) {
+      result.invoice = { sum: originalAmount, instrument: originalCurrency }
+    }
+
+    return result
   })
 }


### PR DESCRIPTION
This PR contains two related fixes for card operations.

## 1. Deduplicate hold and posted card operations

The same card authorization used to be imported twice. It arrives from two endpoints:
- `GetTransactionalAccountReservedFunds` — as a pending `hold`;
- `GetCardTurnover` — as an unconfirmed row (placeholder date `01.01.0001 00:00:00`) while pending, and later as a posted row after confirmation.

The two copies differed by merchant text (one HTML-encoded, e.g. `GALEN PHARM&gt; RS` vs `GALEN PHARM> RS`) and by movement id, so neither the id-based nor the soft-key deduplication merged them.

Changes:
- Skip unconfirmed card turnover rows (placeholder date `01.01.0001`) in `parseCardTurnover`; pending authorizations are imported from reserved funds only.
- Decode HTML entities in merchant addresses (`&gt;` -> `>`) across account/card/reserved parsers so descriptions are consistent.
- Derive `movement.id` from a canonical reference (strip the `CC-` prefix) so reserved funds and card turnover share one id stem.
- Rewrite `deduplicateTransactions` to prefer the posted transaction over the hold with the same movement id, keeping the soft-key fallback.
- Drop the `groupKeys` mechanism from inner transfers (it leaked an unsupported field into the plain transaction output, breaking `Kupovina deviza` / `Interni transfer`).
- Use `getOpt*` getters in `getDeduplicationKey` to avoid a runtime assert on movements with a `null` sum.

## 2. Import pending foreign-currency card authorizations

Pending card authorizations made in a foreign currency were not imported at all. They are returned by a card-specific reserved funds endpoint, while the account-level reserved funds only expose card authorizations in the account currency.

Changes:
- Add `GetCardReservedFundsALTA` (queried per card) and parse it as hold transactions in all currencies. The account-currency amount is used as the movement sum, with an original-currency `invoice` for foreign operations.
- Exclude card-source rows (`Source === 'crd'`) from the account reserved funds so card authorizations are imported only from the card endpoint.
- Deduplication relies on the shared canonical reference id.

## Notes

- hold -> posted reconciliation across syncs (when a pending authorization is later confirmed) is left to ZenMoney's built-in hold matching: the confirmed operation comes with a different reference, merchant and date, so the plugin cannot link it.

## Testing

`yarn test altabanka-rs` passes (lint + type-check + 43 unit tests). Verified live via `yarn start altabanka-rs`: no duplicated card operations, foreign-currency pending authorizations are imported, and the `groupKeys` validation crash is gone.