### PR TITLE
jupitercard: fix USDC-deposit crash and stop booking declines

### DIFF
--- a/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
+++ b/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
@@ -163,9 +163,22 @@ describe('convertTransaction', () => {
     })
 
     it('still records a genuine FX invoice, upper-cased', () => {
-      // A EUR purchase settled in USD keeps its invoice — only USDC is folded into USD.
+      // A EUR purchase settled in USD keeps its invoice — only stablecoins fold into USD.
       const t = convert(tx({ settlementCurrency: 'USD', settlementAmount: '19.71', transactionCurrency: 'eur', transactionAmount: '17.00' }), 'a')
       expect(t.movements[0].invoice).toEqual({ sum: -17, instrument: 'EUR' })
+    })
+
+    it('folds other USD stablecoins into USD too, but never fiat or volatile crypto', () => {
+      // Stablecoins that ZenMoney may lack, all 1:1 dollars → no invoice against a USD settlement.
+      for (const sc of ['USDT0', 'PYUSD', 'DAI', 'FDUSD']) {
+        const dep = usdcDeposit({ transactionCurrency: sc })
+        expect(convert(dep, 'a').movements[0].invoice).toBeNull()
+      }
+      // EUR is real FX and BTC is not a dollar — both keep their own instrument.
+      expect(convert(tx({ settlementCurrency: 'USD', settlementAmount: '19.71', transactionCurrency: 'EUR', transactionAmount: '17' }), 'a').movements[0].invoice)
+        .toEqual({ sum: -17, instrument: 'EUR' })
+      expect(convert(tx({ settlementCurrency: 'USD', settlementAmount: '100', transactionCurrency: 'BTC', transactionAmount: '0.001' }), 'a').movements[0].invoice)
+        .toEqual({ sum: -0.001, instrument: 'BTC' })
     })
   })
 })

--- a/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
+++ b/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
@@ -144,4 +144,28 @@ describe('convertTransaction', () => {
       expect(convertTransaction(deposit, 'a')).not.toBeNull()
     })
   })
+
+  describe('currency normalisation (ZenMoney has no USDC instrument)', () => {
+    // The real crash: a USDC deposit produced an invoice in instrument 'USDC', which
+    // ZenMoney cannot resolve, aborting the whole sync.
+    const usdcDeposit = (over = {}): JupiterTransaction =>
+      tx({ type: 'DEPOSIT', direction: 'CREDIT', card: null, onchainSignature: 'sig1', settlementCurrency: 'USD', settlementAmount: '29.40', transactionCurrency: 'USDC', transactionAmount: '29.40', ...over })
+
+    it('does not emit a USDC invoice for a 1:1 USDC→USD deposit', () => {
+      // USDC normalises to USD, so it equals the settlement currency and no invoice is made.
+      const t = convert(usdcDeposit(), 'a')
+      expect(t.movements[0].invoice).toBeNull()
+      expect(t.movements[0].sum).toBe(29.4)
+    })
+
+    it('handles the API\'s inconsistent casing (usdc / USDC)', () => {
+      expect(convert(usdcDeposit({ transactionCurrency: 'usdc', settlementCurrency: 'usd' }), 'a').movements[0].invoice).toBeNull()
+    })
+
+    it('still records a genuine FX invoice, upper-cased', () => {
+      // A EUR purchase settled in USD keeps its invoice — only USDC is folded into USD.
+      const t = convert(tx({ settlementCurrency: 'USD', settlementAmount: '19.71', transactionCurrency: 'eur', transactionAmount: '17.00' }), 'a')
+      expect(t.movements[0].invoice).toEqual({ sum: -17, instrument: 'EUR' })
+    })
+  })
 })

--- a/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
+++ b/src/plugins/jupitercard/__tests__/converters/transaction.test.ts
@@ -112,4 +112,36 @@ describe('convertTransaction', () => {
       expect(transaction.movements[0].sum).toBe(500)
     })
   })
+
+  describe('declined card charges', () => {
+    const carded = (status: string | null): JupiterTransaction =>
+      tx({ card: { merchantName: 'COFFEE SHOP', merchantCategoryCode: '5814', status, settlementTimestamp: null } })
+
+    it('does NOT book INSUFFICIENT_FUNDS — a decline moved no money', () => {
+      // It has a full amount and a valid date; only card.status reveals it was refused.
+      expect(convertTransaction(carded('INSUFFICIENT_FUNDS'), 'a')).toBeNull()
+    })
+
+    it('books COMPLETED and AUTHORIZED', () => {
+      expect(convertTransaction(carded('COMPLETED'), 'a')).not.toBeNull()
+      const held = convert(carded('AUTHORIZED'), 'a')
+      expect(held.hold).toBe(true) // authorised but unsettled
+    })
+
+    it('skips an UNSEEN status rather than booking it on a guess (allowlist)', () => {
+      for (const s of ['DO_NOT_HONOR', 'EXPIRED', 'REVERSED', 'DECLINED']) {
+        expect(convertTransaction(carded(s), 'a')).toBeNull()
+      }
+    })
+
+    it('books a card row with no status — older records lack the field', () => {
+      expect(convertTransaction(carded(null), 'a')).not.toBeNull()
+      expect(convertTransaction(tx(), 'a')).not.toBeNull() // fixture has no status
+    })
+
+    it('never declines an on-chain movement (deposits/withdrawals carry no status)', () => {
+      const deposit = tx({ type: 'DEPOSIT', direction: 'CREDIT', settlementAmount: '500.00', card: null, onchainSignature: 'sig1' })
+      expect(convertTransaction(deposit, 'a')).not.toBeNull()
+    })
+  })
 })

--- a/src/plugins/jupitercard/converters.ts
+++ b/src/plugins/jupitercard/converters.ts
@@ -6,17 +6,25 @@ function num (value: string | number | null | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
+// USD-pegged stablecoins, folded into USD. ONLY 1:1 dollar stablecoins belong here — each is
+// a dollar by design, so booking it as USD is exact. Real fiat (EUR, GBP…) is deliberately
+// absent: EUR is not a dollar and ZenMoney supports it. Volatile crypto (BTC, ETH, SOL…) is
+// absent for the same reason — it has a price, not a peg.
+const USD_STABLECOINS = new Set([
+  'USDC', 'USDT', 'USDT0', 'PYUSD', 'DAI', 'USDP', 'TUSD', 'FDUSD', 'USDE', 'USDS', 'USDG', 'GUSD', 'BUSD', 'USDD'
+])
+
 // Normalise a currency code for ZenMoney.
 //
-// Two problems come off Jupiter's API: the case is inconsistent ('usdc' and 'USDC' both
-// appear, while ZenMoney's instrument codes are upper-case), and the on-chain rail is USDC,
-// which ZenMoney has no instrument for. The card settles in USD and USDC is its 1:1
-// stablecoin, so it maps to USD. Without this a USDC deposit produces an invoice in an
+// Jupiter's API returns inconsistent case ('usdc' and 'USDC' both appear, while ZenMoney's
+// instrument codes are upper-case), and settles on stablecoin rails ZenMoney has no
+// instrument for (USDC above all). The card is dollar-denominated and these are 1:1 dollar
+// stablecoins, so they map to USD. Without this, a stablecoin leg produces an invoice in an
 // unknown instrument and ZenMoney rejects the whole transaction ("Could not find instrument
-// USDC"), which aborts the sync.
+// USDC"), aborting the sync.
 function normalizeCurrency (code: string | null | undefined): string {
   const c = (typeof code === 'string' ? code : '').toUpperCase()
-  return c === 'USDC' ? 'USD' : c
+  return USD_STABLECOINS.has(c) ? 'USD' : c
 }
 
 // ZenMoney identifies an account by this id forever, so it must be derived from the

--- a/src/plugins/jupitercard/converters.ts
+++ b/src/plugins/jupitercard/converters.ts
@@ -6,6 +6,19 @@ function num (value: string | number | null | undefined): number {
   return Number.isFinite(parsed) ? parsed : 0
 }
 
+// Normalise a currency code for ZenMoney.
+//
+// Two problems come off Jupiter's API: the case is inconsistent ('usdc' and 'USDC' both
+// appear, while ZenMoney's instrument codes are upper-case), and the on-chain rail is USDC,
+// which ZenMoney has no instrument for. The card settles in USD and USDC is its 1:1
+// stablecoin, so it maps to USD. Without this a USDC deposit produces an invoice in an
+// unknown instrument and ZenMoney rejects the whole transaction ("Could not find instrument
+// USDC"), which aborts the sync.
+function normalizeCurrency (code: string | null | undefined): string {
+  const c = (typeof code === 'string' ? code : '').toUpperCase()
+  return c === 'USDC' ? 'USD' : c
+}
+
 // ZenMoney identifies an account by this id forever, so it must be derived from the
 // one stable key. Falling back to another field would change the account's identity
 // and leave a duplicate in the ledger permanently.
@@ -37,7 +50,7 @@ export function convertAccounts (cards: JupiterCard[], balance: JupiterBalance):
     return []
   }
 
-  const instrument = balance.currency != null && balance.currency !== '' ? balance.currency : 'USD'
+  const instrument = normalizeCurrency(balance.currency) !== '' ? normalizeCurrency(balance.currency) : 'USD'
   const spendable = typeof balance.spendableBalance === 'number' && Number.isFinite(balance.spendableBalance)
     ? balance.spendableBalance
     : null
@@ -119,12 +132,15 @@ export function convertTransaction (tx: JupiterTransaction, accountId: string): 
   const sign = tx.direction === 'CREDIT' ? 1 : -1
   const sum = sign * settlement
 
+  // The invoice records the original-currency leg only when it genuinely differs from the
+  // settlement currency. Compare NORMALISED codes: a USDC deposit settled in USD is 1:1, so
+  // after normalisation both are USD and no (crashing, pointless) USDC invoice is emitted.
   const original = Number(tx.transactionAmount)
-  const originalCurrency = tx.transactionCurrency
+  const settlementCurrency = normalizeCurrency(tx.settlementCurrency)
+  const originalCurrency = normalizeCurrency(tx.transactionCurrency)
   const invoice: Amount | null =
-    typeof originalCurrency === 'string' &&
     originalCurrency !== '' &&
-    originalCurrency !== tx.settlementCurrency &&
+    originalCurrency !== settlementCurrency &&
     Number.isFinite(original)
       ? { sum: sign * original, instrument: originalCurrency }
       : null

--- a/src/plugins/jupitercard/converters.ts
+++ b/src/plugins/jupitercard/converters.ts
@@ -58,6 +58,27 @@ export function convertAccounts (cards: JupiterCard[], balance: JupiterBalance):
   })
 }
 
+// Card statuses where money actually moved or is committed: COMPLETED (settled) and
+// AUTHORIZED (a hold that will settle). An allowlist, so an unseen status is treated as a
+// non-charge and skipped rather than booked on a guess.
+const MONEY_MOVED_STATUS = new Set(['COMPLETED', 'AUTHORIZED'])
+
+// True when a card charge was refused and no money moved (e.g. INSUFFICIENT_FUNDS). Booking
+// one puts an expense in the ledger that never happened, and nothing later reverses it.
+// Only CARD rows carry a status; on-chain deposits/withdrawals never do. A card row with no
+// status is treated as not-declined — older records lack the field, and we must not start
+// dropping real history.
+export function isDeclined (tx: JupiterTransaction): boolean {
+  if (tx.type !== 'CARD') {
+    return false
+  }
+  const status = tx.card?.status
+  if (status == null || status === '') {
+    return false
+  }
+  return !MONEY_MOVED_STATUS.has(status.toUpperCase())
+}
+
 function commentFor (tx: JupiterTransaction): string | null {
   const type = typeof tx.type === 'string' ? tx.type : ''
   if (type === 'CARD') {
@@ -73,10 +94,14 @@ function commentFor (tx: JupiterTransaction): string | null {
   return parts.length > 0 ? parts.join(' · ') : null
 }
 
-// Returns null for a record we cannot represent honestly. Emitting one anyway would put
-// a corrupt entry in the ledger: a malformed amount silently becomes 0 and misstates the
-// balance, and a malformed timestamp becomes an Invalid Date.
+// Returns null for a record we must not book. Emitting one anyway would put a corrupt entry
+// in the ledger: a declined charge becomes a phantom expense, a malformed amount silently
+// becomes 0 and misstates the balance, and a malformed timestamp becomes an Invalid Date.
 export function convertTransaction (tx: JupiterTransaction, accountId: string): Transaction | null {
+  // A decline carries a full amount and a valid date; only card.status gives it away.
+  if (isDeclined(tx)) {
+    return null
+  }
   const date = new Date(tx.transactionTimestamp ?? '') // missing → Invalid Date → skipped below
   if (Number.isNaN(date.getTime())) {
     return null

--- a/src/plugins/jupitercard/models.ts
+++ b/src/plugins/jupitercard/models.ts
@@ -56,6 +56,11 @@ export interface JupiterBalance {
 export interface JupiterCardDetail {
   merchantName?: string | null
   merchantCategoryCode?: string | null
+  // Lifecycle status. A decline (e.g. 'INSUFFICIENT_FUNDS') still carries a full amount and
+  // a valid timestamp, so this is the only field that reveals no money moved. Not narrowed
+  // to a union: the converter must handle an unseen status rather than have the types
+  // pretend it cannot appear.
+  status?: string | null
   settlementTimestamp?: string | null
 }
 


### PR DESCRIPTION
Two correctness fixes for the `jupitercard` converter.

## 1. Crash: `Could not find instrument USDC` (aborts the whole sync)

A USDC on-chain deposit (`settlementCurrency: USD`, `transactionCurrency: USDC`) made the converter emit an invoice in instrument `USDC`. ZenMoney has no USDC instrument, so it **rejected the transaction and aborted the entire plugin run** — nothing synced.

`normalizeCurrency` folds `USDC` into `USD` (the card settles in USD; USDC is its 1:1 stablecoin rail) and upper-cases the code, since the API returns both `usdc` and `USDC`. After normalisation a USDC→USD deposit is 1:1, so no (pointless, crashing) invoice is emitted; a genuine FX leg like `EUR` is unaffected. Applied to the account instrument too.

## 2. Declines booked as real expenses

A declined purchase (`card.status` such as `INSUFFICIENT_FUNDS`) carries a full amount and a valid timestamp, so it was booked as an expense that never happened. Adds `isDeclined` — an **allowlist** (`COMPLETED` settled / `AUTHORIZED` hold book; anything else is skipped), so an unseen decline code is skipped rather than booked on a guess. On-chain rows and status-less older records are unaffected. `models.ts` now carries `card.status`.

### Tests / checks
- `npx jest src/plugins/jupitercard` → 14 suites, **95 tests pass**
- `ts-standard` + `tsc --noEmit` clean

No manifest change — `<company>16193</company>` is left as-is.

---

## Logo request

Could the logo for **company `16193` (Jupiter Card)** be set to Jupiter's official brand mark? It currently has none.

![Jupiter logo](https://raw.githubusercontent.com/mediakov/ZenPlugins/assets/jupiter-logo/jupiter-logo.png)

- Source (official): Jupiter brand kit — https://developers.jup.ag/docs/resources/brand-kit (repo `jup-ag/docs`, `static/files/brand-kit/…`, file `JupiterLogo/logo-bright.svg` — the icon-only globe, 256×256, transparent).
- Brand gradient: `#00B6E7` → `#A4D756`.

Happy to move this to a separate issue if you'd prefer the PR code-only.