### PR TITLE
[trading212]: Fix schema to support new export

### DIFF
--- a/src/plugins/trading212/__tests__/convertTransactions.test.ts
+++ b/src/plugins/trading212/__tests__/convertTransactions.test.ts
@@ -106,6 +106,17 @@ describe('convertTransactions', () => {
     expect(result[0].movements[0].account).toEqual({ id: 'acc-1' })
   })
 
+  it('converts current export fields for interest on cash', () => {
+    const operations: ExportOperation[] = [
+      { ID: 'interest-001', Action: 'Interest on cash', 'Time (UTC)': '2026-07-18 01:15:00', Total: '2.48', 'Currency (Total)': 'USD' }
+    ]
+    const result = convertTransactions(operations, 'acc-1', 'acc-1-card', defaultPreferences)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].date).toEqual(new Date('2026-07-18T01:15:00Z'))
+    expect(result[0].movements[0].sum).toBe(2.48)
+  })
+
   it('adds round-up transaction for Card debit when roundUpTransactions is enabled', () => {
     const operations: ExportOperation[] = [
       { ID: 'round-001', Action: 'Card debit', Time: '2026-04-01 10:00:00', 'Gross Total': '-12.30', 'Currency (Gross Total)': 'EUR' }

--- a/src/plugins/trading212/converters.ts
+++ b/src/plugins/trading212/converters.ts
@@ -32,18 +32,21 @@ function convertTransaction (op: ExportOperation, accountId: string, cardId: str
   const isCardDebit = op.Action === 'Card debit'
   const isCardCashback = op.Action === 'Spending cashback' && !preferences.investCashback
   const isCardTransaction = isCardDebit || isCardCashback
+  const time = op['Time (UTC)'] ?? op.Time
+  const date = new Date(op['Time (UTC)'] != null && time != null ? `${time.replace(' ', 'T')}Z` : time ?? '')
+  const sum = Number(op.Total ?? op['Gross Total'])
 
   console.log('Converting operation', op)
 
   const transactions: Transaction[] = [
     {
       hold: false,
-      date: new Date(op.Time),
+      date,
       movements: [{
         id: op.ID,
         account: { id: isCardTransaction ? cardId : accountId },
         invoice: null,
-        sum: +op['Gross Total'],
+        sum,
         fee: 0
       }],
       comment: op.Action,
@@ -59,12 +62,12 @@ function convertTransaction (op: ExportOperation, accountId: string, cardId: str
   ]
 
   if (preferences.roundUpTransactions && isCardDebit) {
-    const roundedSum = Math.ceil(Math.abs(+op['Gross Total']))
-    const roundUpAmount = +(roundedSum - Math.abs(+op['Gross Total'])).toPrecision(5)
+    const roundedSum = Math.ceil(Math.abs(sum))
+    const roundUpAmount = +(roundedSum - Math.abs(sum)).toPrecision(5)
     if (roundUpAmount > 0) {
       transactions.push({
         hold: false,
-        date: new Date(op.Time),
+        date,
         movements: [
           {
             id: null,

--- a/src/plugins/trading212/models.ts
+++ b/src/plugins/trading212/models.ts
@@ -43,9 +43,12 @@ export interface ExportData {
 export interface ExportOperation {
   ID: string
   Action: string
-  Time: string
-  'Gross Total': string
-  'Currency (Gross Total)': string
+  'Time (UTC)'?: string
+  Time?: string
+  Total?: string
+  'Gross Total'?: string
+  'Currency (Total)'?: string
+  'Currency (Gross Total)'?: string
   'Merchant name'?: string
   'Merchant category'?: string
 }


### PR DESCRIPTION
Trading212 changed its CSV fields from `Time/Gross Total` to `Time (UTC)/Total`, causing Invalid Date and NaN values

```
date: Invalid Date
sum: NaN
[RUE] Assertion failed: transaction.date must be valid Date object
```

