### PR TITLE
[statusbank] load account products and transactions

### DIFF
--- a/src/plugins/statusbank/__tests__/api.test.js
+++ b/src/plugins/statusbank/__tests__/api.test.js
@@ -1,4 +1,4 @@
-import { createDateIntervals, fetchFullTransactions, parseFullTransactionsHtml, parseLatestOperations, parseLatestOperationsHtml } from '../api'
+import { createDateIntervals, fetchAccounts, fetchFullTransactions, parseAccountTransactionsHtml, parseFullTransactionsHtml, parseLatestOperations, parseLatestOperationsHtml } from '../api'
 
 function makeNetworkResponse (body, url = 'https://stb24.by/api/sou/admin/xml') {
   return {
@@ -47,6 +47,46 @@ function transactionDateForTest (date) {
     date.getFullYear()
   ].join('.')
 }
+
+describe('fetchAccounts', () => {
+  it('loads ACCOUNT products and extracts their statement action', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><GetProducts/></BS_Response>'))
+      .mockResolvedValueOnce(makeNetworkResponse(`
+        <BS_Response>
+          <GetProducts>
+            <Product Id="73124567-a1b2c3" ProductType="ACCOUNT" ProductTypeName="Счёт без карты" No="договор N 307451928" Currency="840" Balance="12,34">
+              <Action Id="73129901-a1b2c3-account-2048571-b735-getordering-1" Type="B735:GetOrdering" Name="Выписка по счёту"/>
+            </Product>
+          </GetProducts>
+        </BS_Response>
+      `))
+      .mockResolvedValueOnce(makeNetworkResponse(`
+        <BS_Response>
+          <GetProductTypes>
+            <ProductType Type="MS">
+              <Product Id="73120042-d4e5f6" ProductType="MS" LinkedProductId="73124567-a1b2c3" LinkedProductType="ACCOUNT"/>
+            </ProductType>
+          </GetProductTypes>
+        </BS_Response>
+      `))
+
+    await expect(fetchAccounts('session-id')).resolves.toEqual([
+      expect.objectContaining({
+        Id: ['73124567-a1b2c3'],
+        LinkedProductId: ['73120042-d4e5f6'],
+        LinkedProductType: ['MS'],
+        statementExecutionId: '73129901-a1b2c3-account-2048571-b735-getordering-1',
+        lastTrxExecutionId: null
+      })
+    ])
+
+    expect(global.fetch).toHaveBeenCalledTimes(3)
+    expect(global.fetch.mock.calls[0][1].body).toContain('ProductType="MS"')
+    expect(global.fetch.mock.calls[1][1].body).toContain('ProductType="ACCOUNT"')
+    expect(global.fetch.mock.calls[2][1].body).toContain('<GetProductTypes GetProducts="Y"')
+  })
+})
 
 describe('fetchFullTransactions', () => {
   it('fetches a statement returned as ExecuteAction.URL', async () => {
@@ -133,6 +173,52 @@ describe('fetchFullTransactions', () => {
       new Date('2026-06-05T00:00:00Z'),
       new Date('2026-06-05T00:00:00Z')
     )).rejects.toThrow('Unexpected statement response: Не удалось сформировать выписку')
+  })
+})
+
+describe('account statement parsing', () => {
+  it('parses standalone-account transfers and currency exchanges', () => {
+    const html = `
+      <div class="head"><h3>Выписка по счёту</h3><p>Счёт BY86IRJS3014ZZ00000012345678</p></div>
+      <div class="head"></div>
+      <table class="table-schet">
+        <thead><tr>
+          <th>Дата отражения операции по счёту</th>
+          <th>Дата совершения операции</th>
+          <th>Назначение платежа</th>
+          <th>Валюта счёта</th>
+          <th>Сумма операции в валюте счёта</th>
+          <th>Остаток по счёту</th>
+        </tr></thead>
+        <tbody>
+          <tr><td>02.02.2035 10:00:00</td><td>01.02.2035 10:00:00</td><td>Перевод денежных средств со счета №BY86IRJS3014ZZ00000012345678.</td><td>USD</td><td>-12,34</td><td>50,00</td></tr>
+          <tr><td>02.02.2035 11:00:00</td><td>01.02.2035 11:00:00</td><td>Продажа валюты банком с текущего счета №BY41IRJS3014ZZ00000087654321 с переводом на текущий счет №BY86IRJS3014ZZ00000012345678</td><td>USD</td><td>9,87</td><td>59,87</td></tr>
+        </tbody>
+      </table>
+    `
+
+    expect(parseAccountTransactionsHtml(html)).toEqual([
+      expect.objectContaining({
+        statementType: 'account',
+        date: '01.02.2035 10:00:00',
+        reflectedDate: '02.02.2035 10:00:00',
+        description: 'Перевод денежных средств со счета №BY86IRJS3014ZZ00000012345678.',
+        amount: -12.34,
+        amountReal: -12.34,
+        currency: 'USD',
+        currencyReal: 'USD'
+      }),
+      expect.objectContaining({
+        statementType: 'account',
+        date: '01.02.2035 11:00:00',
+        reflectedDate: '02.02.2035 11:00:00',
+        description: 'Продажа валюты банком с текущего счета №BY41IRJS3014ZZ00000087654321 с переводом на текущий счет №BY86IRJS3014ZZ00000012345678',
+        amount: 9.87,
+        amountReal: 9.87,
+        currency: 'USD',
+        currencyReal: 'USD'
+      })
+    ])
   })
 })
 

--- a/src/plugins/statusbank/__tests__/converters/accounts.test.js
+++ b/src/plugins/statusbank/__tests__/converters/accounts.test.js
@@ -1,4 +1,4 @@
-import { convertAccount } from '../../converters'
+import { convertAccount, convertLinkedAccountSource } from '../../converters'
 
 describe('convertAccount', () => {
   beforeEach(() => {
@@ -19,7 +19,6 @@ describe('convertAccount', () => {
   it('maps bank card to zenmoney one', () => {
     expect(convertAccount(bankCard)).toEqual({
       id: '11161311',
-      accountID: NaN,
       transactionsAccId: 'yyyy',
       latestTrID: 'xxxx',
       type: 'card',
@@ -37,5 +36,51 @@ describe('convertAccount', () => {
   it('maps skipped card to nothing', () => {
     global.ZenMoney = { isAccountSkipped: (accountId) => accountId === '11161311' }
     expect(convertAccount(bankCard)).toBeNull()
+  })
+
+  const standaloneAccount = {
+    statementExecutionId: '73129901-a1b2c3-account-2048571-b735-getordering-1',
+    Id: ['73124567-a1b2c3'],
+    No: ['договор N 307451928'],
+    ProductType: ['ACCOUNT'],
+    Balance: ['12,34'],
+    ProductTypeName: ['Счёт без карты'],
+    Currency: ['840']
+  }
+
+  it('maps a standalone bank account to a checking account', () => {
+    expect(convertAccount(standaloneAccount)).toEqual({
+      id: '73124567',
+      transactionsAccId: '73129901-a1b2c3-account-2048571-b735-getordering-1',
+      latestTrID: null,
+      type: 'checking',
+      title: 'Счёт без карты 307451928',
+      currencyCode: '840',
+      instrument: 'USD',
+      balance: 12.34,
+      syncID: ['307451928'],
+      productId: '73124567-a1b2c3',
+      productType: 'ACCOUNT'
+    })
+  })
+
+  it('does not expose an account tied to a card', () => {
+    const linkedAccount = {
+      ...standaloneAccount,
+      ProductTypeName: ['Счёт с картой'],
+      LinkedProductType: ['MS'],
+      LinkedProductId: ['73120042-d4e5f6']
+    }
+
+    expect(convertAccount(linkedAccount)).toBeNull()
+    expect(convertLinkedAccountSource(linkedAccount)).toEqual({
+      id: '73120042',
+      transactionsAccId: '73129901-a1b2c3-account-2048571-b735-getordering-1',
+      type: 'card',
+      instrument: 'USD',
+      productId: '73124567-a1b2c3',
+      productType: 'ACCOUNT',
+      latestTrID: null
+    })
   })
 })

--- a/src/plugins/statusbank/__tests__/converters/transactions.test.js
+++ b/src/plugins/statusbank/__tests__/converters/transactions.test.js
@@ -1,4 +1,4 @@
-import { convertTransaction, deduplicateTransactions } from '../../converters'
+import { convertTransaction, deduplicateTransactions, TransactionSource } from '../../converters'
 import { adjustTransactions } from '../../../../common/transactionGroupHandler'
 
 describe('convertTransaction', () => {
@@ -288,6 +288,135 @@ describe('convertTransaction', () => {
     }))
   })
 
+  it('does not group equal card transfers made at different times on the same day', () => {
+    const sourceAccount = { ...account, id: '73120041' }
+    const destinationAccount = { ...account, id: '73120042' }
+    const makeTransfer = (amount, authCode, date, place, type, transferAccount) => convertTransaction({
+      amount,
+      amountReal: amount,
+      authCode,
+      currency: 'USD',
+      currencyReal: 'USD',
+      date,
+      place,
+      type
+    }, transferAccount)
+    const outcome = makeTransfer(-17.25, '731841', '01.02.2035 10:15:00', 'PEREVOD NA 400000******0041', 'Перевод/списание средств', sourceAccount)
+    const incomeAtAnotherTime = makeTransfer(17.25, '731842', '01.02.2035 16:45:00', 'PEREVOD S 400000******0042', 'Перевод/зачисление средств', destinationAccount)
+
+    expect(adjustTransactions({ transactions: [outcome, incomeAtAnotherTime] })).toHaveLength(2)
+  })
+
+  it('merges a standalone-account transfer with the matching hidden card-account movement', () => {
+    const checkingAccount = { ...account, id: '73124567', type: 'checking' }
+    const linkedCardAccount = { ...account, id: '73120042' }
+    const description = 'Перевод денежных средств со счета №BY86IRJS3014ZZ00000012345678.'
+    const accountOutcome = convertTransaction({
+      statementType: 'account',
+      amount: -17.25,
+      amountReal: -17.25,
+      currency: 'USD',
+      currencyReal: 'USD',
+      date: '01.02.2035 10:00:00',
+      reflectedDate: '02.02.2035 12:34:56',
+      description,
+      place: description,
+      type: description,
+      authCode: null,
+      mcc: null
+    }, checkingAccount)
+    const cardIncome = convertTransaction({
+      statementType: 'account',
+      amount: 17.25,
+      amountReal: 17.25,
+      currency: 'USD',
+      currencyReal: 'USD',
+      date: '01.02.2035 10:00:00',
+      reflectedDate: '02.02.2035 12:34:56',
+      description,
+      place: description,
+      type: description,
+      authCode: null,
+      mcc: null
+    }, linkedCardAccount)
+
+    expect(adjustTransactions({ transactions: [accountOutcome, cardIncome] })).toEqual([
+      expect.objectContaining({
+        merchant: null,
+        movements: [
+          expect.objectContaining({ account: { id: checkingAccount.id }, sum: -17.25 }),
+          expect.objectContaining({ account: { id: linkedCardAccount.id }, sum: 17.25 })
+        ]
+      })
+    ])
+  })
+
+  it('does not merge same-day account transfers with different reflected timestamps', () => {
+    const checkingAccount = { ...account, id: '73124567', type: 'checking' }
+    const linkedCardAccount = { ...account, id: '73120042' }
+    const description = 'Перевод денежных средств со счета №BY86IRJS3014ZZ00000012345678.'
+    const makeApiTransaction = (amount, reflectedDate) => ({
+      statementType: 'account',
+      amount,
+      amountReal: amount,
+      currency: 'USD',
+      currencyReal: 'USD',
+      date: '01.02.2035 10:00:00',
+      reflectedDate,
+      description,
+      place: description,
+      type: description,
+      authCode: null,
+      mcc: null
+    })
+    const outcome = convertTransaction(makeApiTransaction(-17.25, '02.02.2035 12:34:56'), checkingAccount)
+    const unrelatedIncome = convertTransaction(makeApiTransaction(17.25, '02.02.2035 12:35:01'), linkedCardAccount)
+
+    expect(adjustTransactions({ transactions: [outcome, unrelatedIncome] })).toHaveLength(2)
+  })
+
+  it('merges both sides of a standalone-account currency exchange', () => {
+    const bynAccount = { ...account, id: '73124567', type: 'checking', instrument: 'BYN' }
+    const usdAccount = { ...account, id: '73124568', type: 'checking', instrument: 'USD' }
+    const description = 'Продажа валюты банком с текущего счета №BY41IRJS3014ZZ00000087654321 с переводом на текущий счет №BY86IRJS3014ZZ00000012345678'
+    const outcome = convertTransaction({
+      statementType: 'account',
+      amount: -42.5,
+      amountReal: -42.5,
+      currency: 'BYN',
+      currencyReal: 'BYN',
+      date: '01.02.2035 11:00:00',
+      description,
+      place: description,
+      type: description,
+      authCode: null,
+      mcc: null
+    }, bynAccount)
+    const income = convertTransaction({
+      statementType: 'account',
+      amount: 13.75,
+      amountReal: 13.75,
+      currency: 'USD',
+      currencyReal: 'USD',
+      date: '01.02.2035 11:00:00',
+      description,
+      place: description,
+      type: description,
+      authCode: null,
+      mcc: null
+    }, usdAccount)
+
+    expect(adjustTransactions({ transactions: [outcome, income] })).toEqual([
+      expect.objectContaining({
+        merchant: null,
+        movements: [
+          expect.objectContaining({ account: { id: bynAccount.id }, sum: -42.5 }),
+          expect.objectContaining({ account: { id: usdAccount.id }, sum: 13.75 })
+        ]
+      })
+    ])
+  })
+
   it('merges statement P2P transfers after deduplication with latest-ops', () => {
     const accountA = { ...account, id: 'aaaaaaaa-aaaaaa' }
     const accountB = { ...account, id: 'bbbbbbbb-bbbbbb' }
@@ -354,7 +483,7 @@ describe('convertTransaction', () => {
     ])
   })
 
-  it('reconciles statement and latest cash withdrawal in the operation currency', () => {
+  it('deduplicates statement and latest cash withdrawal in the operation currency', () => {
     const statement = convertTransaction({
       amount: -60,
       amountReal: -100,
@@ -434,6 +563,27 @@ describe('convertTransaction', () => {
       hold: false
     })
 
+    const makeDedupTransaction = ({
+      source,
+      authCode = null,
+      description = 'Списание согласно реестру карт-чеков №7421'
+    }) => {
+      const isLinkedAccount = source === TransactionSource.cardAccountStatement
+      return convertTransaction({
+        statementType: isLinkedAccount ? 'account' : undefined,
+        amount: -17.25,
+        amountReal: -17.25,
+        authCode,
+        currency: 'USD',
+        currencyReal: 'USD',
+        date: '01.02.2035 10:00:00',
+        reflectedDate: '02.02.2035 12:34:56',
+        description: isLinkedAccount ? description : null,
+        place: isLinkedAccount ? description : 'BY MINSK, MAGAZIN, STATUSBANK',
+        type: isLinkedAccount ? description : 'Оплата'
+      }, account, source)
+    }
+
     it('keeps one rich statement transaction over identical and latest duplicates', () => {
       const statement = makeTransaction()
       const duplicateStatement = makeTransaction()
@@ -461,6 +611,33 @@ describe('convertTransaction', () => {
       const second = makeTransaction({ id: null })
 
       expect(deduplicateTransactions([first, second], [account])).toEqual([first, second])
+    })
+
+    it('deduplicates linked-account rows count-for-count against card sources', () => {
+      const makeCard = authCode => makeDedupTransaction({ source: TransactionSource.cardStatement, authCode })
+      const makeAccount = () => makeDedupTransaction({ source: TransactionSource.cardAccountStatement })
+
+      const transactions = deduplicateTransactions(
+        [makeAccount(), makeCard('731841'), makeAccount(), makeCard('731842'), makeAccount()],
+        [account]
+      )
+
+      expect(transactions).toHaveLength(3)
+      expect(transactions.map(transaction => transaction.movements[0].id)).toEqual([
+        '731841',
+        '731842',
+        null
+      ])
+    })
+
+    it('keeps a same-amount non-register account fee', () => {
+      const cardTransaction = makeDedupTransaction({ source: TransactionSource.cardStatement, authCode: '731843' })
+      const accountFee = makeDedupTransaction({
+        source: TransactionSource.cardAccountStatement,
+        description: 'Взимание комиссии за снятие наличных в АТМ согласно ведомости №3184'
+      })
+
+      expect(deduplicateTransactions([cardTransaction, accountFee], [account])).toHaveLength(2)
     })
   })
 })

--- a/src/plugins/statusbank/api.js
+++ b/src/plugins/statusbank/api.js
@@ -93,22 +93,17 @@ export async function login (login, password) {
 
 export async function fetchAccounts (sid) {
   console.log('>>> Загрузка списка счетов...')
-  const rawResponse = await fetchApi(BASE_URL,
-    '<BS_Request>\r\n' +
-    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
-    '   <GetProducts ProductType="MS" GetActions="Y" GetBalance="Y"/>\r\n' +
-    '   <RequestType>GetProducts</RequestType>\r\n' +
-    '   <Session SID="' + sid + '"/>\r\n' +
-    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-    '   <TerminalId>stbank.ibank</TerminalId>\r\n' +
-    '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'), true)
-  let resp = null
-  xml2js.parseString(rawResponse, { mergeAttrs: true }, (err, result) => {
-    resp = err ? null : result
-  })
+
+  const [cardProducts, accountProducts, productTypes] = await Promise.all([
+    fetchProducts(sid, 'MS'),
+    fetchProducts(sid, 'ACCOUNT'),
+    fetchProductTypes(sid)
+  ])
+  const productTypeProducts = productTypes.flatMap(productType => productType.Product || [])
+  const linkedCardByAccountId = buildLinkedCardByAccountId(productTypeProducts)
   const accounts = []
-  if (resp) {
-    for (const account of resp.BS_Response.GetProducts[0].Product) {
+  if (cardProducts.length > 0) {
+    for (const account of cardProducts) {
       const accountOperationsExecutionId = account.Action.filter((action) => action !== null).filter((action) => action.Type[0] === 'Group$MS$4')[0].Id[0]
       const [statementResp, lastTrxResp] = await Promise.all([
         // To receive transactions as statement for days up to last working day
@@ -143,8 +138,70 @@ export async function fetchAccounts (sid) {
       })
     }
   }
+  for (const account of accountProducts) {
+    const linkedCardId = linkedCardByAccountId.get(account.Id?.[0]) ||
+      (account.LinkedProductType?.[0] === 'MS' ? account.LinkedProductId?.[0] : null)
+    const statementAction = account.Action
+      ?.filter(action => action !== null)
+      .find(action => action.Type?.[0] === 'B735:GetOrdering')
+    accounts.push({
+      ...account,
+      LinkedProductId: linkedCardId ? [linkedCardId] : account.LinkedProductId,
+      LinkedProductType: linkedCardId ? ['MS'] : account.LinkedProductType,
+      statementExecutionId: statementAction?.Id?.[0] || null,
+      lastTrxExecutionId: null
+    })
+  }
   console.log(`>>> Загружено ${accounts.length} счетов.`)
   return accounts
+}
+
+async function fetchProducts (sid, productType) {
+  const rawResponse = await fetchApi(BASE_URL,
+    '<BS_Request>\r\n' +
+    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    '   <GetProducts ProductType="' + productType + '" GetActions="Y" GetBalance="Y"/>\r\n' +
+    '   <RequestType>GetProducts</RequestType>\r\n' +
+    '   <Session SID="' + sid + '"/>\r\n' +
+    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+    '   <TerminalId>stbank.ibank</TerminalId>\r\n' +
+    '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'), true)
+  const response = await xml2js.parseStringPromise(rawResponse, { mergeAttrs: true })
+  return response?.BS_Response?.GetProducts?.[0]?.Product || []
+}
+
+async function fetchProductTypes (sid) {
+  const rawResponse = await fetchApi(BASE_URL,
+    '<BS_Request>\r\n' +
+    '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n' +
+    '   <GetProductTypes GetProducts="Y" GetActions="N" GetBalance="N"/>\r\n' +
+    '   <RequestType>GetProductTypes</RequestType>\r\n' +
+    '   <Session SID="' + sid + '"/>\r\n' +
+    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+    '   <TerminalId>stbank.ibank</TerminalId>\r\n' +
+    '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'), true)
+  const response = await xml2js.parseStringPromise(rawResponse, { mergeAttrs: true })
+  return response?.BS_Response?.GetProductTypes?.[0]?.ProductType || []
+}
+
+function buildLinkedCardByAccountId (products) {
+  const linkedCardByAccountId = new Map()
+  for (const product of products) {
+    if (product.ProductType?.[0] === 'ACCOUNT' && product.LinkedProductType?.[0] === 'MS') {
+      const accountId = product.Id?.[0]
+      const cardId = product.LinkedProductId?.[0]
+      if (accountId && cardId) {
+        linkedCardByAccountId.set(accountId, cardId)
+      }
+    } else if (product.ProductType?.[0] === 'MS' && product.LinkedProductType?.[0] === 'ACCOUNT') {
+      const accountId = product.LinkedProductId?.[0]
+      const cardId = product.Id?.[0]
+      if (accountId && cardId) {
+        linkedCardByAccountId.set(accountId, cardId)
+      }
+    }
+  }
+  return linkedCardByAccountId
 }
 
 export function createDateIntervals (fromDate, toDate) {
@@ -246,13 +303,20 @@ export function parseTransactions (htmls) {
   return transactions
 }
 
+export function parseAccountTransactions (htmls) {
+  const transactions = flatMap(htmls, html => parseAccountTransactionsHtml(html))
+  console.log(`>>> Загружено ${transactions.length} операций.`)
+  return transactions
+}
+
 export function parseFullTransactionsHtml (html) {
   const $ = cheerio.load(html)
   const tdObjects = $('div[class="head"]').toArray()
   if (tdObjects.length < 2) {
     return []
   }
-  const card = tdObjects[0].children[3].children[0].data.split(' ')[1]
+  const productNumber = $(tdObjects[0]).text().match(/(?:\d{4,}\*+\d{4}|\d{8,})/)
+  const card = productNumber ? productNumber[0] : null
   let counter = 0
   let i = 0
   const data = []
@@ -312,6 +376,35 @@ export function parseFullTransactionsHtml (html) {
     }
   })
   return data
+}
+
+export function parseAccountTransactionsHtml (html) {
+  const $ = cheerio.load(html)
+  return $('table[class="table-schet"] tbody tr').toArray().map(row => {
+    const cells = $(row).find('td').toArray().map(cell => $(cell).text().replace(/\s+/g, ' ').trim())
+    if (cells.length < 6) {
+      return null
+    }
+    const amount = Number.parseFloat(cells[4].replace(/\s/g, '').replace(',', '.'))
+    if (!cells[1] || !cells[2] || !cells[3] || isNaN(amount)) {
+      return null
+    }
+    return {
+      cardNum: null,
+      date: cells[1],
+      reflectedDate: cells[0],
+      description: cells[2],
+      type: cells[2],
+      amountReal: amount,
+      currencyReal: cells[3],
+      amount,
+      currency: cells[3],
+      place: cells[2],
+      authCode: null,
+      mcc: null,
+      statementType: 'account'
+    }
+  }).filter(Boolean)
 }
 
 // Экспорт последних операций по карточке

--- a/src/plugins/statusbank/converters.js
+++ b/src/plugins/statusbank/converters.js
@@ -1,11 +1,23 @@
 import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
 
+/** @enum {string} */
+export const TransactionSource = Object.freeze({
+  cardStatement: 'card-statement',
+  cardAccountStatement: 'card-account-statement',
+  currentAccountStatement: 'current-account-statement',
+  latestOperations: 'latest-operations'
+})
+
 export function convertAccount (ob) {
-  if (ob.Enabled && ob.Enabled[0] === 'N') {
+  const productType = ob.ProductType[0]
+  if (productType === 'MS' && ob.Enabled && ob.Enabled[0] === 'N') {
     return null
   }
   const id = ob.Id[0].split('-')[0]
-  if (!ZenMoney.isAccountSkipped(id)) {
+  if (ZenMoney.isAccountSkipped(id)) {
+    return null
+  }
+  if (productType === 'MS') {
     return {
       id,
       transactionsAccId: ob.statementExecutionId,
@@ -18,14 +30,49 @@ export function convertAccount (ob) {
       syncID: [ob.No[0].slice(-4)],
       productId: ob.Id[0],
       productType: ob.ProductType[0],
-      accountID: Number(ob.BankId[0].split('-')[-1]),
       latestTrID: ob.lastTrxExecutionId
+    }
+  }
+  if (productType === 'ACCOUNT' && ob.ProductTypeName[0] === 'Счёт без карты') {
+    const accountNumber = ob.No[0].replace(/^договор N\s*/i, '')
+    return {
+      id,
+      transactionsAccId: ob.statementExecutionId,
+      type: 'checking',
+      title: (ob.CustomName?.[0] || ob.ProductTypeName[0]) + ' ' + accountNumber,
+      currencyCode: ob.Currency[0],
+      instrument: codeToCurrencyLookup[ob.Currency[0]],
+      balance: Number.parseFloat((ob.Balance[0].replace(/,/g, '.') || 0.0)),
+      syncID: [accountNumber],
+      productId: ob.Id[0],
+      productType: ob.ProductType[0],
+      latestTrID: null
     }
   }
   return null
 }
 
-export function convertTransaction (apiTransaction, account) {
+export function convertLinkedAccountSource (ob) {
+  if (ob.ProductType?.[0] !== 'ACCOUNT' ||
+    ob.ProductTypeName?.[0] !== 'Счёт с картой' ||
+    ob.LinkedProductType?.[0] !== 'MS' ||
+    !ob.LinkedProductId?.[0] ||
+    !ob.statementExecutionId) {
+    return null
+  }
+
+  return {
+    id: ob.LinkedProductId[0].split('-')[0],
+    transactionsAccId: ob.statementExecutionId,
+    type: 'card',
+    instrument: codeToCurrencyLookup[ob.Currency[0]],
+    productId: ob.Id[0],
+    productType: ob.ProductType[0],
+    latestTrID: null
+  }
+}
+
+export function convertTransaction (apiTransaction, account, source = null) {
   if ((apiTransaction.amount && apiTransaction.amount !== 0) || (apiTransaction.amountReal && apiTransaction.amountReal !== 0)) {
     const transaction = {
       date: getDate(apiTransaction.date),
@@ -33,10 +80,18 @@ export function convertTransaction (apiTransaction, account) {
       merchant: null,
       comment: null,
       hold: false
-    };
+    }
+
+    if (source) {
+      transaction._statusbank = {
+        source,
+        dedupKey: getLinkedAccountDedupKey(apiTransaction, account, source)
+      }
+    }
 
     [
       parseCash,
+      parseCurrencyExchange,
       parseInternalTransfer,
       parsePayee
     ].some(parser => parser(transaction, apiTransaction))
@@ -72,10 +127,38 @@ export function deduplicateTransactions (transactions, accounts) {
     }
   }
 
+  const cardCounts = new Map()
+  for (const transaction of result) {
+    const metadata = transaction._statusbank
+    if (![TransactionSource.cardStatement, TransactionSource.latestOperations].includes(metadata?.source) || !metadata?.dedupKey) {
+      continue
+    }
+    cardCounts.set(
+      metadata.dedupKey,
+      (cardCounts.get(metadata.dedupKey) || 0) + 1
+    )
+  }
+
+  const deduplicated = []
+  for (const transaction of result) {
+    const metadata = transaction._statusbank
+    const cardCount = metadata?.dedupKey
+      ? cardCounts.get(metadata.dedupKey) || 0
+      : 0
+    if (metadata?.source === TransactionSource.cardAccountStatement && cardCount > 0) {
+      cardCounts.set(metadata.dedupKey, cardCount - 1)
+      duplicateCount++
+      continue
+    }
+    const cleanedTransaction = { ...transaction }
+    delete cleanedTransaction._statusbank
+    deduplicated.push(cleanedTransaction)
+  }
+
   if (duplicateCount > 0) {
     console.log(`>>> Удалено ${duplicateCount} дубликатов операций.`)
   }
-  return result
+  return deduplicated
 }
 
 function getDeduplicationKey (transaction, accountInstruments) {
@@ -104,6 +187,24 @@ function getTransactionRichness (transaction) {
   return (movement.sum !== null ? 4 : 0) +
     (transaction.merchant?.mcc != null ? 2 : 0) +
     (transaction.merchant?.fullTitle || transaction.merchant?.title ? 1 : 0)
+}
+
+function getLinkedAccountDedupKey (apiTransaction, account, source) {
+  const isCardSource = [TransactionSource.cardStatement, TransactionSource.latestOperations].includes(source)
+  const isCardAccountRow = source === TransactionSource.cardAccountStatement &&
+    /^(Списание|Зачисление) согласно реестру карт-чеков №/.test(apiTransaction.description || '')
+  if (!isCardSource && !isCardAccountRow) {
+    return null
+  }
+  if (typeof apiTransaction.amount !== 'number' || !apiTransaction.currency) {
+    return null
+  }
+  return [
+    account.id,
+    getDate(apiTransaction.date).toISOString(),
+    apiTransaction.amount,
+    apiTransaction.currency
+  ].join('|')
 }
 
 function getMovement (apiTransaction, account) {
@@ -166,8 +267,23 @@ function parseInternalTransfer (transaction, apiTransaction) {
   const isStatementP2P = ['Перевод/зачисление средств', 'Перевод/списание средств'].includes(apiTransaction.type) &&
     (apiTransaction.place?.startsWith('PEREVOD NA ') || apiTransaction.place?.startsWith('PEREVOD S '))
 
-  if (!isLatestOpsP2P && !isStatementP2P) {
+  const isAccountTransfer = apiTransaction.statementType === 'account' &&
+    apiTransaction.description?.startsWith('Перевод денежных средств со счета')
+
+  if (!isLatestOpsP2P && !isStatementP2P && !isAccountTransfer) {
     return false
+  }
+
+  if (isAccountTransfer) {
+    const sourceAccount = apiTransaction.description.match(/№\s*([^\s.]+)/i)?.[1] || ''
+    transaction.groupKeys = [[
+      'statusbank-account-transfer',
+      apiTransaction.reflectedDate || apiTransaction.date,
+      Math.abs(apiTransaction.amount || apiTransaction.amountReal),
+      apiTransaction.currency || apiTransaction.currencyReal,
+      sourceAccount
+    ].join('|')]
+    return true
   }
 
   transaction.groupKeys = [[
@@ -175,6 +291,20 @@ function parseInternalTransfer (transaction, apiTransaction) {
     apiTransaction.date,
     Math.abs(apiTransaction.amount || apiTransaction.amountReal),
     apiTransaction.currency || apiTransaction.currencyReal
+  ].join('|')]
+  return true
+}
+
+function parseCurrencyExchange (transaction, apiTransaction) {
+  if (apiTransaction.statementType !== 'account' ||
+    !apiTransaction.description?.startsWith('Продажа валюты банком с текущего счета')) {
+    return false
+  }
+
+  transaction.groupKeys = [[
+    'statusbank-fx',
+    apiTransaction.date,
+    apiTransaction.description.replace(/\s+/g, ' ').trim()
   ].join('|')]
   return true
 }

--- a/src/plugins/statusbank/index.js
+++ b/src/plugins/statusbank/index.js
@@ -2,18 +2,19 @@ import {
   fetchAccounts,
   fetchFullTransactions,
   login,
+  parseAccountTransactions,
   parseTransactions,
   fetchLatestOperations,
   parseLatestOperations
 } from './api'
-import { convertAccount, convertTransaction, deduplicateTransactions } from './converters'
+import { convertAccount, convertLinkedAccountSource, convertTransaction, deduplicateTransactions, TransactionSource } from './converters'
 import { adjustTransactions } from '../../common/transactionGroupHandler'
 
 export async function scrape ({ preferences, fromDate, toDate }) {
   toDate = toDate || new Date()
   const token = await login(preferences.login, preferences.password)
 
-  let accounts = await allAccounts(token)
+  const { accounts, sources } = await loadAccountsAndSources(token)
   if (accounts.length === 0) {
     // если активация первый раз, но карточки все еще не выпущены
     return {
@@ -22,43 +23,67 @@ export async function scrape ({ preferences, fromDate, toDate }) {
     }
   }
 
-  const transactionsStatement = []
-  accounts = await Promise.all(accounts.map(async account => {
-    if (account.transactionsAccId) {
-      const htmls = await fetchFullTransactions(token, account, fromDate, toDate)
-      const transactions = parseTransactions(htmls)
-      for (const apiTransaction of transactions) {
-        const transaction = convertTransaction(apiTransaction, account)
-        if (transaction) {
-          transactionsStatement.push(transaction)
-        }
-      }
-    }
-    if (account.latestTrID) {
-      const html = await fetchLatestOperations(token, account)
-      if (html) {
-        const transactions = parseLatestOperations(html, fromDate)
-        for (const apiTransaction of transactions) {
-          const transaction = convertTransaction(apiTransaction, account)
-          if (transaction) {
-            transactionsStatement.push(transaction)
-          }
-        }
-      }
-    }
-    return account
-  }))
+  const transactionsBySource = await Promise.all(
+    sources.map(source => loadTransactions(token, source, fromDate, toDate))
+  )
   return {
     accounts,
     transactions: adjustTransactions({
-      transactions: deduplicateTransactions(transactionsStatement, accounts)
+      transactions: deduplicateTransactions(transactionsBySource.flat(), accounts)
     })
   }
 }
 
-async function allAccounts (token) {
-  const accounts = (await fetchAccounts(token))
+async function loadTransactions (token, source, fromDate, toDate) {
+  const { account, type } = source
+  let transactions
+  if (type === TransactionSource.latestOperations) {
+    const html = await fetchLatestOperations(token, account)
+    transactions = html ? parseLatestOperations(html, fromDate) : []
+  } else {
+    const htmls = await fetchFullTransactions(token, account, fromDate, toDate)
+    transactions = type === TransactionSource.cardStatement
+      ? parseTransactions(htmls)
+      : parseAccountTransactions(htmls)
+  }
+  return transactions
+    .map(transaction => convertTransaction(transaction, account, type))
+    .filter(Boolean)
+}
+
+async function loadAccountsAndSources (token) {
+  const products = await fetchAccounts(token)
+  const accounts = products
     .map(convertAccount)
     .filter(account => account !== null)
-  return accounts
+  const visibleAccountIds = new Set(accounts.map(account => account.id))
+  const linkedAccounts = products
+    .map(convertLinkedAccountSource)
+    .filter(account => account !== null && visibleAccountIds.has(account.id))
+
+  const sources = accounts.flatMap(account => {
+    const accountSources = []
+    if (account.transactionsAccId) {
+      accountSources.push({
+        account,
+        type: account.productType === 'ACCOUNT'
+          ? TransactionSource.currentAccountStatement
+          : TransactionSource.cardStatement
+      })
+    }
+    if (account.latestTrID) {
+      accountSources.push({ account, type: TransactionSource.latestOperations })
+    }
+    return accountSources
+  })
+
+  sources.push(...linkedAccounts.map(account => ({
+    account,
+    type: TransactionSource.cardAccountStatement
+  })))
+
+  return {
+    accounts,
+    sources
+  }
 }


### PR DESCRIPTION
Expose accounts without cards as checking accounts and load their statements.

Load account statements for both standalone accounts and accounts linked to cards. Reconcile linked-account rows with the existing card transaction sources so card activity is not duplicated, while preserving account-only operations such as ATM withdrawal fees.

Use account statement legs to detect internal transfers between cards and accounts and currency exchanges between accounts.