### PR TITLE
fix(bgpb): restore DailyFin device OTP sync

### DIFF
--- a/src/plugins/bgpb/ZenmoneyManifest.xml
+++ b/src/plugins/bgpb/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bgpb</id>
     <version>1.0</version>
-    <build>2</build>
+    <build>3</build>
     <company>15372</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bgpb/__tests__/api.test.js
+++ b/src/plugins/bgpb/__tests__/api.test.js
@@ -1,12 +1,16 @@
 import { parseXml } from '../../../common/xmlUtils'
 import {
+  activateDeviceToken,
   createDateIntervals,
   fetchBalance,
   fetchFullTransactions,
   fetchLastTransactions,
   login,
+  loginDeviceToken,
+  logoff,
   parseFullTransactionsMail,
-  parseFullTransactionsMailCardLimit
+  parseFullTransactionsMailCardLimit,
+  registerDeviceToken
 } from '../api'
 
 function makeNetworkResponse (body, url = 'https://mobapp-frontend.bgpb.by/test') {
@@ -43,6 +47,10 @@ describe('request logging', () => {
       .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Balance Amount="1,00"/></BS_Response>'))
 
     await expect(login('login-value', 'password-value')).resolves.toBe('response-secret-sid')
+    const loginRequest = global.fetch.mock.calls[0][1]
+    expect(loginRequest.headers['User-Agent']).toBe('BGPB mobile/1.6.2 (Android; unknownAndroidSDKbuiltforx86; Android 11)')
+    expect(loginRequest.body).toContain('<Parameter Id="AppVersion">1.6.2</Parameter>')
+    expect(loginRequest.body).toContain('<TerminalId Version="1.6.2">41742962</TerminalId>')
     await expect(fetchBalance('request-secret-sid', {
       productType: 'MS',
       cardNumber: '518597******1111',
@@ -79,20 +87,68 @@ describe('request logging', () => {
 
     expect(stringifyDebugCalls(debug)).not.toContain('json-secret-sid')
   })
+
+  it('sanitizes device registration and activation secrets', async () => {
+    const xfad = 'xfad-secret'.padEnd(300, 'A')
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse(`<BS_Response><Registration><Id>123</Id><xfad>${xfad}</xfad><ActivationPwd>code-secret</ActivationPwd></Registration></BS_Response>`))
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Activation/></BS_Response>'))
+
+    await expect(registerDeviceToken('registration-secret-sid', {
+      registrationModel: 'Test Device',
+      registrationDeviceId: 'test-device-id'
+    }, 'nonce-value')).resolves.toEqual({
+      deviceNo: '123',
+      xfad,
+      activationPassword: 'code-secret'
+    })
+    await expect(activateDeviceToken('activation-secret-sid', '123', 'derivation-secret')).resolves.toBeUndefined()
+
+    const logs = stringifyDebugCalls(debug)
+    expect(logs).not.toContain('registration-secret-sid')
+    expect(logs).not.toContain('activation-secret-sid')
+    expect(logs).not.toContain('xfad-secret')
+    expect(logs).not.toContain('code-secret')
+    expect(logs).not.toContain('derivation-secret')
+  })
+
+  it('opens and closes a DailyFin device-token session', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Login SID="device-secret-sid"/></BS_Response>'))
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Logoff/></BS_Response>'))
+
+    await expect(loginDeviceToken('123456', '654321')).resolves.toBe('device-secret-sid')
+    await expect(logoff('device-secret-sid')).resolves.toBeUndefined()
+
+    const loginRequest = global.fetch.mock.calls[0][1].body
+    expect(loginRequest).toContain('Type="BS_TOKEN_EMBEDDED"')
+    expect(loginRequest).toContain('<Parameter Id="DeviceNo">123456</Parameter>')
+    expect(loginRequest).toContain('<Parameter Id="Password">654321</Parameter>')
+
+    const logs = stringifyDebugCalls(debug)
+    expect(logs).not.toContain('654321')
+    expect(logs).not.toContain('device-secret-sid')
+  })
 })
 
 describe('fetchFullTransactions', () => {
-  it('skips high-security statement requests', async () => {
-    const log = jest.spyOn(console, 'log').mockImplementation(() => {})
+  it('uses DailyFin device authorization parameters for a protected action', async () => {
     global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><ExecuteAction><MailId>mail-1</MailId></ExecuteAction></BS_Response>'))
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><MailAttachment><Attachment><Body>statement</Body></Attachment></MailAttachment></BS_Response>'))
 
-    await expect(fetchFullTransactions('sid', {
-      title: 'Card*1111',
+    await expect(fetchFullTransactions('statement-secret-sid', {
+      title: 'Deposit',
       transactionsAccId: 'statement-action'
-    }, new Date('2026-05-01T00:00:00+0300'), new Date('2026-05-21T00:00:00+0300'))).resolves.toEqual([])
+    }, new Date('2026-05-01T00:00:00+0300'), new Date('2026-05-21T00:00:00+0300'), () => ({
+      deviceNo: '123456',
+      otp: '654321'
+    }))).resolves.toHaveLength(1)
 
-    expect(global.fetch).not.toHaveBeenCalled()
-    log.mockRestore()
+    const statementRequest = global.fetch.mock.calls[0][1].body
+    expect(statementRequest).toContain('<Session IpAddress="10.0.2.15" Prolong="Y" SID="statement-secret-sid">')
+    expect(statementRequest).toContain('<Parameter Id="DeviceNo">123456</Parameter>')
+    expect(statementRequest).toContain('<Parameter Id="Password">654321</Parameter>')
   })
 })
 

--- a/src/plugins/bgpb/__tests__/api.test.js
+++ b/src/plugins/bgpb/__tests__/api.test.js
@@ -1,4 +1,5 @@
 import { parseXml } from '../../../common/xmlUtils'
+import { InvalidLoginOrPasswordError, InvalidPreferencesError } from '../../../errors'
 import {
   activateDeviceToken,
   createDateIntervals,
@@ -128,6 +129,24 @@ describe('request logging', () => {
     const logs = stringifyDebugCalls(debug)
     expect(logs).not.toContain('654321')
     expect(logs).not.toContain('device-secret-sid')
+  })
+
+  it('maps bank password rejections to the login error shown by production UI', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Error><ErrorLine>Ошибка проверки пароля</ErrorLine></Error></BS_Response>'))
+
+    const error = await login('login-value', 'password-value').catch(error => error)
+    expect(error).toBeInstanceOf(InvalidLoginOrPasswordError)
+    expect(error.message).toBe('Неверный логин или пароль')
+  })
+
+  it('maps bank device-token rejections to the saved-token preferences error', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce(makeNetworkResponse('<BS_Response><Error><ErrorLine>Ошибка проверки пароля</ErrorLine></Error></BS_Response>'))
+
+    const error = await loginDeviceToken('123456', '654321').catch(error => error)
+    expect(error).toBeInstanceOf(InvalidPreferencesError)
+    expect(error.message).toBe('Банк отклонил PIN-токен BGPB')
   })
 })
 

--- a/src/plugins/bgpb/__tests__/converters/helpers.test.js
+++ b/src/plugins/bgpb/__tests__/converters/helpers.test.js
@@ -1,4 +1,4 @@
-import { transactionsUnique } from '../../converters'
+import { mergeStatementAndLastTransactions, transactionsUnique } from '../../converters'
 
 describe('transactionsUnique', () => {
   it('should return one element', () => {
@@ -88,5 +88,46 @@ describe('transactionsUnique', () => {
         ]
       }
     ])
+  })
+})
+
+describe('mergeStatementAndLastTransactions', () => {
+  function transaction ({ id, date, sum, comment, hold = false }) {
+    return {
+      comment,
+      date: new Date(date),
+      hold,
+      merchant: null,
+      movements: [{
+        account: { id: 'card-account' },
+        fee: 0,
+        id,
+        invoice: null,
+        sum
+      }]
+    }
+  }
+
+  it('removes cross-source copies one-to-one while preserving repeated transfers', () => {
+    const statements = [
+      transaction({ id: 'statement-1', date: '2026-05-15T10:55:00+03:00', sum: -250, comment: 'PEREVOD (SPISANIE)' }),
+      transaction({ id: 'statement-2', date: '2026-05-15T11:05:00+03:00', sum: -250, comment: 'PEREVOD (SPISANIE)' }),
+      transaction({ id: 'statement-3', date: '2026-05-15T12:00:00+03:00', sum: 500, comment: 'ZACHISLENIE NA KARTU' })
+    ]
+    const history = [
+      transaction({ id: 'history-1', date: '2026-05-15T10:55:51+03:00', sum: -250, comment: 'Перевод средств (списание, на др.банки)' }),
+      transaction({ id: 'history-2', date: '2026-05-15T11:05:42+03:00', sum: -250, comment: 'Перевод средств (списание, на др.банки)' }),
+      transaction({ id: 'history-3', date: '2026-05-15T12:00:17+03:00', sum: 500, comment: 'Перевод средств (пополнение)' })
+    ]
+
+    expect(mergeStatementAndLastTransactions(statements, history)).toEqual(statements)
+  })
+
+  it('keeps pending and semantically different recent operations', () => {
+    const statement = transaction({ id: 'statement', date: '2026-05-29T09:00:00+03:00', sum: -100, comment: 'PEREVOD (SPISANIE)' })
+    const pending = transaction({ id: 'pending', date: '2026-05-29T09:00:30+03:00', sum: -100, comment: 'Перевод средств', hold: true })
+    const purchase = transaction({ id: 'purchase', date: '2026-05-29T09:00:45+03:00', sum: -100, comment: 'Оплата покупки' })
+
+    expect(mergeStatementAndLastTransactions([statement], [pending, purchase])).toEqual([statement, pending, purchase])
   })
 })

--- a/src/plugins/bgpb/__tests__/deviceOtp.test.js
+++ b/src/plugins/bgpb/__tests__/deviceOtp.test.js
@@ -1,0 +1,129 @@
+import { createCipheriv, createHash, createHmac } from 'crypto'
+import {
+  buildActivationDescriptor,
+  createDeviceState,
+  generateDeviceOtp,
+  openDeviceState,
+  sealDeviceState
+} from '../deviceOtp'
+
+const NOW = new Date('2026-07-28T12:34:56.000Z').getTime()
+const PIN = '582041'
+const ACTIVATION_PASSWORD = 'A1B2C3D4'
+const NONCE = '1785234896000'
+const SERIAL = '0123456789'
+const IDENTITY = {
+  registrationDeviceId: '0123456789abcdef_android_prod__revamp',
+  registrationModel: 'Unknown Android SDK built for x86 (0123456789abcdef_android_prod__revamp)',
+  dpassDeviceId: '00112233445566778899aabbccddeeff',
+  manufacturer: 'unknown',
+  model: 'Android SDK built for x86'
+}
+const OTP_KEY_1 = Buffer.from(Array.from({ length: 20 }, (_value, index) => index + 1))
+const OTP_KEY_2 = Buffer.from(Array.from({ length: 20 }, (_value, index) => index + 21))
+
+function sha (algorithm, value) {
+  return createHash(algorithm).update(value).digest()
+}
+
+function androidBase64Default (value) {
+  return (value.toString('base64').match(/.{1,76}/g) || []).join('\n') + '\n'
+}
+
+function fingerprintSuffix () {
+  const fingerprintSource = IDENTITY.dpassDeviceId + IDENTITY.manufacturer + IDENTITY.model + PIN
+  const fingerprint = androidBase64Default(sha('sha512', fingerprintSource))
+  return sha('sha256', fingerprint).toString('hex').toUpperCase().slice(0, 20)
+}
+
+function hotp (secret, counter) {
+  const counterBuffer = Buffer.alloc(8)
+  counterBuffer.writeUInt32BE(Math.floor(counter / 0x100000000), 0)
+  counterBuffer.writeUInt32BE(counter >>> 0, 4)
+  const digest = createHmac('sha1', secret).update(counterBuffer).digest()
+  const offset = digest[digest.length - 1] & 0x0f
+  const binary = digest.readUInt32BE(offset) & 0x7fffffff
+  return String(binary % 1000000).padStart(6, '0')
+}
+
+function makeXfad () {
+  const plaintext = Buffer.alloc(88)
+  plaintext[0] = '2'.charCodeAt(0)
+  plaintext.write('OTP_APP_1', 1, 'ascii')
+  OTP_KEY_1.copy(plaintext, 14)
+  plaintext.write('OTP_APP_2', 34, 'ascii')
+  OTP_KEY_2.copy(plaintext, 47)
+
+  const iv = Buffer.from('1020304050607080', 'hex')
+  const activationHash = sha('sha1', ACTIVATION_PASSWORD).subarray(0, 8)
+  const nonceHash = sha('sha1', NONCE + SERIAL.slice(3)).subarray(8, 16)
+  const key = Buffer.concat([activationHash, nonceHash, activationHash])
+  const cipher = createCipheriv('des-ede3-cbc', key, iv)
+  cipher.setAutoPadding(false)
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]).toString('hex').toUpperCase()
+
+  const header = Array(138).fill('0')
+  '0100'.split('').forEach((value, index) => { header[index] = value })
+  iv.toString('hex').toUpperCase().split('').forEach((value, index) => { header[50 + index] = value })
+  SERIAL.split('').forEach((value, index) => { header[128 + index] = value })
+  return header.join('') + encrypted
+}
+
+describe('BGPB device OTP', () => {
+  it('derives activation and runtime OTP values compatible with DailyFin', () => {
+    const descriptor = buildActivationDescriptor({
+      xfad: makeXfad(),
+      activationPassword: ACTIVATION_PASSWORD,
+      nonce: NONCE,
+      pin: PIN,
+      identity: IDENTITY,
+      now: NOW
+    })
+    const counter = Math.floor(NOW / 1000 / 30)
+    const suffix = fingerprintSuffix()
+
+    expect(descriptor).toEqual({
+      otpKey: OTP_KEY_1.toString('hex'),
+      derivationOtp: hotp(OTP_KEY_1, counter) + suffix,
+      derivationOtp2: hotp(OTP_KEY_2, counter) + suffix
+    })
+
+    const state = createDeviceState({
+      login: 'User.Login',
+      deviceNo: '123456',
+      otpKey: descriptor.otpKey,
+      identity: IDENTITY
+    })
+    expect(generateDeviceOtp(state, PIN, NOW)).toBe(
+      hotp(Buffer.concat([OTP_KEY_1, Buffer.from(suffix, 'ascii')]), counter)
+    )
+  })
+
+  it('encrypts, authenticates and restores persisted token state', () => {
+    const state = createDeviceState({
+      login: 'user',
+      deviceNo: '123456',
+      otpKey: OTP_KEY_1.toString('hex'),
+      identity: IDENTITY
+    })
+    const envelope = sealDeviceState(state, PIN, {
+      saltHex: '00112233445566778899aabbccddeeff',
+      ivHex: 'ffeeddccbbaa99887766554433221100'
+    })
+
+    expect(envelope.ciphertext).not.toContain(state.otpKey)
+    expect(openDeviceState(envelope, PIN)).toEqual(state)
+    expect(() => openDeviceState(envelope, '401582')).toThrow('PIN токена BGPB не подходит')
+  })
+
+  it('rejects malformed or weak PIN values before using token material', () => {
+    expect(() => buildActivationDescriptor({
+      xfad: makeXfad(),
+      activationPassword: ACTIVATION_PASSWORD,
+      nonce: NONCE,
+      pin: '123456',
+      identity: IDENTITY,
+      now: NOW
+    })).toThrow('менее простой PIN')
+  })
+})

--- a/src/plugins/bgpb/__tests__/index.test.js
+++ b/src/plugins/bgpb/__tests__/index.test.js
@@ -1,0 +1,27 @@
+import { shouldFetchFullStatement } from '../index'
+
+describe('statement source selection', () => {
+  it('uses protected mailbox statements for complete deposit and card history', () => {
+    expect(shouldFetchFullStatement({
+      type: 'deposit',
+      transactionsAccId: 'deposit-statement'
+    }, true)).toBe(true)
+
+    expect(shouldFetchFullStatement({
+      type: 'card',
+      transactionsAccId: 'card-statement'
+    }, true)).toBe(true)
+  })
+
+  it('does not request a statement without device authorization or an action id', () => {
+    expect(shouldFetchFullStatement({
+      type: 'deposit',
+      transactionsAccId: 'deposit-statement'
+    }, false)).toBe(false)
+
+    expect(shouldFetchFullStatement({
+      type: 'deposit',
+      transactionsAccId: null
+    }, true)).toBe(false)
+  })
+})

--- a/src/plugins/bgpb/api.js
+++ b/src/plugins/bgpb/api.js
@@ -5,6 +5,7 @@ import { fetch, fetchJson } from '../../common/network'
 import { sanitize } from '../../common/sanitize'
 import { generateRandomString } from '../../common/utils'
 import { parseXml } from '../../common/xmlUtils'
+import { BankMessageError, InvalidLoginOrPasswordError, InvalidPreferencesError, TemporaryError } from '../../errors'
 
 const BASE_URL = 'https://mobapp-frontend.bgpb.by/'
 const TERMINAL_ID = 41742962
@@ -134,7 +135,7 @@ async function fetchMailAttachment (sid, mailId) {
     message => new InvalidPreferencesError(message))
 }
 
-async function fetchApi (url, xml, options, predicate = () => true, error = (message) => console.assert(false, message)) {
+async function fetchApi (url, xml, options, predicate = () => true, errorFactory = message => new BankMessageError(message)) {
   const boundary = generateBoundary()
   const boundaryStart = '--' + boundary + '\r\n'
   const boundaryLast = '--' + boundary + '--\r\n'
@@ -155,7 +156,7 @@ async function fetchApi (url, xml, options, predicate = () => true, error = (mes
 
   const response = await fetch(BASE_URL + url, options)
   if (predicate) {
-    validateResponse(response, response => predicate(response), error)
+    validateResponse(response, response => predicate(response), errorFactory)
   }
   const res = parseXml(response.body)
 
@@ -169,8 +170,7 @@ async function fetchApi (url, xml, options, predicate = () => true, error = (mes
     }
     const errorDescription = res.BS_Response.Error.ErrorLine
     const errorMessage = 'Ответ банка: ' + errorDescription
-    if (errorDescription.indexOf('Неверный логин') >= 0) { throw new InvalidPreferencesError(errorMessage) }
-    throw new Error(errorMessage)
+    throw errorFactory(errorMessage)
   }
   return res
 }
@@ -430,7 +430,7 @@ export async function login (login, password) {
     '   <RequestType>Login</RequestType>\r\n' +
     buildTerminalInfoXml() +
     '   <Subsystem>ClientAuth</Subsystem>\r\n' +
-    '</BS_Request>\r\n', { sanitizeRequestLog: { body: true } }, response => true, message => new InvalidPreferencesError('Неверный логин или пароль'))
+    '</BS_Request>\r\n', { sanitizeRequestLog: { body: true } }, response => true, message => new InvalidLoginOrPasswordError('Неверный логин или пароль'))
   if (res.BS_Response.Login && res.BS_Response.Login.SID) {
     return res.BS_Response.Login.SID
   }

--- a/src/plugins/bgpb/api.js
+++ b/src/plugins/bgpb/api.js
@@ -8,14 +8,13 @@ import { parseXml } from '../../common/xmlUtils'
 
 const BASE_URL = 'https://mobapp-frontend.bgpb.by/'
 const TERMINAL_ID = 41742962
-const APP_VERSION = '1.5.0'
+const APP_VERSION = '1.6.2'
 const DEVICE_PLATFORM = 'Android 11'
 const PUSH_HISTORY_ENDPOINT = `push-history/api/android_${APP_VERSION}/v2/getHistory`
 const HISTORY_BASE_PATH = 'history/client/2/1/'
 const HISTORY_CONFIG_ENDPOINT = `${HISTORY_BASE_PATH}getConfig`
 const HISTORY_EXT_OPERATIONS_ENDPOINT = `${HISTORY_BASE_PATH}ext-operations`
 const EXTRA_AUTH_REQUIRED_ERROR = 'Для выполнения действия требуется дополнительная аутентификация'
-const FULL_STATEMENT_REQUESTS_ENABLED = false
 
 const SOU_ADMIN_ENDPOINT = 'sou2/xml_online.admin'
 const SOU_REQUEST_ENDPOINT = 'sou2/xml_online.request'
@@ -45,15 +44,34 @@ function buildTerminalInfoXml () {
     '   <TerminalTime>' + terminalTime() + '</TerminalTime>\r\n'
 }
 
-function buildSessionXml (sid) {
-  return '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + sid + '"/>\r\n'
+function escapeXmlValue (value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function buildSessionXml (sid, deviceAuthorization = null) {
+  if (!deviceAuthorization) {
+    return '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + escapeXmlValue(sid) + '"/>\r\n'
+  }
+  return '   <Session IpAddress="10.0.2.15" Prolong="Y" SID="' + escapeXmlValue(sid) + '">\r\n' +
+    '      <Parameter Id="DeviceNo">' + escapeXmlValue(deviceAuthorization.deviceNo) + '</Parameter>\r\n' +
+    '      <Parameter Id="Password">' + escapeXmlValue(deviceAuthorization.otp) + '</Parameter>\r\n' +
+    '   </Session>\r\n'
 }
 
 function sanitizeBgpbRequestLogBody (body) {
   if (typeof body === 'string') {
     return body
       .replace(/\bSID="([^"]*)"/gi, (_match, value) => `SID="${sanitize(value, true)}"`)
+      .replace(/\b(xfad|ActivationPwd|DerivationOTP|DerivationSign)="([^"]*)"/gi, (_match, name, value) => `${name}="${sanitize(value, true)}"`)
       .replace(/(<Parameter\s+Id="(?:Login|Password)"[^>]*>)([^<]*)(<\/Parameter>)/gi, (_match, openTag, value, closeTag) => {
+        return `${openTag}${sanitize(value, true)}${closeTag}`
+      })
+      .replace(/(<(?:xfad|ActivationPwd|DerivationOTP|DerivationSign)>)([^<]*)(<\/(?:xfad|ActivationPwd|DerivationOTP|DerivationSign)>)/gi, (_match, openTag, value, closeTag) => {
         return `${openTag}${sanitize(value, true)}${closeTag}`
       })
   }
@@ -420,6 +438,92 @@ export async function login (login, password) {
   return null
 }
 
+/**
+ * Opens the device-bound DailyFin session used by protected account actions.
+ */
+export async function loginDeviceToken (deviceNo, otp) {
+  const res = await fetchApi(SOU_ADMIN_ENDPOINT,
+    '<BS_Request>\r\n' +
+    '   <Login Biometric="N" IpAddress="10.0.2.15" Type="BS_TOKEN_EMBEDDED">\r\n' +
+    '      <Parameter Id="Password">' + escapeXmlValue(otp) + '</Parameter>\r\n' +
+    '      <Parameter Id="DeviceNo">' + escapeXmlValue(deviceNo) + '</Parameter>\r\n' +
+    '      <Parameter Id="DevicePlatform">' + DEVICE_PLATFORM + '</Parameter>\r\n' +
+    '      <Parameter Id="AppVersion">' + APP_VERSION + '</Parameter>\r\n' +
+    '   </Login>\r\n' +
+    '   <RequestType>Login</RequestType>\r\n' +
+    buildTerminalInfoXml() +
+    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+    '</BS_Request>\r\n', { sanitizeRequestLog: { body: true } }, response => true, message => new InvalidPreferencesError('Банк отклонил PIN-токен BGPB'))
+  if (res.BS_Response.Login && res.BS_Response.Login.SID) {
+    return res.BS_Response.Login.SID
+  }
+  throw new InvalidPreferencesError('Банк не открыл сессию PIN-токена BGPB')
+}
+
+/**
+ * Closes the password session before the app switches to device-token login.
+ */
+export async function logoff (sid) {
+  await fetchApi(SOU_ADMIN_ENDPOINT,
+    '<BS_Request>\r\n' +
+    '   <Logoff>' + escapeXmlValue(sid) + '</Logoff>\r\n' +
+    '   <RequestType>Logoff</RequestType>\r\n' +
+    buildSessionXml(sid) +
+    buildTerminalInfoXml() +
+    '   <Subsystem>ClientAuth</Subsystem>\r\n' +
+    '</BS_Request>\r\n', { sanitizeRequestLog: { body: true } }, response => true, message => new TemporaryError(message))
+}
+
+/**
+ * Registers a DailyFin-compatible device and returns the server activation payload.
+ */
+export async function registerDeviceToken (sid, identity, nonce) {
+  const response = await fetchApi(SOU_ADMIN_ENDPOINT,
+    '<BS_Request>\r\n' +
+    buildTerminalInfoXml() +
+    '   <RequestType>Registration</RequestType>\r\n' +
+    buildSessionXml(sid) +
+    '   <Subsystem>BSToken</Subsystem>\r\n' +
+    '   <Registration>\r\n' +
+    '      <Nonce>' + escapeXmlValue(nonce) + '</Nonce>\r\n' +
+    '      <Model>' + escapeXmlValue(identity.registrationModel) + '</Model>\r\n' +
+    '      <Platform>Android</Platform>\r\n' +
+    '      <Version>' + APP_VERSION + '</Version>\r\n' +
+    '      <DeviceId>' + escapeXmlValue(identity.registrationDeviceId) + '</DeviceId>\r\n' +
+    '   </Registration>\r\n' +
+    '</BS_Request>\r\n', {}, response => true, message => new TemporaryError(message))
+
+  const registration = response?.BS_Response?.Registration
+  const deviceNo = registration?.Id ?? registration?.id
+  const xfad = registration?.xfad ?? registration?.Xfad
+  const activationPassword = registration?.ActivationPwd ?? registration?.activationPwd ?? ''
+  if (deviceNo === null || deviceNo === undefined || !/^\d+$/.test(String(deviceNo)) || typeof xfad !== 'string') {
+    throw new TemporaryError('Ответ банка: не получены данные регистрации устройства')
+  }
+  return {
+    deviceNo: String(deviceNo),
+    xfad,
+    activationPassword: String(activationPassword || '')
+  }
+}
+
+/**
+ * Completes DailyFin-compatible device activation with the locally derived code.
+ */
+export async function activateDeviceToken (sid, deviceNo, derivationOtp) {
+  await fetchApi(SOU_ADMIN_ENDPOINT,
+    '<BS_Request>\r\n' +
+    buildTerminalInfoXml() +
+    '   <RequestType>Activation</RequestType>\r\n' +
+    buildSessionXml(sid) +
+    '   <Subsystem>BSToken</Subsystem>\r\n' +
+    '   <Activation>\r\n' +
+    '      <Id>' + escapeXmlValue(deviceNo) + '</Id>\r\n' +
+    '      <DerivationOTP>' + escapeXmlValue(derivationOtp) + '</DerivationOTP>\r\n' +
+    '   </Activation>\r\n' +
+    '</BS_Request>\r\n', {}, response => true, message => new TemporaryError(message))
+}
+
 export async function fetchAccounts (sid) {
   console.log('>>> Загрузка списка счетов...')
   const [cards, deposits] = await Promise.all([
@@ -612,12 +716,8 @@ async function fetchCardLastTransactions (sid, account, fromDate, toDate, histor
   }))
 }
 
-export async function fetchFullTransactions (sid, account, fromDate, toDate = new Date()) {
+export async function fetchFullTransactions (sid, account, fromDate, toDate = new Date(), getDeviceAuthorization = null) {
   console.log('>>> Загрузка списка транзакций...')
-  if (!FULL_STATEMENT_REQUESTS_ENABLED) {
-    console.log(`>>> Полная выписка для "${account.title}" требует device-bound аутентификацию приложения, пропускаем.`)
-    return []
-  }
 
   toDate = toDate || new Date()
 
@@ -633,7 +733,7 @@ export async function fetchFullTransactions (sid, account, fromDate, toDate = ne
         '      <Parameter Id="DateTill">' + transactionDate(date[1]) + '</Parameter>\r\n' +
         '   </ExecuteAction>\r\n' +
         '   <RequestType>ExecuteAction</RequestType>\r\n' +
-        buildSessionXml(sid) +
+        buildSessionXml(sid, getDeviceAuthorization ? getDeviceAuthorization() : null) +
         buildTerminalInfoXml() +
         '   <Subsystem>ClientAuth</Subsystem>\r\n' +
         '</BS_Request>\r\n', {}, response => true, message => new InvalidPreferencesError('bad request'))
@@ -644,8 +744,7 @@ export async function fetchFullTransactions (sid, account, fromDate, toDate = ne
       }
     } catch (error) {
       if (error.message && error.message.includes(EXTRA_AUTH_REQUIRED_ERROR)) {
-        console.log(`>>> Полная выписка для "${account.title}" требует device-bound аутентификацию приложения, пропускаем.`)
-        return []
+        throw new InvalidPreferencesError('Банк запросил дополнительную авторизацию выписки BGPB, но PIN-токен не был принят.')
       }
       if (error instanceof TemporaryError) {
         console.log(`>>> Не удалось запросить выписку для "${account.title}" за ${transactionDate(date[0])}-${transactionDate(date[1])}, пропускаем интервал.`)

--- a/src/plugins/bgpb/converters.js
+++ b/src/plugins/bgpb/converters.js
@@ -630,3 +630,82 @@ export function transactionsUnique (array) {
   }
   return uniqueTransactions
 }
+
+function transactionSourceKind (transaction) {
+  const text = [
+    transaction.comment,
+    transaction.merchant?.fullTitle,
+    transaction.merchant?.title
+  ].filter(Boolean).join(' ').toUpperCase()
+  if (/POPOLN|ПОПОЛН|ZACHISL|ЗАЧИСЛ/.test(text)) {
+    return 'topup'
+  }
+  if (/PEREVOD|ПЕРЕВОД|P2P/.test(text)) {
+    return 'transfer'
+  }
+  if (/НАЛИЧ|CASH|ATM/.test(text)) {
+    return 'cash'
+  }
+  if (/EPOS|\bPOS\b|ОПЛАТ|ПОКУПК|PAYMENT/.test(text)) {
+    return 'payment'
+  }
+  return 'other'
+}
+
+function amountsMatch (left, right) {
+  if (!Number.isFinite(left) || !Number.isFinite(right)) {
+    return false
+  }
+  return Math.round(left * 100) === Math.round(right * 100)
+}
+
+function isSamePostedOperation (statement, recent) {
+  if (recent.hold) {
+    return false
+  }
+  const statementMovement = statement.movements[0]
+  const recentMovement = recent.movements[0]
+  if (statementMovement.account.id !== recentMovement.account.id ||
+    !amountsMatch(statementMovement.sum, recentMovement.sum) ||
+    Math.abs(statement.date.getTime() - recent.date.getTime()) > 2 * 60 * 1000) {
+    return false
+  }
+
+  const statementKind = transactionSourceKind(statement)
+  const recentKind = transactionSourceKind(recent)
+  return statementKind === 'other' || recentKind === 'other' || statementKind === recentKind
+}
+
+/**
+ * Reconciles authoritative posted statement rows with recent History API rows.
+ * Matching is one-to-one so repeated same-value operations remain separate.
+ */
+export function mergeStatementAndLastTransactions (statementTransactions, lastTransactions) {
+  const statements = transactionsUnique(statementTransactions)
+  const recent = transactionsUnique(lastTransactions)
+  const availableStatementIndexes = new Set(statements.map((_transaction, index) => index))
+  const unmatchedRecent = []
+
+  for (const transaction of recent) {
+    let bestIndex = null
+    let bestTimeDifference = Infinity
+    for (const index of availableStatementIndexes) {
+      const statement = statements[index]
+      if (!isSamePostedOperation(statement, transaction)) {
+        continue
+      }
+      const timeDifference = Math.abs(statement.date.getTime() - transaction.date.getTime())
+      if (timeDifference < bestTimeDifference) {
+        bestIndex = index
+        bestTimeDifference = timeDifference
+      }
+    }
+    if (bestIndex === null) {
+      unmatchedRecent.push(transaction)
+    } else {
+      availableStatementIndexes.delete(bestIndex)
+    }
+  }
+
+  return transactionsUnique(statements.concat(unmatchedRecent))
+}

--- a/src/plugins/bgpb/deviceOtp.js
+++ b/src/plugins/bgpb/deviceOtp.js
@@ -1,0 +1,293 @@
+import crypto from 'crypto-js'
+import { generateRandomString } from '../../common/utils'
+
+const TOKEN_STATE_VERSION = 1
+const ENVELOPE_VERSION = 1
+const KDF_ITERATIONS = 120000
+const OTP_PERIOD_SECONDS = 30
+const OTP_DIGITS = 6
+const DEVICE_MANUFACTURER = 'unknown'
+const DEVICE_MODEL = 'Android SDK built for x86'
+
+function bytesToWordArray (bytes) {
+  const words = []
+  for (let i = 0; i < bytes.length; i++) {
+    words[i >>> 2] = (words[i >>> 2] || 0) | (bytes[i] << (24 - (i % 4) * 8))
+  }
+  return crypto.lib.WordArray.create(words, bytes.length)
+}
+
+function wordArrayToBytes (wordArray) {
+  const bytes = []
+  for (let i = 0; i < wordArray.sigBytes; i++) {
+    bytes.push((wordArray.words[i >>> 2] >>> (24 - (i % 4) * 8)) & 0xff)
+  }
+  return bytes
+}
+
+function hexToBytes (value) {
+  if (typeof value !== 'string' || value.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(value)) {
+    throw new Error('Invalid hexadecimal data')
+  }
+  const bytes = []
+  for (let i = 0; i < value.length; i += 2) {
+    bytes.push(Number.parseInt(value.slice(i, i + 2), 16))
+  }
+  return bytes
+}
+
+function bytesToHex (bytes) {
+  return bytes.map(value => value.toString(16).padStart(2, '0')).join('')
+}
+
+function asciiBytes (value) {
+  return Array.from(value, char => char.charCodeAt(0) & 0xff)
+}
+
+function androidBase64Default (wordArray) {
+  const encoded = crypto.enc.Base64.stringify(wordArray)
+  return (encoded.match(/.{1,76}/g) || []).join('\n') + '\n'
+}
+
+function buildDeviceFingerprint (identity, pin) {
+  const source = identity.dpassDeviceId + identity.manufacturer + identity.model + pin
+  return androidBase64Default(crypto.SHA512(source))
+}
+
+function fingerprintSuffix (identity, pin) {
+  return crypto.SHA256(buildDeviceFingerprint(identity, pin)).toString(crypto.enc.Hex).toUpperCase().slice(0, 20)
+}
+
+function counterBytes (counter) {
+  const high = Math.floor(counter / 0x100000000)
+  const low = counter >>> 0
+  return [
+    (high >>> 24) & 0xff,
+    (high >>> 16) & 0xff,
+    (high >>> 8) & 0xff,
+    high & 0xff,
+    (low >>> 24) & 0xff,
+    (low >>> 16) & 0xff,
+    (low >>> 8) & 0xff,
+    low & 0xff
+  ]
+}
+
+function hotp (secret, counter) {
+  const digest = wordArrayToBytes(crypto.HmacSHA1(bytesToWordArray(counterBytes(counter)), bytesToWordArray(secret)))
+  const offset = digest[digest.length - 1] & 0x0f
+  const binary = ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff)
+  return String((binary >>> 0) % Math.pow(10, OTP_DIGITS)).padStart(OTP_DIGITS, '0')
+}
+
+function timeCounter (now, offsetPeriods = 0) {
+  return Math.floor(now / 1000 / OTP_PERIOD_SECONDS) + offsetPeriods
+}
+
+function deriveEnvelopeKeys (pin, saltHex) {
+  const derived = crypto.PBKDF2(pin, crypto.enc.Hex.parse(saltHex), {
+    keySize: 16,
+    iterations: KDF_ITERATIONS,
+    hasher: crypto.algo.SHA256
+  }).toString(crypto.enc.Hex)
+  return {
+    encryptionKey: crypto.enc.Hex.parse(derived.slice(0, 64)),
+    macKey: crypto.enc.Hex.parse(derived.slice(64))
+  }
+}
+
+function constantTimeEqual (left, right) {
+  if (typeof left !== 'string' || typeof right !== 'string' || left.length !== right.length) {
+    return false
+  }
+  let difference = 0
+  for (let i = 0; i < left.length; i++) {
+    difference |= left.charCodeAt(i) ^ right.charCodeAt(i)
+  }
+  return difference === 0
+}
+
+function validateDeviceState (state) {
+  if (!state || state.version !== TOKEN_STATE_VERSION ||
+    typeof state.accountHash !== 'string' ||
+    typeof state.deviceNo !== 'string' || !/^\d+$/.test(state.deviceNo) ||
+    typeof state.otpKey !== 'string' || !/^[0-9a-f]{40}$/i.test(state.otpKey) ||
+    !state.identity || typeof state.identity !== 'object' ||
+    typeof state.identity.dpassDeviceId !== 'string' ||
+    typeof state.identity.manufacturer !== 'string' ||
+    typeof state.identity.model !== 'string') {
+    throw new Error('Stored BGPB device token has an invalid format')
+  }
+  return state
+}
+
+/**
+ * Validates the local six-digit PIN used by the BGPB device token.
+ */
+export function validateDevicePin (pin) {
+  if (!/^\d{6}$/.test(pin || '')) {
+    throw new InvalidPreferencesError('PIN токена BGPB должен состоять ровно из 6 цифр')
+  }
+  if (new Set(pin).size < 3 || /(?:0123|1234|2345|3456|4567|5678|6789|9876|8765|7654|6543|5432|4321|3210)/.test(pin)) {
+    throw new InvalidPreferencesError('Выберите менее простой PIN токена BGPB')
+  }
+}
+
+/**
+ * Creates the two stable identifiers used by DailyFin registration and DPass.
+ */
+export function createDeviceIdentity () {
+  const androidId = generateRandomString(16, '0123456789abcdef')
+  const registrationDeviceId = `${androidId}_android_prod__revamp`
+  return {
+    registrationDeviceId,
+    registrationModel: `Unknown ${DEVICE_MODEL} (${registrationDeviceId})`,
+    dpassDeviceId: generateRandomString(32, '0123456789abcdef'),
+    manufacturer: DEVICE_MANUFACTURER,
+    model: DEVICE_MODEL
+  }
+}
+
+/**
+ * Reproduces DailyFin's local XFAD activation derivation.
+ */
+export function buildActivationDescriptor ({ xfad, activationPassword, nonce, pin, identity, now = Date.now() }) {
+  validateDevicePin(pin)
+  if (typeof xfad !== 'string' || xfad.length < 300) {
+    throw new Error('BGPB returned an invalid device activation payload')
+  }
+  const staticVectorLength = Number.parseInt(xfad.slice(0, 4), 10)
+  if (!Number.isInteger(staticVectorLength) || staticVectorLength < 100 || staticVectorLength > 256) {
+    throw new Error('BGPB returned an invalid static-vector length')
+  }
+  if (typeof activationPassword !== 'string' || activationPassword.length === 0 ||
+    typeof nonce !== 'string' || nonce.length === 0) {
+    throw new Error('BGPB device activation data is incomplete')
+  }
+
+  const serial = xfad.slice(128, 138)
+  const ivHex = xfad.slice(50, 66)
+  const encryptedHex = xfad.slice(138)
+  if (!/^[0-9a-f]{16}$/i.test(ivHex) || encryptedHex.length % 16 !== 0 || !/^[0-9a-f]+$/i.test(encryptedHex)) {
+    throw new Error('BGPB returned malformed encrypted token vectors')
+  }
+
+  const nonceHash = wordArrayToBytes(crypto.SHA1(nonce + serial.slice(3))).slice(8, 16)
+  const activationHash = wordArrayToBytes(crypto.SHA1(activationPassword)).slice(0, 8)
+  const key = activationHash.concat(nonceHash, activationHash)
+  const decrypted = crypto.TripleDES.decrypt({ ciphertext: crypto.enc.Hex.parse(encryptedHex) }, bytesToWordArray(key), {
+    iv: crypto.enc.Hex.parse(ivHex),
+    mode: crypto.mode.CBC,
+    padding: crypto.pad.NoPadding
+  })
+  const vectors = wordArrayToBytes(decrypted)
+  const applicationCount = vectors[0] - 48
+  if (applicationCount < 2 || vectors.length < 67) {
+    throw new Error('BGPB device token does not contain the required OTP applications')
+  }
+
+  const otpKey = vectors.slice(14, 34)
+  const otpKey2 = vectors.slice(47, 67)
+  const suffix = fingerprintSuffix(identity, pin)
+  return {
+    otpKey: bytesToHex(otpKey),
+    derivationOtp: hotp(otpKey, timeCounter(now)) + suffix,
+    derivationOtp2: hotp(otpKey2, timeCounter(now)) + suffix
+  }
+}
+
+/**
+ * Generates DailyFin's OTP_1 value for an already activated token.
+ */
+export function generateDeviceOtp (state, pin, now = Date.now(), offsetPeriods = 0) {
+  validateDevicePin(pin)
+  validateDeviceState(state)
+  const suffix = fingerprintSuffix(state.identity, pin)
+  const secret = hexToBytes(state.otpKey).concat(asciiBytes(suffix))
+  return hotp(secret, timeCounter(now, offsetPeriods))
+}
+
+/**
+ * Hashes the selected bank login so persisted token state cannot cross accounts.
+ */
+export function hashAccountLogin (login) {
+  return crypto.SHA256(String(login || '').trim().toLowerCase()).toString(crypto.enc.Hex)
+}
+
+/**
+ * Encrypts and authenticates BGPB token material before plugin-data persistence.
+ */
+export function sealDeviceState (state, pin, random = {}) {
+  validateDevicePin(pin)
+  validateDeviceState(state)
+  const saltHex = random.saltHex || crypto.lib.WordArray.random(16).toString(crypto.enc.Hex)
+  const ivHex = random.ivHex || crypto.lib.WordArray.random(16).toString(crypto.enc.Hex)
+  if (!/^[0-9a-f]{32}$/i.test(saltHex) || !/^[0-9a-f]{32}$/i.test(ivHex)) {
+    throw new Error('Invalid BGPB token encryption parameters')
+  }
+  const keys = deriveEnvelopeKeys(pin, saltHex)
+  const ciphertext = crypto.AES.encrypt(crypto.enc.Utf8.parse(JSON.stringify(state)), keys.encryptionKey, {
+    iv: crypto.enc.Hex.parse(ivHex),
+    mode: crypto.mode.CBC,
+    padding: crypto.pad.Pkcs7
+  }).ciphertext.toString(crypto.enc.Hex)
+  const macPayload = `${ENVELOPE_VERSION}|${saltHex}|${ivHex}|${ciphertext}`
+  const mac = crypto.HmacSHA256(macPayload, keys.macKey).toString(crypto.enc.Hex)
+  return {
+    version: ENVELOPE_VERSION,
+    salt: saltHex,
+    iv: ivHex,
+    ciphertext,
+    mac
+  }
+}
+
+/**
+ * Authenticates and decrypts persisted BGPB token material.
+ */
+export function openDeviceState (envelope, pin) {
+  validateDevicePin(pin)
+  if (!envelope || envelope.version !== ENVELOPE_VERSION ||
+    !/^[0-9a-f]{32}$/i.test(envelope.salt || '') ||
+    !/^[0-9a-f]{32}$/i.test(envelope.iv || '') ||
+    !/^[0-9a-f]+$/i.test(envelope.ciphertext || '') ||
+    !/^[0-9a-f]{64}$/i.test(envelope.mac || '')) {
+    throw new Error('Stored BGPB device token envelope has an invalid format')
+  }
+  const keys = deriveEnvelopeKeys(pin, envelope.salt)
+  const macPayload = `${envelope.version}|${envelope.salt}|${envelope.iv}|${envelope.ciphertext}`
+  const expectedMac = crypto.HmacSHA256(macPayload, keys.macKey).toString(crypto.enc.Hex)
+  if (!constantTimeEqual(expectedMac, envelope.mac)) {
+    throw new InvalidPreferencesError('PIN токена BGPB не подходит к сохраненной активации')
+  }
+  try {
+    const plaintext = crypto.AES.decrypt({ ciphertext: crypto.enc.Hex.parse(envelope.ciphertext) }, keys.encryptionKey, {
+      iv: crypto.enc.Hex.parse(envelope.iv),
+      mode: crypto.mode.CBC,
+      padding: crypto.pad.Pkcs7
+    }).toString(crypto.enc.Utf8)
+    return validateDeviceState(JSON.parse(plaintext))
+  } catch (_error) {
+    throw new Error('Could not decrypt stored BGPB device token')
+  }
+}
+
+/**
+ * Creates the minimal persisted state needed for OTP_1 statement authorization.
+ */
+export function createDeviceState ({ login, deviceNo, otpKey, identity }) {
+  return validateDeviceState({
+    version: TOKEN_STATE_VERSION,
+    accountHash: hashAccountLogin(login),
+    deviceNo: String(deviceNo),
+    otpKey,
+    identity: {
+      dpassDeviceId: identity.dpassDeviceId,
+      manufacturer: identity.manufacturer,
+      model: identity.model
+    }
+  })
+}

--- a/src/plugins/bgpb/index.js
+++ b/src/plugins/bgpb/index.js
@@ -13,7 +13,7 @@ import {
   parseTransactionsAndOverdraft,
   registerDeviceToken
 } from './api'
-import { addOverdraftInfo, convertAccount, convertLastTransaction, convertTransaction, transactionsUnique } from './converters'
+import { addOverdraftInfo, convertAccount, convertLastTransaction, convertTransaction, mergeStatementAndLastTransactions } from './converters'
 import {
   buildActivationDescriptor,
   createDeviceIdentity,
@@ -27,6 +27,14 @@ import {
 
 const DEVICE_TOKEN_DATA_KEY = 'deviceOtp/v1'
 const ACTIVATION_CODE_TIMEOUT_MS = 180000
+
+/**
+ * Full mailbox statements provide complete history when device authorization is
+ * available. History API is merged separately for recent and pending operations.
+ */
+export function shouldFetchFullStatement (account, deviceBound) {
+  return Boolean(deviceBound && account.transactionsAccId)
+}
 
 export async function scrape ({ preferences, fromDate, toDate }) {
   const session = await initializeDeviceSession(preferences)
@@ -43,7 +51,7 @@ export async function scrape ({ preferences, fromDate, toDate }) {
 
   const transactionsStatement = []
   accounts = await Promise.all(accounts.map(async account => {
-    if (account.transactionsAccId && session.deviceBound) {
+    if (shouldFetchFullStatement(account, session.deviceBound)) {
       const mails = await fetchFullTransactions(token, account, fromDate, toDate, session.getDeviceAuthorization)
       const { overdraft, transactions } = parseTransactionsAndOverdraft(mails, account)
       account = addOverdraftInfo(account, overdraft)
@@ -69,7 +77,7 @@ export async function scrape ({ preferences, fromDate, toDate }) {
       }
       return true
     })
-  const transactions = transactionsUnique(transactionsStatement.concat(transactionsLast))
+  const transactions = mergeStatementAndLastTransactions(transactionsStatement, transactionsLast)
     .filter(transaction => transaction.movements[0].sum !== 0)
   return {
     accounts,

--- a/src/plugins/bgpb/index.js
+++ b/src/plugins/bgpb/index.js
@@ -1,18 +1,36 @@
 import _ from 'lodash'
 import { adjustTransactions } from '../../common/transactionGroupHandler'
 import {
+  activateDeviceToken,
   fetchAccounts,
   fetchBalance,
   fetchFullTransactions,
   fetchLastTransactions,
   fetchTransactionsAccId,
   login,
-  parseTransactionsAndOverdraft
+  loginDeviceToken,
+  logoff,
+  parseTransactionsAndOverdraft,
+  registerDeviceToken
 } from './api'
 import { addOverdraftInfo, convertAccount, convertLastTransaction, convertTransaction, transactionsUnique } from './converters'
+import {
+  buildActivationDescriptor,
+  createDeviceIdentity,
+  createDeviceState,
+  generateDeviceOtp,
+  hashAccountLogin,
+  openDeviceState,
+  sealDeviceState,
+  validateDevicePin
+} from './deviceOtp'
+
+const DEVICE_TOKEN_DATA_KEY = 'deviceOtp/v1'
+const ACTIVATION_CODE_TIMEOUT_MS = 180000
 
 export async function scrape ({ preferences, fromDate, toDate }) {
-  const token = await login(preferences.login, preferences.password)
+  const session = await initializeDeviceSession(preferences)
+  const token = session.sid
 
   let accounts = await allAccounts(token)
   if (accounts.length === 0) {
@@ -25,8 +43,8 @@ export async function scrape ({ preferences, fromDate, toDate }) {
 
   const transactionsStatement = []
   accounts = await Promise.all(accounts.map(async account => {
-    if (account.transactionsAccId) {
-      const mails = await fetchFullTransactions(token, account, fromDate, toDate)
+    if (account.transactionsAccId && session.deviceBound) {
+      const mails = await fetchFullTransactions(token, account, fromDate, toDate, session.getDeviceAuthorization)
       const { overdraft, transactions } = parseTransactionsAndOverdraft(mails, account)
       account = addOverdraftInfo(account, overdraft)
       for (const apiTransaction of transactions) {
@@ -56,6 +74,94 @@ export async function scrape ({ preferences, fromDate, toDate }) {
   return {
     accounts,
     transactions: adjustTransactions({ transactions: _.sortBy(transactions, transaction => transaction.date) })
+  }
+}
+
+async function readActivationCode () {
+  const code = await ZenMoney.readLine('Введите 8-значный код активации устройства BGPB', {
+    inputType: 'text',
+    time: ACTIVATION_CODE_TIMEOUT_MS
+  })
+  const normalized = String(code || '').trim()
+  if (normalized.length !== 8) {
+    throw new InvalidPreferencesError('Не введен корректный 8-значный код активации BGPB')
+  }
+  return normalized
+}
+
+async function initializeDeviceSession (preferences) {
+  const pin = String(preferences.appPin || '').trim()
+  if (pin.length === 0) {
+    return {
+      sid: await login(preferences.login, preferences.password),
+      activated: false,
+      deviceBound: false
+    }
+  }
+  validateDevicePin(pin)
+
+  const expectedAccountHash = hashAccountLogin(preferences.login)
+  const storedEnvelope = ZenMoney.getData(DEVICE_TOKEN_DATA_KEY)
+  let state = null
+  if (storedEnvelope) {
+    const storedState = openDeviceState(storedEnvelope, pin)
+    if (storedState.accountHash === expectedAccountHash) {
+      state = storedState
+    }
+  }
+
+  if (!state) {
+    const sid = await login(preferences.login, preferences.password)
+    console.log('>>> Регистрация устройства для выписок BGPB...')
+    const identity = createDeviceIdentity()
+    const nonce = String(Date.now())
+    const registration = await registerDeviceToken(sid, identity, nonce)
+    let activationPassword = registration.activationPassword.trim()
+    if (activationPassword.length !== 8) {
+      activationPassword = await readActivationCode()
+    }
+    const descriptor = buildActivationDescriptor({
+      xfad: registration.xfad,
+      activationPassword,
+      nonce,
+      pin,
+      identity
+    })
+    const activationSid = await login(preferences.login, preferences.password)
+    await activateDeviceToken(activationSid, registration.deviceNo, descriptor.derivationOtp)
+    state = createDeviceState({
+      login: preferences.login,
+      deviceNo: registration.deviceNo,
+      otpKey: descriptor.otpKey,
+      identity
+    })
+    ZenMoney.setData(DEVICE_TOKEN_DATA_KEY, sealDeviceState(state, pin))
+    ZenMoney.saveData()
+    console.log('>>> Устройство BGPB активировано.')
+    try {
+      await logoff(activationSid)
+    } catch (_error) {
+      console.log('>>> Не удалось закрыть парольную сессию BGPB после активации.')
+    }
+    return {
+      sid: await loginDeviceToken(state.deviceNo, generateDeviceOtp(state, pin)),
+      activated: true,
+      deviceBound: true,
+      getDeviceAuthorization: () => ({
+        deviceNo: state.deviceNo,
+        otp: generateDeviceOtp(state, pin)
+      })
+    }
+  }
+
+  return {
+    sid: await loginDeviceToken(state.deviceNo, generateDeviceOtp(state, pin)),
+    activated: false,
+    deviceBound: true,
+    getDeviceAuthorization: () => ({
+      deviceNo: state.deviceNo,
+      otp: generateDeviceOtp(state, pin)
+    })
   }
 }
 

--- a/src/plugins/bgpb/preferences.xml
+++ b/src/plugins/bgpb/preferences.xml
@@ -21,6 +21,17 @@
         summary="||***********"
     />
     <EditTextPreference
+        key="appPin"
+        obligatory="false"
+        inputType="textPassword"
+        title="PIN токена для выписок"
+        dialogTitle="PIN токена BGPB"
+        dialogMessage="Необязательный 6-значный PIN локального устройства. Нужен для загрузки операций по вкладам и полных выписок. Это не PIN банковской карты. При первом запуске с PIN банк зарегистрирует новое устройство."
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||***********"
+    />
+    <EditTextPreference
         key="startDate"
         obligatory="true"
         inputType="date"


### PR DESCRIPTION
## What changed

- align BGPB requests with the DailyFin 1.6.2 client contract
- implement DailyFin-compatible device registration, activation, PIN-token login, and protected-action OTP authorization
- encrypt and authenticate persisted device-token material in plugin data
- enable full statements and deposit transaction synchronization
- add request-sanitization and device-OTP regression tests

## Root cause

The plugin still identified itself as the older 1.5.0 client and skipped protected statements. The current bank flow requires a registered device token plus a locally generated DPass OTP for login and another OTP parameter on protected statement actions.

## User impact

Users can configure a local six-digit device PIN once, activate the device through the bank's code flow, and then synchronize deposit transactions and full statements without requesting a new SMS code on every run.

## Validation

- `npm test -- --runInBand`
- `npm run build -- bgpb`
- read-only live synchronization confirmed account and deposit statement retrieval through the saved encrypted token

No credentials, PINs, OTPs, or local plugin-data files are included in this change.
