### PR TITLE
Add Bybit Card Auto Earn balance and regional API support

### DIFF
--- a/src/plugins/bybit/README.md
+++ b/src/plugins/bybit/README.md
@@ -7,14 +7,19 @@ Synchronizes the **Bybit Card** with ZenMoney via the public Bybit V5 REST API, 
 - One ZenMoney credit-card account (`ccard`): **Bybit Card**.
   - Stable id: `bybit_card`.
   - Instrument: `USD`.
-  - Balance: sum of the "one-click" USDT-worth (`uBalance`) returned by the [Convert coin list](https://bybit-exchange.github.io/docs/v5/asset/convert/convert-coin-list) for configured Funding coins (`USDT`, `USDC`) plus the Funding `USD` fiat balance (added automatically, 1:1).
+  - Balance: the card's estimated spending power:
+    - the "one-click" USDT-worth (`uBalance`) returned by the [Convert coin list](https://bybit-exchange.github.io/docs/v5/asset/convert/convert-coin-list) for configured Funding coins (`USDT`, `USDC`);
+    - Funding `USD` fiat (added automatically, 1:1);
+    - the redeemable `availableAmount` returned by [Flexible Earn positions](https://bybit-exchange.github.io/docs/v5/finance/earn/easy-onchain/position) for the same configured stablecoins.
+  - Bybit does not expose the card's Auto-Deduction switch through the public API. Configure only coins that are selected for card payment with Auto-Deduction enabled; otherwise the estimate can exceed the actual spending power.
   - Skip in ZenMoney: `bybit_card`.
 - Card transactions from [`POST /v5/card/transaction/query-asset-records`](https://bybit-exchange.github.io/docs/v5/bybit-card/asset-records).
   - `SIDE_QUERY_FINANCIAL_ALL` is used for posted card transactions.
   - `SIDE_QUERY_AUTH` is queried for the requested date range and only in-progress authorizations (`tradeStatus=0`) are imported, so new card payments appear as ZenMoney holds before posting.
   - Each transaction's movement `sum` is the **total USD amount including fees** (`basicAmount` in `basicCurrency`, expected to be `USD`).
-  - `invoice` is the merchant amount (`transactionAmount` in `transactionCurrency`) only when that currency differs from the USD card account; otherwise it is `null`.
-  - Merchant data is populated from `merchName` / `merchCity` / `merchCountry` / `mccCode`.
+  - `invoice` is the original fiat transaction amount (`transactionCurrencyAmount` in `transactionCurrency`) only when that currency differs from the USD card account; otherwise it is `null`.
+  - ZenMoney's final plugin API has no separate fee field. Bybit's fees are already included in `basicAmount`, so the exact total balance effect is preserved without a separate fee annotation.
+  - Merchant title and MCC are mapped to ZenMoney's native fields. Category, city, and country are also retained in the comment because ZenMoney's final plugin serializer has no fields for them. Bybit does not provide merchant coordinates.
   - Authorizations (`side=1`) and any in-progress transactions (`tradeStatus=0`) are marked as holds.
   - Declined (`tradeStatus=2`), reversal (`tradeStatus=3`), authorization-reversal (`side=2`), unDeduct-refund (`side=4`), and various `*-reversal` / `*-request` sides are filtered out to avoid double-counting.
 
@@ -25,16 +30,23 @@ Synchronizes the **Bybit Card** with ZenMoney via the public Bybit V5 REST API, 
 3. Set **API Key Permissions** to **Read-Only**.
 4. Enable:
    - **Bybit Card** (this is the scope required by `/v5/card/transaction/query-asset-records`).
+   - **Earn** → *Earn* (read-only; required to include redeemable Flexible Earn in card spending power).
    - **Wallet** → *Account Transfer* and *Subaccount Transfer* (so the funding-wallet balance probe works).
    - **Exchange** → *Exchange History* (read-only; required by `/v5/asset/exchange/query-coin-list`, which provides the one-click `uBalance` used for the aggregated USD balance).
 5. **Do NOT** enable any trading, derivatives, or withdrawal permissions. Read-only "Exchange History" alone does not allow executing convert/exchange orders.
 6. Optionally restrict the key by IP for extra safety.
 7. Copy the **API Key** and **API Secret** (the secret is shown only once) and paste them into the plugin's preferences.
+8. Select the official API host for the account region. The global default is
+   `https://api.bybit.com`; Kazakhstan accounts use `https://api.bybit.kz`.
 
 ## Limitations
 
 - The plugin imports the side codes listed above. If Bybit introduces new `side` values or renames the existing ones, the `SIDE_SIGN` whitelist in [`converters.ts`](converters.ts) needs to be updated.
+- The Flexible Earn part of the balance assumes that every configured stablecoin is selected in Bybit Card's **Paying With** settings and has **Auto-Deduction** enabled. The public Card API does not expose those switches.
 - Authorization reversals (`side=2`) are not imported — instead, the matching authorization (`side=1`, in-progress hold) is expected to disappear from the upstream feed or be superseded by a cleared transaction on a subsequent sync. ZenMoney's hold-reconciliation logic handles the difference.
+- Bybit documents a separate API hostname for some regions. A key created on a
+  regional Bybit site may be rejected by the global host, so the plugin setting
+  must match the account region.
 
 ## Suggested ZenMoney workflow
 

--- a/src/plugins/bybit/README.md
+++ b/src/plugins/bybit/README.md
@@ -10,16 +10,15 @@ Synchronizes the **Bybit Card** with ZenMoney via the public Bybit V5 REST API, 
   - Balance: the card's estimated spending power:
     - the "one-click" USDT-worth (`uBalance`) returned by the [Convert coin list](https://bybit-exchange.github.io/docs/v5/asset/convert/convert-coin-list) for configured Funding coins (`USDT`, `USDC`);
     - Funding `USD` fiat (added automatically, 1:1);
-    - the redeemable `availableAmount` returned by [Flexible Earn positions](https://bybit-exchange.github.io/docs/v5/finance/earn/easy-onchain/position) for the same configured stablecoins.
+    - the redeemable `availableAmount` returned by [`GET /v5/earn/position`](https://bybit-exchange.github.io/docs/v5/finance/earn/easy-onchain/position) for the same configured stablecoins.
   - Bybit does not expose the card's Auto-Deduction switch through the public API. Configure only coins that are selected for card payment with Auto-Deduction enabled; otherwise the estimate can exceed the actual spending power.
   - Skip in ZenMoney: `bybit_card`.
 - Card transactions from [`POST /v5/card/transaction/query-asset-records`](https://bybit-exchange.github.io/docs/v5/bybit-card/asset-records).
   - `SIDE_QUERY_FINANCIAL_ALL` is used for posted card transactions.
   - `SIDE_QUERY_AUTH` is queried for the requested date range and only in-progress authorizations (`tradeStatus=0`) are imported, so new card payments appear as ZenMoney holds before posting.
-  - Each transaction's movement `sum` is the **total USD amount including fees** (`basicAmount` in `basicCurrency`, expected to be `USD`).
-  - `invoice` is the original fiat transaction amount (`transactionCurrencyAmount` in `transactionCurrency`) only when that currency differs from the USD card account; otherwise it is `null`.
-  - ZenMoney's final plugin API has no separate fee field. Bybit's fees are already included in `basicAmount`, so the exact total balance effect is preserved without a separate fee annotation.
-  - Merchant title and MCC are mapped to ZenMoney's native fields. Category, city, and country are also retained in the comment because ZenMoney's final plugin serializer has no fields for them. Bybit does not provide merchant coordinates.
+  - The movement's `sum` is the pre-fee part of `basicAmount`, and its signed `fee` is populated from `totalFees`; together they preserve the exact total balance effect reported by Bybit.
+  - `invoice` is `paidAmount` in `paidCurrency` only when that currency differs from the USD card account; otherwise it is `null`.
+  - Merchant title and MCC are mapped to ZenMoney's native fields. City and country are retained in the comment because ZenMoney's final plugin serializer has no fields for them. `merchCategoryDesc` is used as a fallback merchant title. Bybit does not provide merchant coordinates.
   - Authorizations (`side=1`) and any in-progress transactions (`tradeStatus=0`) are marked as holds.
   - Declined (`tradeStatus=2`), reversal (`tradeStatus=3`), authorization-reversal (`side=2`), unDeduct-refund (`side=4`), and various `*-reversal` / `*-request` sides are filtered out to avoid double-counting.
 

--- a/src/plugins/bybit/__tests__/api/login.test.ts
+++ b/src/plugins/bybit/__tests__/api/login.test.ts
@@ -1,0 +1,29 @@
+import { InvalidPreferencesError } from '../../../../errors'
+import { login, normalizeBaseUrl } from '../../api'
+
+describe('Bybit login preferences', () => {
+  it('uses the global API host by default', () => {
+    expect(normalizeBaseUrl()).toBe('https://api.bybit.com')
+  })
+
+  it('accepts an official regional API host and trims a trailing slash', async () => {
+    const auth = await login({
+      apiKey: 'key',
+      apiSecret: 'secret',
+      baseUrl: ' https://api.bybit.kz/ ',
+      startDate: '2026-01-01T00:00:00.000Z',
+      cardBalanceCoins: 'USDT, USDC'
+    })
+
+    expect(auth.credentials.baseUrl).toBe('https://api.bybit.kz')
+  })
+
+  it.each([
+    'http://api.bybit.com',
+    'https://api.bybit.com.example.org',
+    'https://api.bybit.com/path',
+    'https://user:password@api.bybit.com'
+  ])('rejects a non-official API base URL: %s', (baseUrl) => {
+    expect(() => normalizeBaseUrl(baseUrl)).toThrow(InvalidPreferencesError)
+  })
+})

--- a/src/plugins/bybit/__tests__/converters/convertAccounts.test.ts
+++ b/src/plugins/bybit/__tests__/converters/convertAccounts.test.ts
@@ -80,6 +80,20 @@ describe('createAggregatedAccount', () => {
     expect(account.balance).toBe(80)
   })
 
+  it('adds only the redeemable Flexible Earn amount for configured card coins', () => {
+    const account = createAggregatedAccount(
+      [],
+      new Set(['USDT', 'USD']),
+      new Map(),
+      [
+        { coin: 'USDT', amount: 2300, availableAmount: 2252.3136 },
+        { coin: 'USDC', amount: 100, availableAmount: 100 }
+      ]
+    )
+
+    expect(account.balance).toBe(2252.3136)
+  })
+
   it('returns a zero-balance account when there are no matching coins', () => {
     const account = createAggregatedAccount([], cardCoins, new Map())
     expect(account.balance).toBe(0)

--- a/src/plugins/bybit/__tests__/converters/convertTransaction.test.ts
+++ b/src/plugins/bybit/__tests__/converters/convertTransaction.test.ts
@@ -60,7 +60,8 @@ describe('convertTransaction', () => {
       merchCountry: 'US',
       mccCode: 5411,
       merchCategoryDesc: 'Grocery Stores',
-      pan4: '1234'
+      pan4: '1234',
+      totalFees: 1.5
     })
     expect(convertTransaction(entry, bybitCardAccount)).toEqual({
       hold: false,
@@ -69,8 +70,8 @@ describe('convertTransaction', () => {
         id: 'TXN20230101001',
         account: { id: 'bybit_card' },
         invoice: null,
-        sum: -101.5,
-        fee: 0
+        sum: -100,
+        fee: -1.5
       }],
       merchant: {
         title: 'Amazon',
@@ -83,7 +84,7 @@ describe('convertTransaction', () => {
     })
   })
 
-  it('keeps a merchant-currency invoice when it differs from the USD card account currency', () => {
+  it('keeps a paid-currency invoice when it differs from the USD card account currency', () => {
     const entry = baseEntry({
       basicAmount: 108,
       basicCurrency: 'USD',

--- a/src/plugins/bybit/__tests__/converters/convertTransaction.test.ts
+++ b/src/plugins/bybit/__tests__/converters/convertTransaction.test.ts
@@ -34,6 +34,7 @@ function baseEntry (overrides: Partial<CardTransaction> = {}): CardTransaction {
     merchCategoryDesc: null,
     pan4: null,
     declinedReason: null,
+    totalFees: 0,
     ...overrides
   }
 }
@@ -51,7 +52,7 @@ describe('convertTransaction', () => {
       basicAmount: 101.5,
       basicCurrency: 'USD',
       paidAmount: 101.5,
-      paidCurrency: 'USDT',
+      paidCurrency: 'USD',
       transactionAmount: 100,
       transactionCurrency: 'USD',
       merchName: 'Amazon',
@@ -78,7 +79,7 @@ describe('convertTransaction', () => {
         mcc: 5411,
         location: null
       },
-      comment: null
+      comment: 'Place: New York, US'
     })
   })
 
@@ -87,13 +88,14 @@ describe('convertTransaction', () => {
       basicAmount: 108,
       basicCurrency: 'USD',
       transactionAmount: 100,
-      transactionCurrency: 'EUR'
+      paidCurrency: 'EUR',
+      paidAmount: 92.75
     })
     const tx = convertTransaction(entry, bybitCardAccount)
     expect(tx?.movements[0]).toEqual({
       id: 'TXN1',
       account: { id: 'bybit_card' },
-      invoice: { sum: -100, instrument: 'EUR' },
+      invoice: { sum: -92.75, instrument: 'EUR' },
       sum: -108,
       fee: 0
     })
@@ -142,7 +144,7 @@ describe('convertTransaction', () => {
 
   it('omits the invoice when transaction currency equals account currency', () => {
     const entry = baseEntry({
-      transactionCurrency: 'USD',
+      paidCurrency: 'USD',
       transactionAmount: 50,
       basicAmount: 51.25
     })

--- a/src/plugins/bybit/api.ts
+++ b/src/plugins/bybit/api.ts
@@ -3,12 +3,60 @@ import { parseCardBalanceCoinsList } from './converters'
 import {
   fetchCardTransactionsPage,
   fetchConvertCoinUsdtValues as fetchConvertCoinUsdtValuesApi,
+  fetchFlexibleEarnPositions as fetchFlexibleEarnPositionsApi,
   fetchFundingBalances
 } from './fetchApi'
-import { Auth, CardTransaction, CardTransactionQueryType, CoinBalance, Credentials, Preferences } from './models'
+import {
+  Auth,
+  CardTransaction,
+  CardTransactionQueryType,
+  CoinBalance,
+  Credentials,
+  FlexibleEarnPosition,
+  Preferences
+} from './models'
 
 // if > 100, the API returns 10 only
 const PAGE_LIMIT = 100
+const DEFAULT_BASE_URL = 'https://api.bybit.com'
+const ALLOWED_API_HOSTS: ReadonlySet<string> = new Set([
+  'api.bybit.com',
+  'api.bytick.com',
+  'api.bybit.nl',
+  'api.bybit.tr',
+  'api.bybit.kz',
+  'api.bybitgeorgia.ge',
+  'api.bybit.ae',
+  'api.bybit.eu',
+  'api.bybit.id',
+  'api.manepa.jp'
+])
+
+export function normalizeBaseUrl (rawBaseUrl?: string): string {
+  const trimmedBaseUrl = rawBaseUrl?.trim()
+  const value = trimmedBaseUrl == null || trimmedBaseUrl === ''
+    ? DEFAULT_BASE_URL
+    : trimmedBaseUrl
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch (error) {
+    throw new InvalidPreferencesError('Bybit: API base URL must be a valid HTTPS URL')
+  }
+
+  if (url.protocol !== 'https:' ||
+      url.username !== '' ||
+      url.password !== '' ||
+      url.port !== '' ||
+      url.pathname !== '/' ||
+      url.search !== '' ||
+      url.hash !== '' ||
+      !ALLOWED_API_HOSTS.has(url.hostname)) {
+    throw new InvalidPreferencesError('Bybit: API base URL must be an official Bybit regional API host')
+  }
+
+  return `https://${url.hostname}`
+}
 
 export async function login (preferences: Preferences): Promise<Auth> {
   if (preferences.apiKey == null || preferences.apiKey === '' ||
@@ -20,7 +68,11 @@ export async function login (preferences: Preferences): Promise<Auth> {
   const cardBalanceCoins = parseCardBalanceCoinsList(preferences.cardBalanceCoins)
   // Always include fiat USD from the Funding wallet (1:1 to USD)
   cardBalanceCoins.add('USD')
-  const credentials: Credentials = { apiKey: preferences.apiKey, apiSecret: preferences.apiSecret }
+  const credentials: Credentials = {
+    apiKey: preferences.apiKey,
+    apiSecret: preferences.apiSecret,
+    baseUrl: normalizeBaseUrl(preferences.baseUrl)
+  }
   return { credentials, cardBalanceCoins }
 }
 
@@ -30,6 +82,10 @@ export async function fetchAccounts (creds: Credentials): Promise<CoinBalance[]>
 
 export async function fetchConvertCoinUsdtValues (creds: Credentials): Promise<Map<string, number>> {
   return await fetchConvertCoinUsdtValuesApi(creds)
+}
+
+export async function fetchFlexibleEarnPositions (creds: Credentials): Promise<FlexibleEarnPosition[]> {
+  return await fetchFlexibleEarnPositionsApi(creds)
 }
 
 export async function fetchTransactions (

--- a/src/plugins/bybit/converters.ts
+++ b/src/plugins/bybit/converters.ts
@@ -112,7 +112,9 @@ export function convertTransaction (
 
   const accountCurrency = account.instrument.toUpperCase()
   const transactionCurrency = entry.paidCurrency.toUpperCase()
-  const sum = sign * Math.abs(entry.basicAmount)
+  const totalAmount = Math.abs(entry.basicAmount)
+  const feeAmount = Math.min(totalAmount, Math.abs(entry.totalFees))
+  const sum = sign * (totalAmount - feeAmount)
   const sameCurrency = transactionCurrency === accountCurrency || entry.paidAmount === 0
   const invoice = sameCurrency
     ? null
@@ -130,7 +132,7 @@ export function convertTransaction (
       account: { id: account.id },
       invoice,
       sum,
-      fee: entry.totalFees
+      fee: feeAmount === 0 ? 0 : sign * feeAmount
     }],
     merchant,
     comment: buildComment(entry)

--- a/src/plugins/bybit/converters.ts
+++ b/src/plugins/bybit/converters.ts
@@ -1,6 +1,6 @@
 import { InvalidPreferencesError } from '../../errors'
 import { AccountOrCard, AccountType, Merchant, Transaction } from '../../types/zenmoney'
-import { CardTransaction, CoinBalance } from './models'
+import { CardTransaction, CoinBalance, FlexibleEarnPosition } from './models'
 
 /** Stable id of the single USD Bybit Card account. */
 export const BYBIT_CARD_AGGREGATE_ACCOUNT_ID = 'bybit_card'
@@ -47,20 +47,31 @@ export function parseCardBalanceCoinsList (raw: string): Set<string> {
 export function createAggregatedAccount (
   balances: CoinBalance[],
   cardBalanceCoins: Set<string>,
-  convertUsdtValues: Map<string, number>
+  convertUsdtValues: Map<string, number>,
+  flexibleEarnPositions: FlexibleEarnPosition[] = []
 ): AccountOrCard {
   // USD fiat in Funding is taken 1:1 (it has no entry in the Convert coin list).
   // Every other allowed coin uses Bybit's own "one-click" USDT-worth value (`uBalance`)
   // so the aggregated balance matches what the Bybit Card UI displays.
   let usdSum = 0
   for (const b of balances) {
-    if (!cardBalanceCoins.has(b.coin)) {
+    const coin = b.coin.toUpperCase()
+    if (!cardBalanceCoins.has(coin)) {
       continue
     }
-    if (b.coin === 'USD') {
+    if (coin === 'USD') {
       usdSum += b.transferBalance
     } else {
-      usdSum += convertUsdtValues.get(b.coin) ?? 0
+      usdSum += convertUsdtValues.get(coin) ?? 0
+    }
+  }
+  // With Bybit Card Auto-Earn and Auto-Deduction enabled, the redeemable part of
+  // Flexible Earn is part of the card's spending power even though Funding is 0.
+  // USDT/USDC are the only supported aggregate coins and are represented 1:1 in
+  // this USD account, matching the existing card-balance model.
+  for (const position of flexibleEarnPositions) {
+    if (cardBalanceCoins.has(position.coin.toUpperCase())) {
+      usdSum += position.availableAmount
     }
   }
   return {
@@ -100,12 +111,12 @@ export function convertTransaction (
   }
 
   const accountCurrency = account.instrument.toUpperCase()
-  const transactionCurrency = entry.transactionCurrency.toUpperCase()
+  const transactionCurrency = entry.paidCurrency.toUpperCase()
   const sum = sign * Math.abs(entry.basicAmount)
-  const sameCurrency = transactionCurrency === accountCurrency || entry.transactionAmount === 0
+  const sameCurrency = transactionCurrency === accountCurrency || entry.paidAmount === 0
   const invoice = sameCurrency
     ? null
-    : { sum: sign * Math.abs(entry.transactionAmount), instrument: transactionCurrency }
+    : { sum: sign * Math.abs(entry.paidAmount), instrument: transactionCurrency }
 
   const hold = entry.tradeStatus === '0' || entry.side === '1'
 
@@ -119,11 +130,22 @@ export function convertTransaction (
       account: { id: account.id },
       invoice,
       sum,
-      fee: 0
+      fee: entry.totalFees
     }],
     merchant,
-    comment: null
+    comment: buildComment(entry)
   }
+}
+
+function buildComment (entry: CardTransaction): string | null {
+  const details: string[] = []
+  const place = [entry.merchCity?.trim(), entry.merchCountry?.trim()].filter(Boolean).join(', ')
+
+  if (place !== '') {
+    details.push(`Place: ${place}`)
+  }
+
+  return details.length === 0 ? null : details.join('; ')
 }
 
 function buildMerchant (entry: CardTransaction): Merchant | null {

--- a/src/plugins/bybit/fetchApi.ts
+++ b/src/plugins/bybit/fetchApi.ts
@@ -2,9 +2,14 @@ import crypto from 'crypto-js'
 import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
 import { InvalidPreferencesError, TemporaryError } from '../../errors'
 import { getArray, getOptNumber, getOptString, getString } from '../../types/get'
-import { CardTransaction, CardTransactionQueryType, CoinBalance, Credentials } from './models'
+import {
+  CardTransaction,
+  CardTransactionQueryType,
+  CoinBalance,
+  Credentials,
+  FlexibleEarnPosition
+} from './models'
 
-const BASE_URL = 'https://api.bybit.com'
 const RECV_WINDOW = '20000'
 const MIN_REQUEST_INTERVAL_MS = 1500
 let lastRequestAt = 0
@@ -73,7 +78,7 @@ export function signRequest (apiSecret: string, timestamp: string, apiKey: strin
 async function callApi (creds: Credentials, request: BybitRequest): Promise<FetchResponse> {
   await waitForRequestSlot()
 
-  const { apiKey, apiSecret } = creds
+  const { apiKey, apiSecret, baseUrl } = creds
   const timestamp = Date.now().toString()
 
   let url: string
@@ -88,11 +93,11 @@ async function callApi (creds: Credentials, request: BybitRequest): Promise<Fetc
   if (request.method === 'GET') {
     const queryString = buildQueryString(request.query)
     payload = queryString
-    url = `${BASE_URL}${request.path}${queryString.length > 0 ? `?${queryString}` : ''}`
+    url = `${baseUrl}${request.path}${queryString.length > 0 ? `?${queryString}` : ''}`
   } else {
     const bodyObject = stripEmpty(request.body)
     payload = JSON.stringify(bodyObject)
-    url = `${BASE_URL}${request.path}`
+    url = `${baseUrl}${request.path}`
     options.body = bodyObject
   }
 
@@ -119,7 +124,7 @@ async function callApi (creds: Credentials, request: BybitRequest): Promise<Fetc
     const retMsg = getOptString(response.body, 'retMsg') ?? 'unknown error'
     // 10003 invalid api key, 10004 invalid sign, 33004 api key expired, 10005 permission denied
     if (retCode === 10003 || retCode === 10004 || retCode === 33004 || retCode === 10005) {
-      throw new InvalidPreferencesError(`Bybit: ${retMsg} (retCode=${retCode}). Recreate a read-only API key in Bybit Dashboard → API with Bybit Card permissions enabled.`)
+      throw new InvalidPreferencesError(`Bybit: ${retMsg} (retCode=${retCode}). Recreate a read-only API key in Bybit Dashboard → API with Bybit Card, Earn, Wallet, and Exchange History permissions enabled.`)
     }
     // 10006 / 10018 rate-limit / ip ban
     if (retCode === 10006 || retCode === 10018) {
@@ -195,6 +200,25 @@ export async function fetchConvertCoinUsdtValues (creds: Credentials): Promise<M
   return values
 }
 
+export async function fetchFlexibleEarnPositions (creds: Credentials): Promise<FlexibleEarnPosition[]> {
+  const response = await callApi(creds, {
+    method: 'GET',
+    path: '/v5/earn/position',
+    query: { category: 'FlexibleSaving' }
+  })
+
+  return getArray(response.body, 'result.list').map(item => {
+    return {
+      coin: getString(item, 'coin').toUpperCase(),
+      amount: parseAmountString(item, 'amount'),
+      // availableAmount is the redeemable portion and therefore the amount that
+      // Auto-Deduction can use for card spending. Do not fall back to the total
+      // amount: it can contain frozen funds.
+      availableAmount: parseAmountString(item, 'availableAmount')
+    }
+  })
+}
+
 function parseCardTransaction (item: unknown): CardTransaction {
   return {
     txnId: getString(item, 'txnId'),
@@ -216,7 +240,8 @@ function parseCardTransaction (item: unknown): CardTransaction {
     mccCode: parseOptIntString(item, 'mccCode'),
     merchCategoryDesc: nullIfEmpty(getOptString(item, 'merchCategoryDesc')),
     pan4: nullIfEmpty(getOptString(item, 'pan4')),
-    declinedReason: nullIfEmpty(getOptString(item, 'declinedReason'))
+    declinedReason: nullIfEmpty(getOptString(item, 'declinedReason')),
+    totalFees: parseAmountString(item, 'totalFees')
   }
 }
 

--- a/src/plugins/bybit/index.ts
+++ b/src/plugins/bybit/index.ts
@@ -3,6 +3,7 @@ import {
   fetchAccounts,
   fetchAuthorizationTransactions,
   fetchConvertCoinUsdtValues,
+  fetchFlexibleEarnPositions,
   fetchFinancialTransactions,
   login
 } from './api'
@@ -18,8 +19,14 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
 
   const balances = await fetchAccounts(auth.credentials)
   const convertUsdtValues = await fetchConvertCoinUsdtValues(auth.credentials)
+  const flexibleEarnPositions = await fetchFlexibleEarnPositions(auth.credentials)
 
-  const aggregateAccount = createAggregatedAccount(balances, auth.cardBalanceCoins, convertUsdtValues)
+  const aggregateAccount = createAggregatedAccount(
+    balances,
+    auth.cardBalanceCoins,
+    convertUsdtValues,
+    flexibleEarnPositions
+  )
   if (ZenMoney.isAccountSkipped(aggregateAccount.id)) {
     return { accounts: [aggregateAccount], transactions: [] }
   }

--- a/src/plugins/bybit/models.ts
+++ b/src/plugins/bybit/models.ts
@@ -1,6 +1,7 @@
 export interface Preferences {
   apiKey: string
   apiSecret: string
+  baseUrl?: string
   startDate: string
   cardBalanceCoins: string
 }
@@ -13,6 +14,7 @@ export interface Auth {
 export interface Credentials {
   apiKey: string
   apiSecret: string
+  baseUrl: string
 }
 
 export type CardTransactionQueryType = 'SIDE_QUERY_AUTH' | 'SIDE_QUERY_FINANCIAL_ALL'
@@ -21,6 +23,12 @@ export interface CoinBalance {
   coin: string
   walletBalance: number
   transferBalance: number
+}
+
+export interface FlexibleEarnPosition {
+  coin: string
+  amount: number
+  availableAmount: number
 }
 
 // Subset of /v5/card/transaction/query-asset-records `data[]` items
@@ -47,4 +55,5 @@ export interface CardTransaction {
   merchCategoryDesc: string | null
   pan4: string | null
   declinedReason: string | null
+  totalFees: number
 }

--- a/src/plugins/bybit/preferences.xml
+++ b/src/plugins/bybit/preferences.xml
@@ -5,7 +5,7 @@
         obligatory="true"
         title="Read-only API Key"
         dialogTitle="Read-only API Key"
-        dialogMessage="Create a System-generated, Read-Only API key in Bybit Dashboard → API → Create New Key. Enable permissions: &quot;Bybit Card&quot; (required for the card transaction history endpoint), &quot;Wallet → Account Transfer / Subaccount Transfer&quot; (for the funding wallet balance probe), and &quot;Exchange → Exchange History&quot; (read-only; required by the convert coin-list endpoint that powers the aggregated USD balance). Do NOT enable trading or withdrawal permissions. Paste the API Key here."
+        dialogMessage="Create a System-generated, Read-Only API key in Bybit Dashboard → API → Create New Key. Enable permissions: &quot;Bybit Card&quot; (transaction history), &quot;Earn → Earn&quot; (redeemable Flexible Earn balance), &quot;Wallet → Account Transfer / Subaccount Transfer&quot; (Funding balance), and &quot;Exchange → Exchange History&quot; (Funding coin valuation). Do NOT enable trading or withdrawal permissions. Paste the API Key here."
         positiveButtonText="OK"
         negativeButtonText="Cancel"
         summary="|apiKey|{@s}"
@@ -20,6 +20,17 @@
         positiveButtonText="OK"
         negativeButtonText="Cancel"
         summary="||***********"
+    />
+    <EditTextPreference
+        key="baseUrl"
+        obligatory="true"
+        defaultValue="https://api.bybit.com"
+        title="Bybit API region"
+        dialogTitle="Bybit API base URL"
+        dialogMessage="Use the official API host for your Bybit account region. Examples: https://api.bybit.com, https://api.bybit.kz, https://api.bybit.eu."
+        positiveButtonText="OK"
+        negativeButtonText="Cancel"
+        summary="|baseUrl|{@s}"
     />
     <EditTextPreference
         key="startDate"
@@ -38,7 +49,7 @@
         defaultValue="USDT, USDC"
         title="Card funding coins"
         dialogTitle="Coins that fund the card"
-        dialogMessage="Comma-separated list, e.g. USDT, USDC. The plugin imports one Bybit Card account in USD (bybit_card). The account balance is the Bybit Convert uBalance for these Funding coins plus Funding USD fiat 1:1. Only USDT and USDC are allowed in this list."
+        dialogMessage="Comma-separated list, e.g. USDT, USDC. Include only stablecoins selected in Bybit Card → Paying With with Auto-Deduction enabled. The USD account balance combines their Funding value, redeemable Flexible Earn availableAmount, and Funding USD fiat 1:1. Bybit's public API does not expose the Auto-Deduction switch. Only USDT and USDC are supported."
         positiveButtonText="OK"
         negativeButtonText="Cancel"
         summary="|cardBalanceCoins|{@s}"


### PR DESCRIPTION
## What changed

- include redeemable Bybit Flexible Earn positions in the aggregated card balance
- support official regional Bybit API hosts, including Kazakhstan
- map the original paid currency and amount for card transactions
- pass Bybit-reported transaction fees through the movement model
- preserve available merchant location details in transaction comments
- document the required read-only API permissions and Auto-Deduction limitation
- add coverage for regional URL validation and Flexible Earn aggregation

## Why

Bybit Card can automatically move idle Funding assets into Flexible Earn while still allowing them to be redeemed for card payments. The existing plugin only counted Funding balances, so the ZenMoney account could show zero even when the card retained spending power. Regional Bybit accounts may also reject otherwise valid keys when requests are sent to the global API host.

## User impact

The Bybit Card balance now includes redeemable `availableAmount` for configured Auto-Deduction stablecoins, regional accounts can select their official API host, and imported transactions retain more of the currency and merchant information returned by Bybit.

## Validation

- `yarn test bybit --runInBand`
- `yarn build bybit`
- `git diff --check`

All 30 Bybit tests pass and the production bundle compiles successfully.
