### PR TITLE
fix(bnbank): migrate plugin to Iskra API

### DIFF
--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>2</build>
+    <build>4</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -1,16 +1,574 @@
-import { createDateIntervals } from '../api'
+import fetchMock from 'fetch-mock'
+import { fetchAccounts, fetchTransactions, generateDeviceID, login } from '../api'
+import { makePluginDataApi } from '../../../ZPAPI.pluginData'
+import { InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../../errors'
 
-describe('createDateIntervals', () => {
-  it('should convert date period', () => {
-    expect(
-      createDateIntervals(new Date('2018-01-01T20:45+03:00'), new Date('2018-02-05T09:00+03:00'))
-    ).toEqual(
-      [
-        [new Date('2018-01-01T20:45:00+03:00'), new Date('2018-01-11T20:44:59.000+03:00')],
-        [new Date('2018-01-11T20:45:00+03:00'), new Date('2018-01-21T20:44:59.000+03:00')],
-        [new Date('2018-01-21T20:45:00+03:00'), new Date('2018-01-31T20:44:59.000+03:00')],
-        [new Date('2018-01-31T20:45:00+03:00'), new Date('2018-02-05T09:00:00.000+03:00')]
-      ]
+const BASE_URL = 'https://bnb-mobile.bnb.by/'
+
+describe('Iskra API', () => {
+  afterEach(() => fetchMock.restore())
+
+  it('generates the UUID format used by the Iskra app', () => {
+    expect(generateDeviceID()).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+  })
+
+  it('reuses a refresh token without requesting an SMS code', async () => {
+    const pluginData = makePluginDataApi({
+      auth: { accessToken: 'old-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' }
+    })
+    global.ZenMoney = {
+      device: {
+        manufacturer: 'Zenmoney Manufacturer',
+        brand: 'zenmoney-brand',
+        model: 'Sync',
+        os: { name: 'android', version: '15' }
+      },
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 200,
+      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
+    }, { method: 'POST' })
+
+    await expect(login({})).resolves.toBe('new-access-token')
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
+    expect(pluginData.currentData.auth).toEqual({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      deviceTrustStatus: 'TRUSTED'
+    })
+    expect(pluginData.currentData.device).toMatchObject({
+      uuid: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      fingerprint: {
+        location: { latitude: '53.900000', longitude: '27.566700' },
+        deviceModel: 'samsung SM-S948B',
+        deviceName: 'SM-S948B',
+        locale: 'ru-RU',
+        timeZone: '180',
+        osName: 'Android',
+        osVersion: '16',
+        deviceDisplayData: { width: '1440', height: '3120', scale: '3.5' },
+        buildBootLoader: 'S948BXXS4AZG5',
+        buildDisplay: 'S948BXXS4AZG5',
+        buildFingerprint: 'samsung/m3qxxx/m3q:16/BP4A.251205.006/S948BXXS4AZG5:user/release-keys',
+        buildId: 'BP4A.251205.006',
+        buildRadio: 'S948BXXS4AZG5',
+        buildManufacturer: 'samsung',
+        systemFeatures: expect.arrayContaining([
+          'android.hardware.fingerprint',
+          'android.hardware.location.gps',
+          'android.hardware.nfc',
+          'android.software.secure_lock_screen'
+        ])
+      }
+    })
+    const [, fingerprintRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/fingerprint`)
+    expect(fingerprintRequest.headers).toMatchObject({
+      'user-agent': 'Android/GOOGLE/16/samsung/SM-S948B/1.8.3',
+      'accept-language': 'RU'
+    })
+    expect(JSON.parse(fingerprintRequest.body)).toMatchObject({
+      location: { latitude: '53.900000', longitude: '27.566700' },
+      deviceModel: 'samsung SM-S948B',
+      osVersion: '16',
+      buildDisplay: 'S948BXXS4AZG5'
+    })
+    expect(pluginData.saveDataRequested).toBe(true)
+  })
+
+  it('completes the captured phone verification before checking the device fingerprint', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'OnePlus', brand: 'OnePlus', model: 'NE2211', os: { version: '11' } },
+      readLine: jest.fn()
+        .mockResolvedValueOnce('111111')
+        .mockResolvedValueOnce('222222'),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp`, {
+      status: 200,
+      body: { secret: 'login-secret', validationType: 'OTP', expiredTime: 60 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp/validation`, {
+      status: 200,
+      body: { secret: 'validated-login-secret' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth`, {
+      status: 200,
+      body: {
+        actionType: 'SUCCESS_AUTHENTICATION',
+        authData: {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          deviceTrustStatus: 'NOT_TRUSTED_WITH_OTHER_TRUSTED'
+        }
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification`, {
+      status: 200,
+      body: {
+        steps: [{ type: 'PHONE', status: 'ENABLED' }],
+        policy: 'ALL_SUCCESS',
+        status: 'IN_PROGRESS'
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification/phone/otp`, {
+      status: 200,
+      body: {
+        secret: 'device-secret',
+        validationType: 'OTP',
+        expiredTime: 60,
+        creationStatus: 'NEW',
+        recipient: '+375*********',
+        recipientType: 'PHONE'
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification/phone`, {
+      status: 200,
+      body: {
+        steps: [{ type: 'PHONE', status: 'SUCCESS' }],
+        policy: 'ALL_SUCCESS',
+        status: 'SUCCESS'
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 200,
+      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
+    }, { method: 'POST' })
+
+    await expect(login({
+      phone: '+375000000000',
+      identificationNumber: 'TEST123',
+      isResident: true
+    })).resolves.toBe('access-token')
+
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(2)
+    expect(pluginData.currentData.auth).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      deviceTrustStatus: 'TRUSTED'
+    })
+    expect(fetchMock.calls().matched.map(([url]) => url)).toEqual([
+      `${BASE_URL}user/v1/auth/otp`,
+      `${BASE_URL}user/v1/auth/otp/validation`,
+      `${BASE_URL}user/v1/auth`,
+      `${BASE_URL}user/v1/devices/verification`,
+      `${BASE_URL}user/v1/devices/verification/phone/otp`,
+      `${BASE_URL}user/v1/devices/verification/phone`,
+      `${BASE_URL}user/v1/fingerprint`
+    ])
+    const [, deviceOtpRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/devices/verification/phone`)
+    expect(JSON.parse(deviceOtpRequest.body)).toEqual({ secret: 'device-secret', otp: '222222' })
+  })
+
+  it('rejects an unsupported trusted-device verification step', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn().mockResolvedValueOnce('111111'),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp`, {
+      status: 200,
+      body: { secret: 'login-secret', expiredTime: 60 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp/validation`, {
+      status: 200,
+      body: { secret: 'validated-login-secret' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth`, {
+      status: 200,
+      body: {
+        actionType: 'SUCCESS_AUTHENTICATION',
+        authData: {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          deviceTrustStatus: 'NOT_TRUSTED_WITH_OTHER_TRUSTED'
+        }
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification`, {
+      status: 200,
+      body: {
+        steps: [{ type: 'EMAIL', status: 'ENABLED' }],
+        policy: 'ALL_SUCCESS',
+        status: 'IN_PROGRESS'
+      }
+    }, { method: 'POST' })
+
+    await expect(login({
+      phone: '+375000000000',
+      identificationNumber: 'TEST123',
+      isResident: true
+    })).rejects.toMatchObject({
+      message: expect.stringContaining('EMAIL')
+    })
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(1)
+  })
+
+  it('classifies an incorrect trusted-device SMS code as an invalid OTP', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn()
+        .mockResolvedValueOnce('111111')
+        .mockResolvedValueOnce('222222'),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp`, {
+      status: 200,
+      body: { secret: 'login-secret', expiredTime: 60 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp/validation`, {
+      status: 200,
+      body: { secret: 'validated-login-secret' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth`, {
+      status: 200,
+      body: {
+        actionType: 'SUCCESS_AUTHENTICATION',
+        authData: {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          deviceTrustStatus: 'NOT_TRUSTED_WITH_OTHER_TRUSTED'
+        }
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification`, {
+      status: 200,
+      body: {
+        steps: [{ type: 'PHONE', status: 'ENABLED' }],
+        policy: 'ALL_SUCCESS',
+        status: 'IN_PROGRESS'
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification/phone/otp`, {
+      status: 200,
+      body: { secret: 'device-secret', validationType: 'OTP', expiredTime: 60 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification/phone`, {
+      status: 400,
+      body: { code: 'INCORRECT_OTP', userMessage: 'Некорректный код' }
+    }, { method: 'POST' })
+
+    await expect(login({
+      phone: '+375000000000',
+      identificationNumber: 'TEST123',
+      isResident: true
+    })).rejects.toBeInstanceOf(InvalidOtpCodeError)
+  })
+
+  it('migrates a legacy synthetic fingerprint without replacing device identifiers', async () => {
+    const pluginData = makePluginDataApi({
+      auth: { accessToken: 'old-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' },
+      device: {
+        uuid: 'existing-uuid',
+        fingerprint: {
+          location: null,
+          deviceId: 'existing-device-id',
+          adsUUID: 'existing-ads-uuid'
+        }
+      }
+    })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', brand: 'zenmoney', model: 'Sync', os: { version: '9' } },
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 200,
+      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
+    }, { method: 'POST' })
+
+    await expect(login({})).resolves.toBe('new-access-token')
+
+    expect(pluginData.currentData.device).toEqual({
+      uuid: 'existing-uuid',
+      fingerprint: expect.objectContaining({
+        location: { latitude: '53.900000', longitude: '27.566700' },
+        deviceModel: 'samsung SM-S948B',
+        deviceName: 'SM-S948B',
+        deviceId: 'existing-device-id',
+        adsUUID: 'existing-ads-uuid',
+        osVersion: '16',
+        buildDisplay: 'S948BXXS4AZG5',
+        buildFingerprint: 'samsung/m3qxxx/m3q:16/BP4A.251205.006/S948BXXS4AZG5:user/release-keys'
+      })
+    })
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
+  })
+
+  it('paginates operations using the APK request contract', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({ id: `operation-${index}` }))
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-20' }], totalCount: 21 }
+    }, { method: 'POST' })
+
+    const result = await fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
     )
+
+    expect(result).toHaveLength(21)
+    const requestBodies = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)
+      .map(([, options]) => JSON.parse(options.body))
+    expect(requestBodies).toEqual([{
+      filter: {
+        date: {
+          till: '2026-07-29T00:00:00.000Z',
+          from: '2026-07-01T00:00:00.000Z'
+        },
+        productTypes: [{ id: 'card-1', type: 'CARD' }]
+      },
+      pagination: { limit: 20, offset: 0 }
+    }, {
+      filter: {
+        date: {
+          till: '2026-07-29T00:00:00.000Z',
+          from: '2026-07-01T00:00:00.000Z'
+        },
+        productTypes: [{ id: 'card-1', type: 'CARD' }]
+      },
+      pagination: { limit: 20, offset: 20 }
+    }])
+  })
+
+  it('refreshes an expired bearer token and retries a protected request once', async () => {
+    const pluginData = makePluginDataApi({
+      auth: { accessToken: 'expired-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' }
+    })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', brand: 'zenmoney', model: 'Sync', os: { version: '9' } },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
+      status: 401,
+      body: { code: 'UNAUTHORIZED' }
+    })
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
+      status: 200,
+      body: { cards: [], accounts: [], deposits: [] }
+    })
+
+    await expect(fetchAccounts('expired-access-token')).resolves.toEqual({
+      cards: [],
+      checkingAccounts: [],
+      deposits: []
+    })
+
+    const productRequests = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations/products`)
+    expect(productRequests).toHaveLength(2)
+    expect(productRequests[0][1].headers.Authorization).toBe('Bearer expired-access-token')
+    expect(productRequests[1][1].headers.Authorization).toBe('Bearer new-access-token')
+    expect(pluginData.currentData.auth).toEqual({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      deviceTrustStatus: 'TRUSTED'
+    })
+
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [], totalCount: 0 }
+    }, { method: 'POST' })
+    await fetchTransactions(
+      'expired-access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )
+    const [, operationsRequest] = fetchMock.lastCall(`${BASE_URL}product-transaction/v1/operations`)
+    expect(operationsRequest.headers.Authorization).toBe('Bearer new-access-token')
+    expect(fetchMock.calls(`${BASE_URL}user/v1/oauth/refresh`)).toHaveLength(1)
+  })
+
+  it('does not classify a product request INVALID_DATA response as invalid preferences', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 400,
+      body: { code: 'INVALID_DATA', userMessage: 'Некорректный фильтр' }
+    }, { method: 'POST' })
+
+    const promise = fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z')
+    )
+    await expect(promise).rejects.toBeInstanceOf(TemporaryError)
+    await expect(promise).rejects.not.toBeInstanceOf(InvalidPreferencesError)
+  })
+
+  it('classifies the APK incorrect-phone response as invalid preferences', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp`, {
+      status: 400,
+      body: { code: 'INCORRECT_PHONE_ERROR', userMessage: 'Некорректный номер телефона' }
+    }, { method: 'POST' })
+
+    await expect(login({
+      phone: '+375000000000',
+      identificationNumber: 'TEST123',
+      isResident: true
+    })).rejects.toBeInstanceOf(InvalidPreferencesError)
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed product arrays', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
+      status: 200,
+      body: { cards: null, accounts: [], deposits: [] }
+    })
+
+    await expect(fetchAccounts('access-token')).rejects.toBeInstanceOf(TemporaryError)
+  })
+
+  it('imports only deposits exposed by the operations service', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
+      status: 200,
+      body: { cards: [], accounts: [], deposits: [{ id: 'deposit-1' }] }
+    })
+    fetchMock.once(`${BASE_URL}deposit/v1/deposits/sync`, {
+      status: 200,
+      body: { deposits: [{ id: 'deposit-1' }, { id: 'deposit-hidden' }] }
+    }, { method: 'POST' })
+
+    await expect(fetchAccounts('access-token')).resolves.toEqual({
+      cards: [],
+      checkingAccounts: [],
+      deposits: [{ id: 'deposit-1' }]
+    })
+  })
+
+  it.each([
+    'FRAUD_BLOCKED_ERROR',
+    'MISSING_FATCA_DATA_BLOCKED_ERROR',
+    'PHOBOS_BLOCKED_ERROR',
+    'USER_AGREEMENTS_BLOCKED_ERROR',
+    'USER_AML_BLOCKED_ERROR',
+    'USER_FRAUD_BLOCKED_ERROR',
+    'USER_MANUAL_BLOCKED_ERROR',
+    'USER_OTP_BLOCKED_ERROR'
+  ])('reports the %s bank block without exposing its internal service name', async code => {
+    const pluginData = makePluginDataApi({
+      auth: { accessToken: 'old-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' }
+    })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 400,
+      body: { code, message: 'User blocked by phobos' }
+    }, { method: 'POST' })
+
+    const promise = login({})
+    await expect(promise).rejects.toMatchObject({
+      message: expect.stringContaining('Откройте приложение Iskra')
+    })
+    await expect(promise).rejects.not.toMatchObject({
+      message: expect.stringContaining('phobos')
+    })
+  })
+
+  it('rejects a malformed operations response', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { totalCount: 1 }
+    }, { method: 'POST' })
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
+  })
+
+  it('rejects a malformed operations total count', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [], totalCount: 'unknown' }
+    }, { method: 'POST' })
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
+  })
+
+  it('stops when the bank returns an empty page before totalCount is reached', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [], totalCount: 1 }
+    }, { method: 'POST' })
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
   })
 })

--- a/src/plugins/bnbank/__tests__/converters/accounts.test.js
+++ b/src/plugins/bnbank/__tests__/converters/accounts.test.js
@@ -235,4 +235,71 @@ describe('convertAccount', () => {
 
     expect(account).toEqual(null)
   })
+
+  it('skips an Iskra product without balance currency', () => {
+    expect(convertCard({ id: 'card-1', name: 'Карта', balance: null })).toBeNull()
+  })
+
+  it('keeps two fractional digits in split Iskra money values', () => {
+    expect(convertCard({
+      id: 'card-1',
+      name: 'Карта',
+      balance: { integerPart: 10, fractionalPart: 5, currency: 'BYN', sign: 'PLUS' }
+    })).toMatchObject({ balance: 10.05 })
+  })
+
+  it('uses split Iskra money when the display amount is hidden', () => {
+    expect(convertCard({
+      id: 'card-1',
+      name: 'Карта',
+      balance: { amount: '*****', integerPart: 10, fractionalPart: 5, currency: 'BYN', sign: 'PLUS' }
+    })).toMatchObject({ balance: 10.05 })
+  })
+
+  it('skips a malformed Iskra deposit instead of treating it as a legacy account', () => {
+    expect(convertDeposit({
+      id: 'deposit-1',
+      balance: { amount: '1000.00', currency: 'BYN', sign: 'PLUS' },
+      contractOpenDate: '2025-06-01',
+      contractEndDate: '2026-06-01'
+    })).toBeNull()
+  })
+
+  it('converts an Iskra deposit list item into a complete ZenMoney deposit', () => {
+    expect(convertDeposit({
+      id: 'deposit-1',
+      name: 'Верное решение',
+      balance: { amount: '1000.00', currency: 'USD', sign: 'PLUS' },
+      contractOpenDate: '2025-06-01',
+      contractEndDate: '2026-06-01',
+      interestRateType: 'FIXED',
+      currentInterestRate: '5,25',
+      maxInterestRate: null,
+      isIrrevocable: false
+    })).toEqual({
+      id: 'deposit-1',
+      type: 'deposit',
+      title: 'Депозит Верное решение',
+      currencyCode: 'USD',
+      instrument: 'USD',
+      balance: 1000,
+      syncID: ['deposit-1'],
+      startDate: new Date('2025-06-01'),
+      startBalance: 1000,
+      capitalization: true,
+      percent: 5.25,
+      endDateOffsetInterval: 'day',
+      endDateOffset: 365,
+      payoffInterval: 'month',
+      payoffStep: 1
+    })
+  })
+
+  it('skips an Iskra deposit without a valid contract period', () => {
+    expect(convertDeposit({
+      id: 'deposit-1',
+      name: 'Верное решение',
+      balance: { amount: '1000.00', currency: 'USD', sign: 'PLUS' }
+    })).toBeNull()
+  })
 })

--- a/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
@@ -1,0 +1,99 @@
+import { convertTransaction } from '../../../converters'
+
+const accounts = [{
+  id: 'card-1',
+  type: 'card',
+  instrument: 'BYN',
+  syncID: ['card-1']
+}]
+
+function makeOperation (overrides = {}) {
+  return {
+    id: 'operation-1',
+    productId: 'card-1',
+    productType: 'CARD',
+    paymentDate: '2026-07-28T12:30:00+03:00',
+    operationName: 'Покупка',
+    operationDetail: {
+      statusCode: 'EXECUTED',
+      authorizationCode: '123456'
+    },
+    operationSum: { amount: '32.15', currency: 'BYN', sign: 'MINUS' },
+    transactionSum: { amount: '10.00', currency: 'USD', sign: 'MINUS' },
+    ...overrides
+  }
+}
+
+describe('Iskra transactions', () => {
+  it('uses the amount in the account currency and keeps the foreign invoice', () => {
+    expect(convertTransaction(makeOperation(), accounts)).toMatchObject({
+      date: new Date('2026-07-28T09:30:00.000Z'),
+      movements: [{
+        account: { id: 'card-1' },
+        sum: -32.15,
+        invoice: { sum: -10, instrument: 'USD' }
+      }],
+      hold: false
+    })
+  })
+
+  it('uses the API operation type and id instead of a reusable authorization code', () => {
+    const transaction = convertTransaction(makeOperation({
+      idType: 'CARD_OPERATION',
+      operationDetail: {
+        statusCode: 'EXECUTED',
+        authorizationCode: '123456'
+      }
+    }), accounts)
+
+    expect(transaction.movements[0].id).toBe('CARD_OPERATION:operation-1')
+  })
+
+  it('parses a single fractional digit as hundredths', () => {
+    const transaction = convertTransaction(makeOperation({
+      transactionSum: {
+        integerPart: 10,
+        fractionalPart: 5,
+        currency: 'USD',
+        sign: 'MINUS'
+      }
+    }), accounts)
+
+    expect(transaction.movements[0].invoice).toEqual({ sum: -10.05, instrument: 'USD' })
+  })
+
+  it('marks only in-progress operations as holds', () => {
+    const transaction = convertTransaction(makeOperation({
+      operationDetail: { statusCode: 'IN_PROGRESS' }
+    }), accounts)
+
+    expect(transaction.hold).toBe(true)
+  })
+
+  it('skips cancelled operations', () => {
+    expect(convertTransaction(makeOperation({
+      operationDetail: { statusCode: 'CANCELLED' }
+    }), accounts)).toBeNull()
+  })
+
+  it.each(['CANCELLED', 'IN_PROGRESS'])('treats %s status as executed for non-card products', statusCode => {
+    const checkingAccounts = [{
+      id: 'account-1',
+      type: 'checking',
+      instrument: 'BYN',
+      syncID: ['account-1']
+    }]
+    const transaction = convertTransaction(makeOperation({
+      productId: 'account-1',
+      productType: 'ACCOUNT',
+      operationDetail: { statusCode },
+      operationSum: null,
+      transactionSum: { amount: '25.00', currency: 'BYN', sign: 'PLUS' }
+    }), checkingAccounts)
+
+    expect(transaction).toMatchObject({
+      movements: [{ sum: 25, invoice: null }],
+      hold: false
+    })
+  })
+})

--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -1,535 +1,274 @@
 import fetchMock from 'fetch-mock'
 import { scrape } from '..'
 import { makePluginDataApi } from '../../../ZPAPI.pluginData'
-import { generateDeviceID } from '../api'
+
+const BASE_URL = 'https://bnb-mobile.bnb.by/'
 
 describe('scrape', () => {
-  it('should hit the mocks and return results', async () => {
-    const deviceId = generateDeviceID()
-    global.ZenMoney = {
-      device_id: deviceId,
-      device: {
-        manufacturer: 'Zenmoney',
-        model: 'Sync'
-      },
-      ...makePluginDataApi({
-        deviceId
-      }).methods
-    }
-    mockLogin()
-    mockFetchAccount()
-    mockCardAccountStatement()
-    mockCardLastTransactions()
-    mockDepositAccountStatement()
+  afterEach(() => fetchMock.restore())
 
-    const result = await scrape(
-      {
-        preferences: { phone: '123456789', password: 'pass' },
-        fromDate: new Date('2018-12-27T00:00:00.000+03:00'),
-        toDate: new Date('2019-01-02T00:00:00.000+03:00')
+  it('authenticates through Iskra and converts products and operations', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      isAccountSkipped: jest.fn().mockReturnValue(false),
+      readLine: jest.fn()
+        .mockResolvedValueOnce('123456')
+        .mockResolvedValueOnce('112233')
+        .mockResolvedValueOnce('654321'),
+      ...pluginData.methods
+    }
+
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp`, {
+      status: 200,
+      body: { secret: 'otp-request-secret', expiredTime: 60, otpLength: 6 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp/validation`, {
+      status: 200,
+      body: { secret: 'validated-secret' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth`, {
+      status: 200,
+      body: {
+        actionType: 'SUCCESS_AUTHENTICATION',
+        authData: {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          deviceTrustStatus: 'NOT_TRUSTED_WITH_OTHER_TRUSTED'
+        }
       }
-    )
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification`, {
+      status: 200,
+      body: {
+        steps: [{ type: 'PHONE', status: 'ENABLED' }],
+        policy: 'ALL_SUCCESS',
+        status: 'IN_PROGRESS'
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification/phone/otp`, {
+      status: 200,
+      body: {
+        secret: 'device-verification-secret',
+        validationType: 'OTP',
+        expiredTime: 60,
+        otpLength: 6
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/devices/verification/phone`, {
+      status: 200,
+      body: {
+        steps: [{ type: 'PHONE', status: 'SUCCESS' }],
+        policy: 'ALL_SUCCESS',
+        status: 'SUCCESS'
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 200,
+      body: { referenceState: 'NEED_CREATE_UPDATE', fingerprintId: 'fingerprint-id' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference/verification`, {
+      status: 200,
+      body: {
+        secret: 'device-otp-secret',
+        validationType: 'OTP',
+        expiredTime: 60,
+        otpLength: 6
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/users/otp/validation`, {
+      status: 200,
+      body: { secret: 'device-task-id' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference`, {
+      status: 204
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
+      status: 200,
+      body: {
+        cards: [{
+          id: 'card-1',
+          name: '1-2-3',
+          balance: { amount: '125.40', currency: 'BYN', sign: 'PLUS' },
+          pan: '5355********1234'
+        }],
+        accounts: [],
+        credits: [],
+        deposits: [{
+          id: 'deposit-1',
+          name: 'Верное решение',
+          balance: { amount: '1000.00', currency: 'USD', sign: 'PLUS' }
+        }]
+      }
+    })
+    fetchMock.once(`${BASE_URL}deposit/v1/deposits/sync`, {
+      status: 200,
+      body: {
+        deposits: [{
+          id: 'deposit-1',
+          name: 'Верное решение',
+          balance: { amount: '1000.00', currency: 'USD', sign: 'PLUS' },
+          contractOpenDate: '2025-06-01',
+          contractEndDate: '2026-06-01',
+          interestRateType: 'FIXED',
+          currentInterestRate: '5.25',
+          maxInterestRate: null,
+          isIrrevocable: false
+        }]
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: {
+        operations: [{
+          id: 'operation-1',
+          idType: 'OPERATION',
+          productId: 'card-1',
+          productType: 'CARD',
+          paymentDate: '2026-07-28T12:30:00+03:00',
+          operationName: 'Оплата товаров и услуг',
+          operationDetail: {
+            operationDate: '2026-07-28T12:29:00+03:00',
+            merchantName: 'COFFEE SHOP',
+            mccCode: '5814',
+            terminalLocation: 'BLR MINSK',
+            authorizationCode: '654321',
+            statusCode: 'EXECUTED'
+          },
+          operationSum: { amount: '12.50', currency: 'BYN', sign: 'MINUS' },
+          transactionSum: { amount: '12.50', currency: 'BYN', sign: 'MINUS' }
+        }],
+        totalCount: 1
+      }
+    }, { method: 'POST' })
+
+    const result = await scrape({
+      preferences: {
+        phone: '+375000000000',
+        identificationNumber: 'TEST123',
+        isResident: 'true'
+      },
+      fromDate: new Date('2026-07-01T00:00:00Z'),
+      toDate: new Date('2026-07-29T00:00:00Z')
+    })
 
     expect(result.accounts).toEqual([{
-      balance: 7.4,
-      cardHash: '8dkwk_a5l1A0nOffbenDdrrv14VyBN2YY1PeYsU8d2c5ZSpRKcZoj-dDd6aUt-TVBvIYmbwzA2l7Dv6aT1aFqL',
-      currencyCode: '933',
-      id: '2007500000000000',
+      id: 'card-1',
+      type: 'card',
+      title: '1-2-3',
+      currencyCode: 'BYN',
       instrument: 'BYN',
-      rkcCode: '004',
-      syncID: ['2007500000000000', '0000'],
-      title: 'Личные, BYN - Maxima Plus',
-      type: 'card'
+      balance: 125.4,
+      syncID: ['card-1', '1234']
     }, {
-      balance: 865.23,
-      capitalization: true,
-      currencyCode: '840',
-      endDateOffset: 182,
-      endDateOffsetInterval: 'day',
-      id: '1100000000000000',
-      instrument: 'USD',
-      payoffInterval: 'month',
-      payoffStep: 1,
-      percent: 2.25,
-      rkcCode: '765',
-      startDate: new Date('2018-12-13T21:00:00.000Z'),
-      syncID: ['1100000000000000'],
+      id: 'deposit-1',
+      type: 'deposit',
       title: 'Депозит Верное решение',
-      type: 'deposit'
+      currencyCode: 'USD',
+      instrument: 'USD',
+      balance: 1000,
+      syncID: ['deposit-1'],
+      startDate: new Date('2025-06-01'),
+      startBalance: 1000,
+      capitalization: true,
+      percent: 5.25,
+      endDateOffsetInterval: 'day',
+      endDateOffset: 365,
+      payoffInterval: 'month',
+      payoffStep: 1
     }])
-
-    expect(result.transactions).toEqual([
-      {
-        comment: null,
-        date: new Date('2019-01-02T21:00:00.000Z'),
-        hold: false,
-        merchant: {
-          fullTitle: 'AWS EMEA',
-          location: null,
-          mcc: null
-        },
-        movements: [{
-          account: {
-            id: '2007500000000000'
-          },
-          fee: 0,
-          id: '939000',
-          invoice: {
-            instrument: 'USD',
-            sum: -0.64
-          },
-          sum: -1.4
-        }]
+    expect(result.transactions).toEqual([{
+      date: new Date('2026-07-28T09:29:00Z'),
+      movements: [{
+        id: 'OPERATION:operation-1',
+        account: { id: 'card-1' },
+        invoice: null,
+        sum: -12.5,
+        fee: 0
+      }],
+      merchant: {
+        title: 'COFFEE SHOP',
+        mcc: 5814,
+        city: 'MINSK',
+        country: 'BLR',
+        location: null
       },
-      {
-        comment: 'Списание по операции ПЦ \'Оплата услуг в ИБ\' ',
-        date: new Date('2019-01-06T21:00:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '2007500000000000'
-          },
-          fee: 0,
-          id: '161000',
-          invoice: null,
-          sum: -2.17
-        }]
-      },
-      {
-        comment: 'Списание по операции ПЦ \'Оплата услуг в ИБ\' ',
-        date: new Date('2019-01-08T21:00:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '2007500000000000'
-          },
-          fee: 0,
-          id: '163000',
-          invoice: null,
-          sum: -2.16
-        }]
-      },
-      {
-        comment: 'Списание по операции ПЦ \'Оплата услуг в ИБ\' ',
-        date: new Date('2019-01-08T21:00:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '2007500000000000'
-          },
-          fee: 0,
-          id: '957000',
-          invoice:
-            {
-              instrument: 'USD',
-              sum: -200
-            },
-          sum: -437
-        }]
-      },
-      {
-        comment: null,
-        date: new Date('2019-01-08T21:00:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '1100000000000000'
-          },
-          fee: 0,
-          id: null,
-          invoice: null,
-          sum: 200
-        }]
-      },
-      {
-        comment: null,
-        date: new Date('2019-01-08T21:00:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '1100000000000000'
-          },
-          fee: 0,
-          id: null,
-          invoice: null,
-          sum: 206
-        }]
-      },
-      {
-        comment: 'Зачисление дохода от предпринимательской деятельности',
-        date: new Date('2019-01-09T07:38:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '2007500000000000'
-          },
-          fee: 0,
-          id: null,
-          invoice: null,
-          sum: 3000
-        }]
-      },
-      {
-        comment: null,
-        date: new Date('2019-01-09T21:00:00.000Z'),
-        hold: false,
-        merchant: null,
-        movements: [{
-          account: {
-            id: '1100000000000000'
-          },
-          fee: 0,
-          id: null,
-          invoice: null,
-          sum: 0.02
-        }]
+      comment: 'Оплата товаров и услуг',
+      hold: false
+    }])
+    expect(pluginData.currentData.auth).toEqual({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      deviceTrustStatus: 'TRUSTED'
+    })
+    expect(pluginData.currentData.device).toMatchObject({
+      uuid: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      fingerprint: {
+        deviceModel: 'samsung SM-S948B',
+        deviceName: 'SM-S948B',
+        locale: 'ru-RU'
       }
+    })
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(3)
+    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint`)).toHaveLength(1)
+    expect(pluginData.saveDataRequested).toBe(true)
+  })
+
+  it('returns skipped accounts without requesting their operations', async () => {
+    const pluginData = makePluginDataApi({
+      auth: {
+        accessToken: 'old-access-token',
+        refreshToken: 'refresh-token',
+        deviceTrustStatus: 'TRUSTED'
+      }
+    })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      isAccountSkipped: jest.fn(id => id === 'card-skipped'),
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'access-token', refreshToken: 'refresh-token' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 200,
+      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
+      status: 200,
+      body: {
+        cards: [{
+          id: 'card-active',
+          name: 'Активная карта',
+          balance: { amount: '10.00', currency: 'BYN', sign: 'PLUS' }
+        }, {
+          id: 'card-skipped',
+          name: 'Пропущенная карта',
+          balance: { amount: '20.00', currency: 'BYN', sign: 'PLUS' }
+        }],
+        accounts: [],
+        deposits: []
+      }
+    })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [], totalCount: 0 }
+    }, { method: 'POST' })
+
+    const result = await scrape({
+      preferences: {},
+      fromDate: new Date('2026-07-01T00:00:00Z'),
+      toDate: new Date('2026-07-29T00:00:00Z')
+    })
+
+    expect(result.accounts.map(account => account.id)).toEqual(['card-active', 'card-skipped'])
+    const [, operationsRequest] = fetchMock.lastCall(`${BASE_URL}product-transaction/v1/operations`)
+    expect(JSON.parse(operationsRequest.body).filter.productTypes).toEqual([
+      { id: 'card-active', type: 'CARD' }
     ])
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
   })
 })
-
-function mockDepositAccountStatement () {
-  fetchMock.once('https://mb.bnb.by/services/v2/products/getDepositAccountStatement', {
-    status: 200,
-    body: JSON.stringify({
-      errorInfo: {
-        error: '0',
-        errorText: 'Успешно'
-      },
-      accountType: 'Верное решение',
-      concreteType: '0',
-      operations: [
-        {
-          accountType: '0',
-          concreteType: '0',
-          accountNumber: '1100000000000000',
-          operationName: 'On-line пополнение договора (списание с БПК)',
-          transactionDate: 1547051340000,
-          operationDate: 1546981200000,
-          transactionAmount: 200.0,
-          transactionCurrency: '840',
-          operationAmount: 200.0,
-          operationCurrency: '840',
-          operationSign: '1',
-          actionGroup: 2,
-          clientName: 'Вася Пупкин',
-          operationClosingBalance: 655.6,
-          operationCode: 2
-        },
-        {
-          accountType: '0',
-          concreteType: '0',
-          accountNumber: '1100000000000000',
-          operationName: 'On-line пополнение договора (списание с БПК)',
-          transactionDate: 1547060220000,
-          operationDate: 1546981200000,
-          transactionAmount: 206.0,
-          transactionCurrency: '840',
-          operationAmount: 206.0,
-          operationCurrency: '840',
-          operationSign: '1',
-          actionGroup: 2,
-          clientName: 'Вася Пупкин',
-          operationClosingBalance: 861.6,
-          operationCode: 2
-        },
-        {
-          accountType: '0',
-          concreteType: '0',
-          accountNumber: '1100000000000000',
-          operationName: 'On-line пополнение договора (списание с БПК)',
-          transactionDate: 1547095560000,
-          operationDate: 1547067600000,
-          transactionAmount: 0.02,
-          transactionCurrency: '840',
-          operationAmount: 0.02,
-          operationCurrency: '840',
-          operationSign: '1',
-          actionGroup: 2,
-          clientName: 'Вася Пупкин',
-          operationClosingBalance: 861.62,
-          operationCode: 2
-        }
-      ],
-      accountNumber: '1100000000000000',
-      accountCurrency: 'USD'
-    }),
-    statusText: 'OK',
-    headers: { session_token: '6af71bdf-69f8-4f62-8e59-4c26ce68add1' },
-    sendAsJson: false
-  }, { method: 'POST' })
-}
-
-function mockCardLastTransactions () {
-  fetchMock.once('https://mb.bnb.by/services/v2/products/getCardTransactions', {
-    status: 200,
-    body: JSON.stringify({
-      errorInfo:
-    {
-      error: '0',
-      errorText: 'Успешно'
-    },
-      transactions:
-    [
-      {
-        identifier: '_aabb',
-        operations:
-            [
-              {
-                operationSign: '1',
-                operationId: '-',
-                transactionAmount: 0.0,
-                transactionCurrency: '840',
-                operationAmount: 0.0,
-                operationCurrency: '840',
-                operationName: 'Капитализация',
-                transType: '-',
-                operationDetail:
-                    {
-                      source: '5*** **** **** 1111',
-                      authCode: '-',
-                      mccCode: '-',
-                      paymentDate: 1547051340000,
-                      operationDescription: '-',
-                      status: 'DONE',
-                      terminalLocation: '-',
-                      operationName: '-'
-                    }
-              }
-            ]
-      }
-    ]
-    }),
-    statusText: 'OK',
-    headers: { session_token: '6af71bdf-69f8-4f62-8e59-4c26ce68add1' },
-    sendAsJson: false
-  }, { method: 'POST' })
-}
-
-function mockCardAccountStatement () {
-  fetchMock.once('https://mb.bnb.by/services/v2/products/getCardAccountFullStatement', {
-    status: 200,
-    body: JSON.stringify({
-      errorInfo: {
-        error: '0',
-        errorText: 'Успешно'
-      },
-      accountType: '1',
-      concreteType: '1',
-      operations: [
-        {
-          accountType: '1',
-          concreteType: '1',
-          accountNumber: '2007500000000000',
-          operationName: 'Зачисление дохода от предпринимательской деятельности',
-          transactionDate: 1547019480000,
-          operationDate: 1547019480000,
-          transactionAmount: 3000.0,
-          transactionCurrency: '933',
-          operationAmount: 3000.0,
-          operationCurrency: '933',
-          operationSign: '1',
-          actionGroup: 2,
-          salaryOrganizationUNP: '100123456',
-          salaryOrganizationName: 'СБОРНЫЕ СЧЕТА С БПК ФИЗИЧЕСКИХ ЛИЦ (РЕЗИДЕНТЫ)',
-          operationCode: 2
-        },
-        {
-          accountType: '1',
-          concreteType: '1',
-          accountNumber: '2007500000000000',
-          operationName: 'Покупка товаров и услуг',
-          operationPlace: 'AWS EMEA',
-          merchantId: '323670000150000',
-          transactionAuthCode: '939000',
-          transactionDate: 1546940640000,
-          operationDate: 1546462800000,
-          rrn: '892',
-          transactionAmount: 0.64,
-          transactionCurrency: '840',
-          operationAmount: 1.4,
-          operationCurrency: '933',
-          operationSign: '-1',
-          actionGroup: 1802,
-          cardPAN: '4500000040120000',
-          operationCode: 3
-        },
-        {
-          accountType: '1',
-          concreteType: '1',
-          accountNumber: '2007500000000000',
-          operationName: 'Списание по операции ПЦ \'Оплата услуг в ИБ\' ',
-          operationPlace: 'BNB - OPLATA USLUG',
-          merchantId: '1600000',
-          transactionAuthCode: '161000',
-          transactionDate: 1546938780000,
-          operationDate: 1546808400000,
-          rrn: '4321000',
-          transactionAmount: 2.17,
-          transactionCurrency: '933',
-          operationAmount: 2.17,
-          operationCurrency: '933',
-          operationSign: '-1',
-          actionGroup: 1802,
-          cardPAN: '4500000040120000',
-          operationCode: 3
-        },
-        {
-          accountType: '1',
-          concreteType: '1',
-          accountNumber: '2007500000000000',
-          operationName: 'Списание по операции ПЦ \'Оплата услуг в ИБ\' ',
-          operationPlace: 'BNB - OPLATA USLUG',
-          merchantId: '1600000',
-          transactionAuthCode: '163000',
-          transactionDate: 1547109960000,
-          operationDate: 1546981200000,
-          rrn: '9267000',
-          transactionAmount: 2.16,
-          transactionCurrency: '933',
-          operationAmount: 2.16,
-          operationCurrency: '933',
-          operationSign: '-1',
-          actionGroup: 1802,
-          cardPAN: '4500000040120000',
-          operationCode: 3
-        },
-        {
-          accountType: '1',
-          concreteType: '1',
-          accountNumber: '2007500000000000',
-          operationName: 'Списание по операции ПЦ \'Оплата услуг в ИБ\' ',
-          operationPlace: 'OPLATA USLUG - KOMPLAT BNB',
-          merchantId: '1600000',
-          transactionAuthCode: '957000',
-          transactionDate: 1547110200000,
-          operationDate: 1546981200000,
-          rrn: '9249000',
-          transactionAmount: 200.0,
-          transactionCurrency: '840',
-          operationAmount: 437.0,
-          operationCurrency: '933',
-          operationSign: '-1',
-          actionGroup: 1802,
-          cardPAN: '4500000040120000',
-          operationCode: 3
-        }
-      ],
-      incomingBalance: 122.88,
-      closingBalance: 2230.04,
-      accountNumber: '2007500000000000',
-      accountName: '200754 - Личные, BYN - \'Maxima Plus\'',
-      accountCurrency: 'BYN'
-    }),
-    statusText: 'OK',
-    headers: { session_token: '6af71bdf-69f8-4f62-8e59-4c26ce68add1' },
-    sendAsJson: false
-  }, { method: 'POST' })
-}
-
-function mockFetchAccount () {
-  fetchMock.once('https://mb.bnb.by/services/v2/products/getUserAccountsOverview', {
-    status: 200,
-    body: JSON.stringify({
-      errorInfo: { error: '0', errorText: 'Успешно' },
-      overviewResponse:
-        {
-          status: { totalStatus: 0 },
-          cardAccount: [
-            {
-              internalAccountId: '2007500000000000',
-              currency: '933',
-              agreementDate: 1458853200000,
-              openDate: 1458853200000,
-              accountNumber: 'BY41BLNB00000000000000000933',
-              cardAccountNumber: '765754000000',
-              productCode: '200754',
-              productName: 'Личные, BYN - Maxima Plus',
-              availableAmount: 108.84,
-              contractId: '18684000',
-              interestRate: 2.5,
-              accountStatus: 'OPEN',
-              cards: [
-                {
-                  cardNumberMasked: '4*** **** **** 0000',
-                  cardHash: '8dkwk_a5l1A0nOffbenDdrrv14VyBN2YY1PeYsU8d2c5ZSpRKcZoj-dDd6aUt-TVBvIYmbwzA2l7Dv6aT1aFqL',
-                  cardType: { value: 25, name: 'Visa Gold (EMV)', imageUri: 'https://alseda.by/media/public/bnb_g.png', paySysImageUri: 'https://alseda.by/media/public/credit_card_str_visa.png', textColor: 'ffffffff', paySystemName: 'Visa' },
-                  cardStatus: 'OPEN',
-                  expireDate: 1585602000000,
-                  owner: 'Vasia Pupkin',
-                  tariffName: '754 Visa Gold (EMV)',
-                  balance: 7.40,
-                  payment: '0',
-                  currency: '933',
-                  status: { code: '00' },
-                  numberDaysBeforeCardExpiry: 366,
-                  additionalCardType: 2,
-                  canChange3D: true,
-                  cardDepartmentAddress: 'г. Минск;пр. Дзержинского 104',
-                  retailCardId: 19200000
-                }],
-              bankCode: '288',
-              rkcCode: '004',
-              rkcName: 'ЦБУ №4 г.Минск',
-              percentsLeft: '2.5',
-              accountType: '1',
-              ibanNum: 'BY92BLNB30142007549330000248',
-              url: 'https://alseda.by/media/public/orange_dream.jpg',
-              canSell: false,
-              canCloseSameCurrency: false,
-              canCloseOtherCurrency: false,
-              canClose: false,
-              canRefillSameCurrency: false,
-              canRefillOtherCurrency: false,
-              canRefill: false
-            }],
-          depositAccount: [{
-            internalAccountId: '1100000000000000',
-            currency: '840',
-            openDate: 1544734800000,
-            endDate: 1560459600000,
-            accountNumber: 'BY89BLNB00000000009100000840',
-            productCode: '10062',
-            productName: 'Верное решение',
-            balanceAmount: 865.23,
-            contractId: '22092000',
-            interestRate: 2.25,
-            accountStatus: 'OPEN',
-            bankCode: '288',
-            rkcCode: '765',
-            rkcName: 'Белорусский народный банк',
-            accountType: '0',
-            ibanNum: 'BY37BLNB34141100628400000043',
-            url: 'https://alseda.by/media/public/deposit_vernoe_reshenie.png',
-            canSell: false,
-            canCloseSameCurrency: true,
-            canCloseOtherCurrency: false,
-            canClose: true,
-            canRefillSameCurrency: false,
-            canRefillOtherCurrency: true,
-            canRefill: true,
-            plannedEndDate: 1560459600000,
-            bare: false
-          }]
-        }
-    }),
-    statusText: 'OK',
-    headers: { session_token: '6af71bdf-69f8-4f62-8e59-4c26ce68add1' },
-    sendAsJson: false
-  }, { method: 'POST' })
-}
-
-function mockLogin () {
-  fetchMock.once('https://mb.bnb.by/services/v2/session/login', {
-    status: 200,
-    body: JSON.stringify({ errorInfo: { error: '0', errorText: 'Успешно' }, sessionToken: '6af71bdf-69f8-4f62-8e59-4c26ce68add1' }),
-    statusText: 'OK',
-    sendAsJson: false
-  }, { method: 'POST' })
-}

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -1,268 +1,679 @@
-import { flatMap } from 'lodash'
-import { createDateIntervals as commonCreateDateIntervals } from '../../common/dateUtils'
 import { fetchJson } from '../../common/network'
 import { generateRandomString } from '../../common/utils'
-import { card, deposit, checking } from './converters'
-import { TemporaryError } from '../../errors'
+import { InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../errors'
 
-const BASE_URL = 'https://mb.bnb.by/services/v2/'
-const APP_VERSION = '1.56.1'
+const BASE_URL = 'https://bnb-mobile.bnb.by/'
+const APP_VERSION = '1.8.3'
+const PAGE_SIZE = 20
+const DEVICE_KEY = 'device'
+const AUTH_KEY = 'auth'
+const TRUSTED_DEVICE_STATUS = 'TRUSTED'
+const DEVICE_VERIFICATION_POLICY = 'ALL_SUCCESS'
+const DEVICE_VERIFICATION_SUCCESS = 'SUCCESS'
+const REFERENCE_DEVICE = Object.freeze({
+  manufacturer: 'samsung',
+  brand: 'samsung',
+  model: 'SM-S948B',
+  osVersion: '16',
+  buildDisplay: 'S948BXXS4AZG5',
+  buildId: 'BP4A.251205.006',
+  product: 'm3qxxx',
+  device: 'm3q'
+})
+const REFERENCE_BUILD_FINGERPRINT = `${REFERENCE_DEVICE.manufacturer}/${REFERENCE_DEVICE.product}/${REFERENCE_DEVICE.device}:${REFERENCE_DEVICE.osVersion}/${REFERENCE_DEVICE.buildId}/${REFERENCE_DEVICE.buildDisplay}:user/release-keys`
+const REFERENCE_DEVICE_SYSTEM_FEATURES = Object.freeze([
+  'android.hardware.audio.output',
+  'android.hardware.bluetooth',
+  'android.hardware.bluetooth_le',
+  'android.hardware.camera',
+  'android.hardware.camera.any',
+  'android.hardware.camera.autofocus',
+  'android.hardware.camera.flash',
+  'android.hardware.camera.front',
+  'android.hardware.fingerprint',
+  'android.hardware.location',
+  'android.hardware.location.gps',
+  'android.hardware.location.network',
+  'android.hardware.microphone',
+  'android.hardware.nfc',
+  'android.hardware.ram.normal',
+  'android.hardware.screen.landscape',
+  'android.hardware.screen.portrait',
+  'android.hardware.sensor.accelerometer',
+  'android.hardware.sensor.barometer',
+  'android.hardware.sensor.compass',
+  'android.hardware.sensor.gyroscope',
+  'android.hardware.sensor.light',
+  'android.hardware.sensor.proximity',
+  'android.hardware.sensor.stepcounter',
+  'android.hardware.sensor.stepdetector',
+  'android.hardware.telephony',
+  'android.hardware.telephony.gsm',
+  'android.hardware.touchscreen',
+  'android.hardware.touchscreen.multitouch',
+  'android.hardware.touchscreen.multitouch.distinct',
+  'android.hardware.touchscreen.multitouch.jazzhand',
+  'android.hardware.usb.accessory',
+  'android.hardware.usb.host',
+  'android.hardware.vulkan.compute',
+  'android.hardware.vulkan.level',
+  'android.hardware.vulkan.version',
+  'android.hardware.wifi',
+  'android.hardware.wifi.direct',
+  'android.software.app_widgets',
+  'android.software.autofill',
+  'android.software.backup',
+  'android.software.companion_device_setup',
+  'android.software.controls',
+  'android.software.cts',
+  'android.software.device_admin',
+  'android.software.home_screen',
+  'android.software.ipsec_tunnels',
+  'android.software.midi',
+  'android.software.picture_in_picture',
+  'android.software.print',
+  'android.software.secure_lock_screen',
+  'android.software.webview',
+  'com.google.android.feature.GOOGLE_BUILD',
+  'com.google.android.feature.GOOGLE_EXPERIENCE'
+])
+
+const invalidPreferenceCodes = new Set([
+  'DEVICE_LIMIT_EXCEEDED',
+  'INCORRECT_PERSONAL_NUMBER_NOT_RESIDENT',
+  'INCORRECT_PERSONAL_NUMBER_RESIDENT',
+  'INVALID_DATA',
+  'INVALID_RETAIL_USER_ERROR',
+  'INVALID_USER_DATA_ERROR',
+  'MISSING_RETAIL_USER_ERROR'
+])
+
+const invalidOtpCodes = new Set([
+  'INCORRECT_OTP',
+  'INCORRECT_OTP_LIMIT_EXCEEDED_ERROR',
+  'INVALID_OTP',
+  'OTP_ATTEMPTS_EXCEEDED',
+  'OTP_EXPIRED'
+])
+
+const blockedUserCodes = new Set([
+  'FRAUD_BLOCKED_ERROR',
+  'MISSING_FATCA_DATA_BLOCKED_ERROR',
+  'PHOBOS_BLOCKED_ERROR',
+  'USER_AGREEMENTS_BLOCKED_ERROR',
+  'USER_AML_BLOCKED_ERROR',
+  'USER_FRAUD_BLOCKED_ERROR',
+  'USER_MANUAL_BLOCKED_ERROR',
+  'USER_OTP_BLOCKED_ERROR'
+])
 
 export function generateDeviceID () {
-  return generateRandomString(16)
+  const randomHex = length => generateRandomString(length, 'abcdef0123456789')
+  return `${randomHex(8)}-${randomHex(4)}-4${randomHex(3)}-${generateRandomString(1, '89ab')}${randomHex(3)}-${randomHex(12)}`
 }
 
-async function fetchApiJson (url, options, predicate = () => true, error = (message) => console.assert(false, message)) {
-  const response = await fetchJson(BASE_URL + url, options)
-  if (predicate) {
-    validateResponse(response, response => predicate(response), error)
+function getDeviceID () {
+  let device = ZenMoney.getData(DEVICE_KEY)
+  if (!isReferenceDevice(device)) {
+    device = createDevice(device)
+    ZenMoney.setData(DEVICE_KEY, device)
+    ZenMoney.saveData()
   }
+  return device.uuid
+}
 
-  if (response.body && response.body.errorInfo && response.body.errorInfo.error !== '0' && response.body.errorInfo.errorText) {
-    const errorDescription = response.body.errorInfo.errorText
-    const errorMessage = 'Ответ банка: ' + errorDescription
-    if (errorDescription.indexOf('Некорректно введен логин или пароль') >= 0) {
-      throw new InvalidPreferencesError(errorMessage)
+function createDefaultDeviceLocation () {
+  return { latitude: '53.900000', longitude: '27.566700' }
+}
+
+function isDeviceLocationUsable (location) {
+  const latitude = Number(location?.latitude)
+  const longitude = Number(location?.longitude)
+  return location != null &&
+    typeof location === 'object' &&
+    typeof location.latitude === 'string' && location.latitude.length > 0 &&
+    typeof location.longitude === 'string' && location.longitude.length > 0 &&
+    Number.isFinite(latitude) && latitude >= -90 && latitude <= 90 &&
+    Number.isFinite(longitude) && longitude >= -180 && longitude <= 180
+}
+
+function getDeviceOsVersion () {
+  return REFERENCE_DEVICE.osVersion
+}
+
+function isReferenceDevice (device) {
+  const fingerprint = device?.fingerprint
+  return Boolean(device?.uuid && fingerprint &&
+    isDeviceLocationUsable(fingerprint.location) &&
+    fingerprint.deviceModel === `${REFERENCE_DEVICE.manufacturer} ${REFERENCE_DEVICE.model}` &&
+    fingerprint.deviceName === REFERENCE_DEVICE.model &&
+    fingerprint.osVersion === REFERENCE_DEVICE.osVersion &&
+    fingerprint.locale === 'ru-RU' &&
+    fingerprint.deviceDisplayData?.width === '1440' &&
+    fingerprint.deviceDisplayData?.height === '3120' &&
+    fingerprint.deviceDisplayData?.scale === '3.5' &&
+    fingerprint.buildBootLoader === REFERENCE_DEVICE.buildDisplay &&
+    fingerprint.buildDisplay === REFERENCE_DEVICE.buildDisplay &&
+    fingerprint.buildFingerprint === REFERENCE_BUILD_FINGERPRINT &&
+    fingerprint.buildId === REFERENCE_DEVICE.buildId &&
+    fingerprint.buildRadio === REFERENCE_DEVICE.buildDisplay &&
+    fingerprint.buildManufacturer === REFERENCE_DEVICE.manufacturer &&
+    Array.isArray(fingerprint.systemFeatures) && fingerprint.systemFeatures.length > 0)
+}
+
+function createDevice (savedDevice) {
+  savedDevice = savedDevice || {}
+  const savedFingerprint = savedDevice?.fingerprint || {}
+  const { manufacturer, model, osVersion, buildDisplay, buildId } = REFERENCE_DEVICE
+
+  return {
+    uuid: savedDevice.uuid || generateDeviceID(),
+    fingerprint: {
+      location: isDeviceLocationUsable(savedFingerprint.location)
+        ? savedFingerprint.location
+        : createDefaultDeviceLocation(),
+      deviceModel: `${manufacturer} ${model}`,
+      deviceName: model,
+      deviceId: savedFingerprint.deviceId || generateRandomString(16, 'abcdef0123456789'),
+      locale: 'ru-RU',
+      timeZone: '180',
+      osName: 'Android',
+      osVersion,
+      deviceDisplayData: {
+        width: '1440',
+        height: '3120',
+        scale: '3.5'
+      },
+      buildBootLoader: buildDisplay,
+      buildDisplay,
+      buildFingerprint: REFERENCE_BUILD_FINGERPRINT,
+      buildId,
+      buildRadio: buildDisplay,
+      buildManufacturer: manufacturer,
+      systemFeatures: [...REFERENCE_DEVICE_SYSTEM_FEATURES],
+      simInfo: typeof savedFingerprint.simInfo === 'string' ? savedFingerprint.simInfo : '',
+      adsUUID: savedFingerprint.adsUUID || generateDeviceID()
     }
-    if (errorDescription.indexOf('Для авторизации на устройстве необходимо ввести код, отправленный на доверенное устройство') >= 0) {
-      return response
-    }
-    throw new TemporaryError(errorMessage)
   }
+}
+
+function getDeviceFingerprint () {
+  getDeviceID()
+  return ZenMoney.getData(DEVICE_KEY).fingerprint
+}
+
+function getUserAgent () {
+  return `Android/GOOGLE/${getDeviceOsVersion()}/${REFERENCE_DEVICE.brand}/${REFERENCE_DEVICE.model}/${APP_VERSION}`
+}
+
+function getErrorMessage (response) {
+  return response.body?.userMessage || response.body?.message || response.statusText || `HTTP ${response.status}`
+}
+
+function throwApiError (response, url, context) {
+  const code = response.body?.code || response.body?.serverCode || response.body?.errorCode
+  const bankMessage = getErrorMessage(response)
+  const message = `Ответ банка: ${bankMessage}`
+
+  if ([
+    'user/v1/auth/otp/validation',
+    'user/v1/devices/verification/phone',
+    'user/v1/users/otp/validation'
+  ].includes(url) && invalidOtpCodes.has(code)) {
+    throw new InvalidOtpCodeError(message)
+  }
+  if (url === 'user/v1/auth/otp' && code === 'INCORRECT_PHONE_ERROR') {
+    throw new InvalidPreferencesError(message)
+  }
+  if (url === 'user/v1/auth' && invalidPreferenceCodes.has(code)) {
+    throw new InvalidPreferencesError(message)
+  }
+  if (blockedUserCodes.has(code)) {
+    throw new TemporaryError('BNB Iskra заблокировал доступ к данным. Откройте приложение Iskra и выполните указанные там действия или обратитесь в поддержку BNB, затем повторите синхронизацию.')
+  }
+  if (code === 'DEVICE_VERIFICATION_TIMEOUT') {
+    throw new TemporaryError('Время подтверждения доверенного устройства истекло. Повторите синхронизацию и запросите новый SMS-код.')
+  }
+  throw new TemporaryError(`${context}. ${message}`)
+}
+
+async function fetchApi (url, options = {}) {
+  const response = await fetchJson(BASE_URL + url.replace(/^\//, ''), {
+    ...options,
+    headers: {
+      uuid: getDeviceID(),
+      time: new Date().toISOString(),
+      'accept-language': 'RU',
+      'user-agent': getUserAgent(),
+      ...options.headers
+    },
+    sanitizeRequestLog: {
+      ...options.sanitizeRequestLog,
+      headers: {
+        Authorization: true,
+        ...options.sanitizeRequestLog?.headers
+      },
+      body: {
+        ...options.sanitizeRequestLog?.body
+      }
+    }
+  })
 
   return response
 }
 
-function validateResponse (response, predicate, error) {
-  if (!predicate || !predicate(response)) {
-    error('non-successful response')
-  }
-}
-
-export async function login (phone, password) {
-  if (typeof ZenMoney.trustCertificates === 'function') {
-    ZenMoney.trustCertificates([
-      `-----BEGIN CERTIFICATE-----
-MIIGSTCCBTGgAwIBAgIMdSTTalkelmYt8TryMA0GCSqGSIb3DQEBCwUAMFUxCzAJ
-BgNVBAYTAkJFMRkwFwYDVQQKExBHbG9iYWxTaWduIG52LXNhMSswKQYDVQQDEyJH
-bG9iYWxTaWduIEdDQyBSNiBBbHBoYVNTTCBDQSAyMDIzMB4XDTI1MDUxNjA2NTUz
-MVoXDTI2MDYxNzA2NTUzMFowEzERMA8GA1UEAwwIKi5ibmIuYnkwggEiMA0GCSqG
-SIb3DQEBAQUAA4IBDwAwggEKAoIBAQDPM3/YX0sPYaLUZsnOci6POa+VP/3jkorC
-977rZCEk9XI4dfHbXoidVEOSD9ygnIcAaGW5kWp+QwGUz4la0U9Z4D7IotVg/R8b
-QCupOV6aOpJxkA+LGl9VaRsxDiI1a5DLcS9jv2pi+XiPGbgpSwuH3zpvhsQTc2Nj
-yaS4goGWjTH0yPG/OEtpusWogiMV9r8qafJDWJcU2X+LLz9ifLNtp/VOeTYj4rIX
-vjvRCa1FqX1yKRONpgoBrPnrXvkuhsVIK+vr+F54yuTF+9cxhmXnbRFtsUE+5hFN
-6xqVfEkal+4IrBwux5zsKkBMAUIxcIyT9kiuBnZ6FKacWWb2rlnZAgMBAAGjggNZ
-MIIDVTAOBgNVHQ8BAf8EBAMCBaAwDAYDVR0TAQH/BAIwADCBmQYIKwYBBQUHAQEE
-gYwwgYkwSQYIKwYBBQUHMAKGPWh0dHA6Ly9zZWN1cmUuZ2xvYmFsc2lnbi5jb20v
-Y2FjZXJ0L2dzZ2NjcjZhbHBoYXNzbGNhMjAyMy5jcnQwPAYIKwYBBQUHMAGGMGh0
-dHA6Ly9vY3NwLmdsb2JhbHNpZ24uY29tL2dzZ2NjcjZhbHBoYXNzbGNhMjAyMzBX
-BgNVHSAEUDBOMAgGBmeBDAECATBCBgorBgEEAaAyCgEDMDQwMgYIKwYBBQUHAgEW
-Jmh0dHBzOi8vd3d3Lmdsb2JhbHNpZ24uY29tL3JlcG9zaXRvcnkvMEQGA1UdHwQ9
-MDswOaA3oDWGM2h0dHA6Ly9jcmwuZ2xvYmFsc2lnbi5jb20vZ3NnY2NyNmFscGhh
-c3NsY2EyMDIzLmNybDAbBgNVHREEFDASgggqLmJuYi5ieYIGYm5iLmJ5MB0GA1Ud
-JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBS9BbfzipM8c8t5
-+g+FEqF3lhiRdDAdBgNVHQ4EFgQUAm5xfUxljla7HefOKdrBeGnGH/kwggF8Bgor
-BgEEAdZ5AgQCBIIBbASCAWgBZgB1AGQRxGykEuyniRyiAi4AvKtPKAfUHjUnq+r+
-1QPJfc3wAAABltfgecIAAAQDAEYwRAIgXluD26yEOIP3BOZE3npInFtbOgQAoPsG
-Nrpe6xfic/kCICuvOfQZJy3dNemtjW0Vhleocrrkk+bMMYglesSNcUlFAHYAyzj3
-FYl8hKFEX1vB3fvJbvKaWc1HCmkFhbDLFMMUWOcAAAGW1+B4WAAABAMARzBFAiEA
-8/Rc5cR/3Oi+vEGQPMVGzp63XEXmtx4iWIpN76iHlo4CIGiAzeTE/zhMwlIi4Pag
-yeawv0g7bzMBzin8A41zFvzGAHUASZybad4dfOz8Nt7Nh2SmuFuvCoeAGdFVUvvp
-6ynd+MMAAAGW1+B58wAABAMARjBEAiAHcgmp92tQC0+ceZKgr1EZbZt5MhSoo8lj
-JHoNq4/P/QIgTbHF18gVGfyYlNcLJf2msPzVu0OvHCf/QsuCD0kxMV4wDQYJKoZI
-hvcNAQELBQADggEBAICzH136Tzh1BrZq73Dghh0xk0PUk+7YOHntuiiE24ZfZpXx
-uvG2htXQo2UQD7qYOsg6CcPL+//ZsdrVe8dHcX7uxI30PDxwZ44KMplIKUR+VhZV
-usARc/Gmja10Iw2zQ7macNzXig9WzFKVmgZS8WyQ9lHmdhyYHBoUMQpi9yr6d/B6
-Ios1mr50fiZqyWn6nQxVY86QKb4R8Mrewl4+ClCV19VB6k+f6Jo8+Bylmm0awcCw
-tja9AP434+ezEwx2DIyZ3NpRBYT/f/qgyNENE5jSIS2mtqIGeRVH7peZfclfzPdo
-2y75S/O0e2tuBMBVLuEJMrPoKbV6rSApHfqoCa4=
------END CERTIFICATE-----`
-    ])
-  }
-
-  let login = (phone || '').trim()
-  if (!login) { throw new InvalidPreferencesError('Некорректный логин или номер телефона') }
-  if (/\+\d+/.test(login)) {
-    login = login.substring(1)
-  }
-
-  const deviceID = ZenMoney.getData('device_id') ? ZenMoney.getData('device_id') : generateDeviceID()
-  ZenMoney.setData('device_id', deviceID)
-
-  const res = await fetchApiJson('session/login', {
-    method: 'POST',
-    body: {
-      applicID: APP_VERSION,
-      clientKind: '0',
-      browser: ZenMoney.device.manufacturer, // Build.DEVICE
-      browserVersion: `${ZenMoney.device.model} (${ZenMoney.device.manufacturer})`, // Build.MODEL + " (" + Build.PRODUCT + ")"
-      platform: 'Android',
-      platformVersion: '10',
-      agreement: true,
-      deviceUDID: deviceID,
-      login,
-      password
-    },
-    sanitizeRequestLog: { body: { login: true, password: true } }
-  }, response => response.success || (response.body.errorInfo && response.body.errorInfo.error === '10027'), message => new TemporaryError(message))
-
-  if (res.body.errorInfo && res.body.errorInfo.error === '10027') {
-    // SMS-code confirmation needed
-    const smsCode = await ZenMoney.readLine('Подтвердите вход из приложения BNB Bank, после чего введите код из СМС', {
-      time: 30000
-    })
-    if (!smsCode) {
-      throw new TemporaryError('No SMS Code received')
-    }
-    const res = await fetchApiJson('session/login', {
-      method: 'POST',
-      body: {
-        applicID: APP_VERSION,
-        clientKind: '0',
-        browser: ZenMoney.device.manufacturer, // Build.DEVICE
-        browserVersion: `${ZenMoney.device.model} (${ZenMoney.device.manufacturer})`, // Build.MODEL + " (" + Build.PRODUCT + ")"
-        platform: 'Android',
-        platformVersion: '10',
-        agreement: true,
-        deviceUDID: deviceID,
-        login,
-        password,
-        confirmationData: smsCode
-      },
-      sanitizeRequestLog: { body: { login: true, password: true } }
-    }, response => response.success, message => new TemporaryError(message))
-    return res.body.sessionToken
-  }
-
-  return res.body.sessionToken
-}
-
-export async function fetchAccounts (token) {
-  console.log('>>> Загрузка списка счетов...')
-  const products = (await fetchApiJson('products/getUserAccountsOverview', {
-    method: 'POST',
-    body: {
-      cardAccount: {
-        withBalance: null
-      },
-      corpoCardAccount: {
-        withBalance: null
-      },
-      creditAccount: {},
-      currentAccount: {
-        withBalance: null
-      },
-      depositAccount: {}
-    },
-    headers: { session_token: token }
-  }, response => response.body && response.body.overviewResponse && (response.body.overviewResponse.cardAccount || response.body.overviewResponse.depositAccount || response.body.overviewResponse.currentAccount), message => new TemporaryError(message))).body.overviewResponse
-
-  let cards = []
-  let checkingAccounts = []
-  if (products.cardAccount) {
-    cards = cards.concat(products.cardAccount)
-  }
-  if (products.corpoCardAccount) {
-    cards = cards.concat(products.corpoCardAccount)
-  }
-  if (products.currentAccount) {
-    checkingAccounts = [...products.currentAccount]
-  }
-  return {
-    cards,
-    checkingAccounts,
-    deposits: products.depositAccount
-  }
-}
-
-export function createDateIntervals (fromDate, toDate) {
-  const interval = 10 * 24 * 60 * 60 * 1000 // 10 days interval for fetching data
-  const gapMs = 1000
-  return commonCreateDateIntervals({
-    fromDate,
-    toDate,
-    addIntervalToDate: date => new Date(date.getTime() + interval - gapMs),
-    gapMs
-  })
-}
-
-export async function fetchTransactions (token, accounts, fromDate, toDate = new Date()) {
-  console.log('>>> Загрузка списка транзакций...')
-  toDate = toDate || new Date()
-
-  const dates = createDateIntervals(fromDate, toDate)
-  const responses = await Promise.all(flatMap(accounts, (account) => {
-    return dates.map(dates => {
-      let url = ''
-      let accountType = ''
-      switch (account.type) {
-        case card:
-          url = 'products/getCardAccountFullStatement'
-          accountType = '1'
-          break
-        case deposit:
-          url = 'products/getDepositAccountStatement'
-          accountType = '0'
-          break
-        case checking:
-          url = 'products/getCurrentAccountStatement'
-          accountType = '5'
-          break
-        default:
-          return null
-      }
-      return fetchApiJson(url, {
-        method: 'POST',
-        headers: { session_token: token },
-        body: {
-          accountType,
-          bankCode: '288',
-          currencyCode: account.currencyCode,
-          internalAccountId: account.id,
-          reportData: {
-            from: dates[0].getTime(),
-            till: dates[1].getTime()
-          },
-          rkcCode: account.rkcCode
+async function fetchApiJson (url, options, context) {
+  let response = await fetchApi(url, options)
+  if (response.status === 401 && options?.headers?.Authorization) {
+    const savedAuth = ZenMoney.getData(AUTH_KEY)
+    const refreshedAuth = savedAuth?.refreshToken && await refreshAuth(savedAuth.refreshToken)
+    if (refreshedAuth) {
+      storeAuth({ ...savedAuth, ...refreshedAuth })
+      response = await fetchApi(url, {
+        ...options,
+        headers: {
+          ...options.headers,
+          ...authHeaders(refreshedAuth.accessToken)
         }
-      }, response => response.body)
-    })
-  }))
-  const operations = flatMap(responses, response => {
-    return flatMap(response.body.operations, d => d)
-  })
-
-  const filteredOperations = operations.filter(function (op) {
-    return op.transactionDate > fromDate
-  })
-
-  console.log(`>>> Загружено ${filteredOperations.length} операций.`)
-  return filteredOperations
+      })
+    } else {
+      clearAuth()
+    }
+  }
+  if (!response.ok) {
+    throwApiError(response, url, context)
+  }
+  return response.body
 }
 
-export async function fetchLastCardTransactions (token, account) {
-  console.log('>>> Загрузка списка последних транзакций для карты ' + account.title)
-
-  const response = await fetchApiJson('products/getCardTransactions', {
-    method: 'POST',
-    headers: { session_token: token },
-    body: {
-      cards: [
-        account.cardHash
-      ],
-      reportData: {
-        from: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).getTime(),
-        till: new Date().getTime()
-      },
-      internalAccountId: account.id
-    }
-  }, response => response.body)
-  const transactions = response.body.transactions || []
-  const operations = flatMap(transactions, t => t.operations || [])
-  for (let i = 0; i < operations.length; i++) {
-    operations[i].accountNumber = account.syncID[0]
+function normalizePhone (value) {
+  let phone = String(value || '').replace(/[^+\d]/g, '')
+  if (/^\d{9}$/.test(phone)) {
+    phone = `+375${phone}`
+  } else if (/^375\d{9}$/.test(phone)) {
+    phone = `+${phone}`
   }
+  if (!/^\+\d{7,15}$/.test(phone)) {
+    throw new InvalidPreferencesError('Введите номер телефона Iskra в международном формате, например +375000000000.')
+  }
+  return phone
+}
+
+function normalizeIdentificationNumber (value) {
+  const identificationNumber = String(value || '').replace(/\s/g, '').toUpperCase()
+  if (!identificationNumber) {
+    throw new InvalidPreferencesError('Введите личный номер резидента РБ или номер паспорта нерезидента.')
+  }
+  return identificationNumber
+}
+
+function clearAuth () {
+  ZenMoney.setData(AUTH_KEY, null)
+  ZenMoney.saveData()
+}
+
+function storeAuth ({ accessToken, refreshToken, deviceTrustStatus }) {
+  if (!accessToken || !refreshToken) {
+    throw new TemporaryError('Банк вернул неполные данные авторизации. Повторите синхронизацию позже.')
+  }
+  ZenMoney.setData(AUTH_KEY, { accessToken, refreshToken, deviceTrustStatus })
+  ZenMoney.saveData()
+}
+
+async function refreshAuth (refreshToken) {
+  const response = await fetchApi('user/v1/oauth/refresh', {
+    method: 'POST',
+    body: { refreshToken },
+    sanitizeRequestLog: { body: { refreshToken: true } },
+    sanitizeResponseLog: { body: { accessToken: true, refreshToken: true } }
+  })
+  if (!response.ok) {
+    return null
+  }
+  return response.body?.accessToken && response.body?.refreshToken ? response.body : null
+}
+
+async function requestOtp (phone) {
+  return fetchApiJson('user/v1/auth/otp', {
+    method: 'POST',
+    body: { phone },
+    sanitizeRequestLog: { body: { phone: true } },
+    sanitizeResponseLog: { body: { secret: true, recipient: true } }
+  }, 'Не удалось запросить код подтверждения')
+}
+
+async function validateOtp (secret, otp) {
+  return fetchApiJson('user/v1/auth/otp/validation', {
+    method: 'POST',
+    body: { secret, otp },
+    sanitizeRequestLog: { body: { secret: true, otp: true } },
+    sanitizeResponseLog: { body: { secret: true } }
+  }, 'Не удалось подтвердить код')
+}
+
+async function authenticate (secret, identificationNumber, isResident) {
+  return fetchApiJson('user/v1/auth', {
+    method: 'POST',
+    body: { secret, identificationNumber, isResident },
+    sanitizeRequestLog: { body: { secret: true, identificationNumber: true } },
+    sanitizeResponseLog: {
+      body: {
+        authData: {
+          accessToken: true,
+          refreshToken: true,
+          userData: true
+        },
+        msiData: { secret: true }
+      }
+    }
+  }, 'Не удалось войти в Iskra')
+}
+
+function authHeaders (accessToken) {
+  const currentAccessToken = ZenMoney.getData(AUTH_KEY)?.accessToken || accessToken
+  return { Authorization: `Bearer ${currentAccessToken}` }
+}
+
+function storeDeviceTrustStatus (deviceTrustStatus) {
+  const savedAuth = ZenMoney.getData(AUTH_KEY)
+  if (!savedAuth?.accessToken || !savedAuth.refreshToken) {
+    throw new TemporaryError('Не удалось сохранить состояние доверенного устройства. Повторите синхронизацию позже.')
+  }
+  storeAuth({ ...savedAuth, deviceTrustStatus })
+}
+
+async function requestDeviceVerification (accessToken) {
+  return fetchApiJson('user/v1/devices/verification', {
+    method: 'POST',
+    headers: authHeaders(accessToken)
+  }, 'Не удалось проверить состояние доверенного устройства')
+}
+
+async function requestDeviceVerificationOtp (accessToken, stepType) {
+  return fetchApiJson(`user/v1/devices/verification/${stepType.toLowerCase()}/otp`, {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    sanitizeResponseLog: { body: { secret: true, recipient: true } }
+  }, 'Не удалось запросить код подтверждения доверенного устройства')
+}
+
+async function validateDeviceVerificationStep (accessToken, stepType, secret, otp) {
+  return fetchApiJson(`user/v1/devices/verification/${stepType.toLowerCase()}`, {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: { secret, otp },
+    sanitizeRequestLog: { body: { secret: true, otp: true } }
+  }, 'Не удалось подтвердить доверенное устройство')
+}
+
+function validateDeviceVerificationResponse (verification) {
+  if (!verification || typeof verification !== 'object' ||
+    verification.policy !== DEVICE_VERIFICATION_POLICY ||
+    !Array.isArray(verification.steps) ||
+    typeof verification.status !== 'string') {
+    throw new TemporaryError('Банк вернул некорректное состояние подтверждения доверенного устройства. Повторите синхронизацию позже.')
+  }
+  return verification
+}
+
+async function ensureDeviceVerification (accessToken, deviceTrustStatus) {
+  if (deviceTrustStatus === TRUSTED_DEVICE_STATUS) return
+
+  let verification = validateDeviceVerificationResponse(await requestDeviceVerification(accessToken))
+  if (verification.status === DEVICE_VERIFICATION_SUCCESS) {
+    storeDeviceTrustStatus(TRUSTED_DEVICE_STATUS)
+    return
+  }
+  if (verification.status !== 'IN_PROGRESS') {
+    throw new TemporaryError(`Банк вернул неподдерживаемое состояние подтверждения устройства: ${verification.status}.`)
+  }
+
+  const enabledSteps = verification.steps.filter(step => step?.status === 'ENABLED')
+  if (enabledSteps.length === 0) {
+    throw new TemporaryError('Банк не вернул доступный способ подтверждения доверенного устройства.')
+  }
+
+  for (const step of enabledSteps) {
+    if (step.type !== 'PHONE') {
+      throw new TemporaryError(`Банк запросил неподдерживаемый способ подтверждения устройства: ${step.type || 'UNKNOWN'}.`)
+    }
+    const otpRequest = await requestDeviceVerificationOtp(accessToken, step.type)
+    if (!otpRequest?.secret || otpRequest.validationType !== 'OTP') {
+      throw new TemporaryError('Банк вернул неполные данные SMS-подтверждения доверенного устройства.')
+    }
+    const otp = await ZenMoney.readLine('Введите дополнительный код из SMS от BNB Iskra для подтверждения доверенного устройства', {
+      time: Math.max(Number(otpRequest.expiredTime || 0) * 1000, 30000)
+    })
+    if (!otp) {
+      throw new InvalidOtpCodeError('Код подтверждения доверенного устройства не был введен.')
+    }
+    verification = validateDeviceVerificationResponse(await validateDeviceVerificationStep(
+      accessToken,
+      step.type,
+      otpRequest.secret,
+      String(otp).trim()
+    ))
+  }
+
+  const allStepsSuccessful = verification.steps.length > 0 &&
+    verification.steps.every(step => step?.status === DEVICE_VERIFICATION_SUCCESS)
+  if (verification.status !== DEVICE_VERIFICATION_SUCCESS || !allStepsSuccessful) {
+    throw new TemporaryError('Банк не подтвердил доверенное устройство. Повторите синхронизацию позже.')
+  }
+  storeDeviceTrustStatus(TRUSTED_DEVICE_STATUS)
+}
+
+async function getDeviceFingerprintState (accessToken) {
+  return fetchApiJson('user/v1/fingerprint', {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: getDeviceFingerprint(),
+    sanitizeRequestLog: {
+      body: {
+        deviceId: true,
+        simInfo: true,
+        adsUUID: true
+      }
+    },
+    sanitizeResponseLog: { body: { fingerprintId: true } }
+  }, 'Не удалось проверить доверенное устройство')
+}
+
+async function requestDeviceFingerprintVerification (accessToken, fingerprintId) {
+  return fetchApiJson('user/v1/fingerprint/reference/verification', {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: { fingerprintId },
+    sanitizeRequestLog: { body: { fingerprintId: true } },
+    sanitizeResponseLog: { body: { secret: true, recipient: true } }
+  }, 'Не удалось запросить подтверждение устройства')
+}
+
+async function validateDeviceOtp (accessToken, secret, otp) {
+  return fetchApiJson('user/v1/users/otp/validation', {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: { secret, otp },
+    sanitizeRequestLog: { body: { secret: true, otp: true } },
+    sanitizeResponseLog: { body: { secret: true } }
+  }, 'Не удалось подтвердить код устройства')
+}
+
+async function confirmDeviceFingerprint (accessToken, taskId) {
+  await fetchApiJson('user/v1/fingerprint/reference', {
+    method: 'POST',
+    headers: authHeaders(accessToken),
+    body: { taskId },
+    sanitizeRequestLog: { body: { taskId: true } }
+  }, 'Не удалось зарегистрировать доверенное устройство')
+}
+
+async function ensureDeviceFingerprint (accessToken) {
+  const fingerprintState = await getDeviceFingerprintState(accessToken)
+  if (fingerprintState?.referenceState === 'CONFIRMED') return
+  if (fingerprintState?.referenceState !== 'NEED_CREATE_UPDATE' || !fingerprintState.fingerprintId) {
+    throw new TemporaryError('Банк вернул неизвестное состояние доверенного устройства. Повторите синхронизацию позже.')
+  }
+
+  const verification = await requestDeviceFingerprintVerification(accessToken, fingerprintState.fingerprintId)
+  if (!verification?.secret) {
+    throw new TemporaryError('Банк вернул неполные данные подтверждения устройства. Повторите синхронизацию позже.')
+  }
+  let taskId = verification.secret
+
+  if (['OTP', 'EMAIL_OTP'].includes(verification.validationType)) {
+    const otp = await ZenMoney.readLine('Введите дополнительный код из SMS от BNB Iskra для регистрации устройства', {
+      time: Math.max(Number(verification.expiredTime || 0) * 1000, 30000)
+    })
+    if (!otp) {
+      throw new InvalidOtpCodeError('Код подтверждения устройства не был введен.')
+    }
+    const otpValidation = await validateDeviceOtp(accessToken, verification.secret, String(otp).trim())
+    if (!otpValidation?.secret) {
+      throw new TemporaryError('Банк не подтвердил код регистрации устройства. Повторите синхронизацию позже.')
+    }
+    taskId = otpValidation.secret
+  } else if (!['LOCAL', 'HIDDEN'].includes(verification.validationType)) {
+    throw new TemporaryError('Банк не поддерживает доступный способ подтверждения устройства.')
+  }
+
+  await confirmDeviceFingerprint(accessToken, taskId)
+}
+
+/**
+ * Creates or refreshes an Iskra bearer session.
+ */
+export async function login ({ phone, identificationNumber, isResident }) {
+  const savedAuth = ZenMoney.getData(AUTH_KEY)
+  if (savedAuth?.refreshToken) {
+    const refreshedAuth = await refreshAuth(savedAuth.refreshToken)
+    if (refreshedAuth) {
+      const refreshedSession = { ...savedAuth, ...refreshedAuth }
+      storeAuth(refreshedSession)
+      await ensureDeviceVerification(refreshedAuth.accessToken, refreshedSession.deviceTrustStatus)
+      await ensureDeviceFingerprint(refreshedAuth.accessToken)
+      return refreshedAuth.accessToken
+    }
+    clearAuth()
+  }
+
+  phone = normalizePhone(phone)
+  identificationNumber = normalizeIdentificationNumber(identificationNumber)
+  isResident = isResident !== 'false' && isResident !== false
+
+  const otpRequest = await requestOtp(phone)
+  if (!otpRequest?.secret) {
+    throw new TemporaryError('Банк вернул неполные данные запроса SMS-кода. Повторите синхронизацию позже.')
+  }
+  const otp = await ZenMoney.readLine('Введите код из SMS от BNB Iskra', {
+    time: Math.max(Number(otpRequest.expiredTime || 0) * 1000, 30000)
+  })
+  if (!otp) {
+    throw new InvalidOtpCodeError('Код из SMS не был введен.')
+  }
+
+  const otpValidation = await validateOtp(otpRequest.secret, String(otp).trim())
+  if (!otpValidation?.secret) {
+    throw new TemporaryError('Банк не подтвердил SMS-код. Повторите синхронизацию позже.')
+  }
+  const authResponse = await authenticate(otpValidation.secret, identificationNumber, isResident)
+
+  if (authResponse?.actionType !== 'SUCCESS_AUTHENTICATION' || !authResponse.authData) {
+    throw new InvalidPreferencesError('Завершите регистрацию или подтверждение личности в приложении BNB Iskra, затем повторите синхронизацию.')
+  }
+
+  storeAuth(authResponse.authData)
+  await ensureDeviceVerification(authResponse.authData.accessToken, authResponse.authData.deviceTrustStatus)
+  await ensureDeviceFingerprint(authResponse.authData.accessToken)
+  return authResponse.authData.accessToken
+}
+
+/**
+ * Fetches the products exposed by Iskra's operations service.
+ */
+export async function fetchAccounts (accessToken) {
+  console.log('>>> Загрузка списка счетов...')
+  const products = await fetchApiJson('product-transaction/v1/operations/products', {
+    headers: authHeaders(accessToken)
+  }, 'Не удалось загрузить список счетов')
+  if (!products || typeof products !== 'object' ||
+    !Array.isArray(products.cards) ||
+    !Array.isArray(products.accounts) ||
+    !Array.isArray(products.deposits)) {
+    throw new TemporaryError('Банк вернул некорректный список счетов. Повторите синхронизацию позже.')
+  }
+
+  let deposits = []
+  if (products.deposits?.length > 0) {
+    const depositResponse = await fetchApiJson('deposit/v1/deposits/sync', {
+      method: 'POST',
+      headers: authHeaders(accessToken)
+    }, 'Не удалось загрузить данные вкладов')
+    if (!Array.isArray(depositResponse?.deposits)) {
+      throw new TemporaryError('Банк вернул некорректный список вкладов. Повторите синхронизацию позже.')
+    }
+    const operationDepositIds = new Set(products.deposits.map(deposit => deposit?.id).filter(Boolean))
+    deposits = depositResponse.deposits.filter(deposit => operationDepositIds.has(deposit?.id))
+  }
+
+  return {
+    cards: products.cards || [],
+    checkingAccounts: products.accounts || [],
+    deposits
+  }
+}
+
+function toIskraProductType (account) {
+  switch (account.type) {
+    case 'card': return 'CARD'
+    case 'checking': return 'ACCOUNT'
+    case 'deposit': return 'DEPOSIT'
+    default: return null
+  }
+}
+
+/**
+ * Fetches every operation in the requested interval using offset pagination.
+ */
+export async function fetchTransactions (accessToken, accounts, fromDate, toDate = new Date()) {
+  console.log('>>> Загрузка списка транзакций...')
+  const productTypes = accounts
+    .map(account => ({ id: account.id, type: toIskraProductType(account) }))
+    .filter(product => product.type)
+  if (productTypes.length === 0) {
+    return []
+  }
+
+  const operations = []
+  let totalCount = 0
+  do {
+    const response = await fetchApiJson('product-transaction/v1/operations', {
+      method: 'POST',
+      headers: authHeaders(accessToken),
+      body: {
+        filter: {
+          date: {
+            till: (toDate || new Date()).toISOString(),
+            from: fromDate.toISOString()
+          },
+          productTypes
+        },
+        pagination: {
+          limit: PAGE_SIZE,
+          offset: operations.length
+        }
+      }
+    }, 'Не удалось загрузить операции')
+    const responseTotalCount = Number(response?.totalCount)
+    if (!Array.isArray(response?.operations) || !Number.isInteger(responseTotalCount) || responseTotalCount < 0) {
+      throw new TemporaryError('Банк вернул некорректный список операций. Повторите синхронизацию позже.')
+    }
+    if (response.operations.length === 0 && responseTotalCount > operations.length) {
+      throw new TemporaryError('Банк вернул неполную страницу операций. Повторите синхронизацию позже.')
+    }
+    operations.push(...response.operations)
+    totalCount = responseTotalCount
+  } while (operations.length < totalCount)
 
   console.log(`>>> Загружено ${operations.length} операций.`)
   return operations

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -4,6 +4,7 @@ import { toISODateString } from '../../common/dateUtils'
 export const card = 'card'
 export const deposit = 'deposit'
 export const checking = 'checking'
+const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 export function convertCard (json) {
   return convertAccount(json, card)
@@ -18,6 +19,10 @@ export function convertCheckingAccount (json) {
 }
 
 export function convertAccount (json, accountType) {
+  if (!json || typeof json !== 'object') return null
+  if (Object.prototype.hasOwnProperty.call(json, 'id')) {
+    return convertIskraAccount(json, accountType)
+  }
   switch (accountType) {
     case card:
       if (json.cards && json.cards.length > 0) { // only loading card accounts
@@ -74,7 +79,64 @@ export function convertAccount (json, accountType) {
   }
 }
 
+function getInstrument (currency) {
+  return codeToCurrencyLookup[currency] || currency
+}
+
+function getMoneyAmount (money) {
+  if (!money) return 0
+  const displayAmount = Number.parseFloat(String(money.amount ?? '').replace(',', '.'))
+  const fractionalPart = String(money.fractionalPart ?? 0).padStart(2, '0')
+  const structuredAmount = Number.parseFloat(`${money.integerPart ?? 0}.${fractionalPart}`)
+  const amount = Number.isFinite(displayAmount) ? displayAmount : structuredAmount
+  if (!Number.isFinite(amount)) return 0
+  return money.sign === 'MINUS' ? -Math.abs(amount) : Math.abs(amount)
+}
+
+function convertIskraAccount (json, accountType) {
+  if (typeof json.id !== 'string' || !json.id ||
+    typeof json.name !== 'string' || !json.name ||
+    typeof json.balance?.currency !== 'string' || !json.balance.currency) return null
+  const currency = json.balance.currency
+  const balance = getMoneyAmount(json.balance)
+  const account = {
+    id: json.id,
+    type: accountType,
+    title: accountType === deposit ? `Депозит ${json.name}` : json.name,
+    currencyCode: currency,
+    instrument: getInstrument(currency),
+    balance,
+    syncID: [json.id]
+  }
+
+  if (typeof json.pan === 'string' && json.pan.length >= 4) {
+    account.syncID.push(json.pan.slice(-4))
+  }
+  if (accountType === deposit) {
+    const startDate = new Date(json.contractOpenDate)
+    const endDate = new Date(json.contractEndDate)
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime()) || endDate < startDate) {
+      return null
+    }
+    const rate = Number.parseFloat(String(json.currentInterestRate).replace(',', '.'))
+    Object.assign(account, {
+      startDate,
+      startBalance: balance,
+      capitalization: true,
+      percent: Number.isFinite(rate) ? rate : null,
+      endDateOffsetInterval: 'day',
+      endDateOffset: Math.round((endDate - startDate) / MS_PER_DAY),
+      payoffInterval: 'month',
+      payoffStep: 1
+    })
+  }
+  return account
+}
+
 export function convertTransaction (apiTransaction, accounts, hold = false) {
+  if (apiTransaction.productId && apiTransaction.transactionSum) {
+    return convertIskraTransaction(apiTransaction, accounts)
+  }
   if (apiTransaction.accountNumber.length > 16) {
     apiTransaction.accountNumber = apiTransaction.accountNumber.slice(-16)
   }
@@ -121,6 +183,69 @@ export function convertTransaction (apiTransaction, accounts, hold = false) {
   ].some(parser => parser(transaction, apiTransaction, account, invoice))
 
   return transaction
+}
+
+function convertIskraTransaction (apiTransaction, accounts) {
+  const account = accounts.find(account => account.id === apiTransaction.productId)
+  if (!account) return null
+
+  const detail = apiTransaction.operationDetail || {}
+  const statusCode = apiTransaction.productType === 'CARD' || account.type === card
+    ? detail.statusCode
+    : 'EXECUTED'
+  if (statusCode === 'CANCELLED') return null
+
+  const operationSum = getMoneyAmount(apiTransaction.operationSum)
+  const transactionSum = getMoneyAmount(apiTransaction.transactionSum)
+  if (operationSum === 0 && transactionSum === 0) return null
+
+  const operationInstrument = getInstrument(apiTransaction.operationSum?.currency) || account.instrument
+  const transactionInstrument = getInstrument(apiTransaction.transactionSum?.currency) || operationInstrument
+  const transactionMoney = { sum: transactionSum, instrument: transactionInstrument }
+  const operationMoney = { sum: operationSum, instrument: operationInstrument }
+  const accountMoney = [transactionMoney, operationMoney].find(money => money.instrument === account.instrument) || transactionMoney
+  const invoiceMoney = [transactionMoney, operationMoney]
+    .find(money => money !== accountMoney && money.instrument !== accountMoney.instrument)
+  const date = new Date(detail.operationDate || apiTransaction.paymentDate)
+  if (Number.isNaN(date.getTime())) return null
+  const invoice = invoiceMoney ? { sum: invoiceMoney.sum, instrument: invoiceMoney.instrument } : null
+  const merchantTitle = cleanMerchantTitle(detail.merchantName)
+  const { city, country } = parseLocation(apiTransaction)
+  const mcc = parseMcc(apiTransaction)
+  const transaction = {
+    date,
+    movements: [{
+      id: getIskraOperationId(apiTransaction, detail),
+      account: { id: account.id },
+      invoice,
+      sum: accountMoney.sum,
+      fee: 0
+    }],
+    merchant: null,
+    comment: null,
+    hold: statusCode === 'IN_PROGRESS'
+  }
+
+  if (merchantTitle) {
+    transaction.merchant = {
+      title: merchantTitle,
+      mcc,
+      city,
+      country,
+      location: null
+    }
+  }
+  if (apiTransaction.operationName && apiTransaction.operationName !== merchantTitle) {
+    transaction.comment = apiTransaction.operationName
+  }
+  return transaction
+}
+
+function getIskraOperationId (apiTransaction, detail) {
+  if (apiTransaction.id) {
+    return apiTransaction.idType ? `${apiTransaction.idType}:${apiTransaction.id}` : apiTransaction.id
+  }
+  return detail.authorizationCode || null
 }
 
 function parseCashTransfer (transaction, apiTransaction, account, invoice) {
@@ -377,7 +502,7 @@ export function transactionsUnique (array) {
 export function convertTestTransactions (apiTransactions, accounts, hold = false) {
   const transactions = []
   for (const apiTransaction of apiTransactions) {
-    const transaction = convertTransaction(apiTransaction, accounts, hold = false)
+    const transaction = convertTransaction(apiTransaction, accounts, hold)
     if (transaction) {
       transactions.push(transaction)
     }

--- a/src/plugins/bnbank/index.js
+++ b/src/plugins/bnbank/index.js
@@ -1,18 +1,13 @@
-import _ from 'lodash'
 import { adjustTransactions } from '../../common/transactionGroupHandler'
-import { fetchAccounts, fetchLastCardTransactions, fetchTransactions, login } from './api'
-import { convertCard, convertDeposit, convertCheckingAccount, convertTransaction, transactionsUnique } from './converters'
+import { fetchAccounts, fetchTransactions, login } from './api'
+import { convertCard, convertDeposit, convertCheckingAccount, convertTransaction } from './converters'
 
 export async function scrape ({ preferences, fromDate, toDate }) {
-  const token = await login(preferences.phone, preferences.password)
+  const token = await login(preferences)
   const accounts = (await fetchAccounts(token))
   const cards = accounts.cards
     .map(convertCard)
     .filter(account => account !== null)
-  let lastTransactions = []
-  for (let i = 0; i < cards.length; i++) {
-    lastTransactions = lastTransactions.concat(await fetchLastCardTransactions(token, cards[i]))
-  }
   let preparedAccounts = cards
   if (accounts.deposits) {
     const deposits = accounts.deposits
@@ -27,15 +22,13 @@ export async function scrape ({ preferences, fromDate, toDate }) {
     preparedAccounts = preparedAccounts.concat(checkingAccounts)
   }
 
-  const transactions = (await fetchTransactions(token, preparedAccounts, fromDate, toDate))
+  const accountsForTransactions = preparedAccounts
+    .filter(account => !ZenMoney.isAccountSkipped(account.id))
+  const transactions = (await fetchTransactions(token, accountsForTransactions, fromDate, toDate))
     .map(transaction => convertTransaction(transaction, preparedAccounts))
     .filter(transaction => transaction !== null)
-  lastTransactions = lastTransactions
-    .map(transaction => convertTransaction(transaction, cards, true))
-    .filter(transaction => transaction !== null)
-  const allTransactions = _.sortBy(transactionsUnique(transactions.concat(lastTransactions)), transaction => transaction.date)
   return {
     accounts: preparedAccounts,
-    transactions: adjustTransactions({ transactions: allTransactions })
+    transactions: adjustTransactions({ transactions: transactions.sort((a, b) => a.date - b.date) })
   }
 }

--- a/src/plugins/bnbank/preferences.xml
+++ b/src/plugins/bnbank/preferences.xml
@@ -3,23 +3,34 @@
     <EditTextPreference
         key="phone"
         obligatory="true"
-        title="Логин или номер телефона"
-        dialogTitle="Логин или номер телефона"
-        dialogMessage="Логин или номер телефона без плюса"
+        inputType="phone"
+        title="Номер телефона Iskra"
+        dialogTitle="Номер телефона Iskra"
+        dialogMessage="Номер телефона в международном формате, например +375000000000"
         positiveButtonText="ОК"
         negativeButtonText="Отмена"
         summary="||{@s}"
     />
     <EditTextPreference
-        key="password"
+        key="identificationNumber"
         obligatory="true"
-        inputType="textPassword"
-        title="Пароль от интернет-банка"
-        dialogTitle="Пароль от интернет-банка"
-        dialogMessage="Пароль от интернет-банка и пин-код от приложения — это разные пароли. Если вы не помните пароль от интернет-банка, восстановите его на сайте банка."
+        title="Идентификационный номер"
+        dialogTitle="Идентификационный номер"
+        dialogMessage="Для резидента РБ — идентификационный номер документа, удостоверяющего личность. Для нерезидента — номер документа."
         positiveButtonText="ОК"
         negativeButtonText="Отмена"
-        summary="||***********"
+        summary="||{@s}"
+    />
+    <ListPreference
+        key="isResident"
+        title="Резидент РБ"
+        dialogTitle="Резидент РБ"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        entries="Да|Нет"
+        entryValues="true|false"
+        defaultValue="true"
+        summary="||{@s}"
     />
     <EditTextPreference
         key="startDate"


### PR DESCRIPTION
## Summary

- migrate the BNB plugin from the retired mobile API to the current Iskra API
- persist a stable Samsung-compatible device profile and complete phone/device verification flows
- refresh expired sessions and synchronize Iskra cards, deposits, balances, and operations
- preserve account-selection behavior and harden malformed/error response handling

## Authentication and device trust

- request the login OTP and authenticate the customer
- complete server-requested device-verification steps
- request the additional fingerprint OTP only when the server reports `NEED_CREATE_UPDATE`
- reuse persisted randomized device identifiers on later runs
- redact phone, identification number, OTPs, tokens, and device identifiers from request/response logs

## Privacy

- tests use explicit synthetic phone, identity, token, OTP, account, and UUID fixtures
- the device profile contains only public Samsung reference metadata
- captured traffic, runtime preferences, credentials, and local plugin data are ignored and are not part of this branch

## Verification

- `yarn jest src/plugins/bnbank --runInBand` (67 tests passed)
- `yarn lint -- "src/plugins/bnbank/**/*.js"`
- `git diff upstream/master --check`
