### PR TITLE
[solutionbank] Устранить дублирование платы за обслуживание карточки

### DIFF
--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -293,6 +293,7 @@ describe('convertTransaction', () => {
     expect(merged[0].hold).toEqual(false)
     expect(transaction.movements[0].sum).toEqual(0.1)
     expect(transaction.movements[0].id).toEqual(transactionId('2026-06-30', '0.10', 'Зачисление на счет'))
+    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
   })
 
   it('matches money-back income when mini statement has generic income name', () => {
@@ -323,6 +324,7 @@ describe('convertTransaction', () => {
     expect(merged[0].hold).toEqual(false)
     expect(transaction.movements[0].sum).toEqual(4.09)
     expect(transaction.movements[0].id).toEqual(transactionId('2026-07-01', '4.09', 'Зачисление на счет'))
+    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
   })
 
   it('matches monthly card service fee with posted subscription fee', () => {
@@ -353,6 +355,7 @@ describe('convertTransaction', () => {
     expect(merged[0].hold).toEqual(false)
     expect(transaction.movements[0].sum).toEqual(-7.5)
     expect(transaction.movements[0].id).toEqual(transactionId('2020-01-02', '-7.50', 'Ежемесячная плата за обслуживание карточки'))
+    expect(convertTransaction(hold).movements[0].id).toEqual(convertTransaction(postedOperation).movements[0].id)
   })
 
   it('does not merge unrelated no-merchant expense operation names', () => {

--- a/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
+++ b/src/plugins/solutionbank/__tests__/converters/transactions/transactions.test.js
@@ -325,6 +325,63 @@ describe('convertTransaction', () => {
     expect(transaction.movements[0].id).toEqual(transactionId('2026-07-01', '4.09', 'Зачисление на счет'))
   })
 
+  it('matches monthly card service fee with posted subscription fee', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2020-01-02T12:34:56+03:00'),
+      transactionName: 'Ежемесячная плата за обслуживание карточки',
+      transactionCurrencyCode: '933',
+      transactionAmount: -7.5,
+      hold: true
+    }
+    const postedOperation = {
+      account_id: 'mock-account-001',
+      operationName: 'Абонентская плата',
+      operationDate: new Date('2020-01-02T12:00:00+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -7.5,
+      transactionDate: new Date('2020-01-02T12:00:00+03:00'),
+      transactionAmount: 0,
+      transactionCurrencyCode: '933',
+      hold: false
+    }
+    const merged = merge([hold], [postedOperation])
+    const transaction = convertTransaction(merged[0])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0].hold).toEqual(false)
+    expect(transaction.movements[0].sum).toEqual(-7.5)
+    expect(transaction.movements[0].id).toEqual(transactionId('2020-01-02', '-7.50', 'Ежемесячная плата за обслуживание карточки'))
+  })
+
+  it('does not merge unrelated no-merchant expense operation names', () => {
+    const hold = {
+      account_id: 'mock-account-001',
+      accountCurrencyCode: '933',
+      transactionDate: new Date('2020-01-02T12:34:56+03:00'),
+      transactionName: 'Комиссия за перевод',
+      transactionCurrencyCode: '933',
+      transactionAmount: -7.5,
+      hold: true
+    }
+    const postedOperation = {
+      account_id: 'mock-account-001',
+      operationName: 'Абонентская плата',
+      operationDate: new Date('2020-01-02T12:00:00+03:00'),
+      operationCurrencyCode: '933',
+      operationAmount: -7.5,
+      transactionDate: new Date('2020-01-02T12:00:00+03:00'),
+      transactionAmount: 0,
+      transactionCurrencyCode: '933',
+      hold: false
+    }
+    const transactions = merge([hold], [postedOperation]).map(transaction => convertTransaction(transaction))
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(transaction => transaction.hold)).toEqual([false, true])
+  })
+
   it('matches posted card operation shifted to the next bank date when merchant is exact', () => {
     const hold = {
       account_id: 'mock-account-001',

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -8,6 +8,8 @@ const CANONICAL_TRANSACTION_ID_SOURCE_FIELD = 'transactionIdSource'
 const GENERIC_ACCOUNT_INCOME_NAME = 'ЗАЧИСЛЕНИЕ НА СЧЕТ'
 const CAPITALIZATION_OPERATION_NAME_PREFIX = 'КАПИТАЛИЗАЦИЯ '
 const MONEY_BACK_OPERATION_NAME_PREFIX = 'НАЧИСЛЕНИЕ MONEY-BACK'
+const CARD_SERVICE_FEE_HOLD_NAME = 'ЕЖЕМЕСЯЧНАЯ ПЛАТА ЗА ОБСЛУЖИВАНИЕ КАРТОЧКИ'
+const CARD_SERVICE_FEE_POSTED_NAME = 'АБОНЕНТСКАЯ ПЛАТА'
 const md5 = new MD5()
 
 export function convertAccount (json) {
@@ -392,7 +394,13 @@ function normalizeOperationName (value) {
 
 function areOperationNamesCompatible (left, right) {
   return (isGenericAccountIncomeName(left) && isKnownGenericAccountIncomePeerName(right)) ||
-    (isGenericAccountIncomeName(right) && isKnownGenericAccountIncomePeerName(left))
+    (isGenericAccountIncomeName(right) && isKnownGenericAccountIncomePeerName(left)) ||
+    isCardServiceFeePair(left, right)
+}
+
+function isCardServiceFeePair (left, right) {
+  return (left === CARD_SERVICE_FEE_HOLD_NAME && right === CARD_SERVICE_FEE_POSTED_NAME) ||
+    (left === CARD_SERVICE_FEE_POSTED_NAME && right === CARD_SERVICE_FEE_HOLD_NAME)
 }
 
 function isGenericAccountIncomeName (value) {

--- a/src/plugins/solutionbank/converters.js
+++ b/src/plugins/solutionbank/converters.js
@@ -5,10 +5,12 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000
 const MERCHANT_ID_PREFIX_LENGTH = 25
 const SAFE_MERCHANT_PREFIX_MIN_LENGTH = 16
 const CANONICAL_TRANSACTION_ID_SOURCE_FIELD = 'transactionIdSource'
-const GENERIC_ACCOUNT_INCOME_NAME = 'ЗАЧИСЛЕНИЕ НА СЧЕТ'
+const GENERIC_ACCOUNT_INCOME_ID_NAME = 'Зачисление на счет'
+const GENERIC_ACCOUNT_INCOME_NAME = GENERIC_ACCOUNT_INCOME_ID_NAME.toUpperCase()
 const CAPITALIZATION_OPERATION_NAME_PREFIX = 'КАПИТАЛИЗАЦИЯ '
 const MONEY_BACK_OPERATION_NAME_PREFIX = 'НАЧИСЛЕНИЕ MONEY-BACK'
-const CARD_SERVICE_FEE_HOLD_NAME = 'ЕЖЕМЕСЯЧНАЯ ПЛАТА ЗА ОБСЛУЖИВАНИЕ КАРТОЧКИ'
+const CARD_SERVICE_FEE_HOLD_ID_NAME = 'Ежемесячная плата за обслуживание карточки'
+const CARD_SERVICE_FEE_HOLD_NAME = CARD_SERVICE_FEE_HOLD_ID_NAME.toUpperCase()
 const CARD_SERVICE_FEE_POSTED_NAME = 'АБОНЕНТСКАЯ ПЛАТА'
 const md5 = new MD5()
 
@@ -104,8 +106,20 @@ function getTransactionIdentitySource (json) {
     getDateIdValue(getFirstPresent(json.transactionDate, json.date, json.operationDate)),
     getAmountIdValue(getTransactionAmountIdValue(json)),
     getTransactionCurrencyIdValue(json),
-    getMerchantIdValue(json.merchant) || getFirstPresent(json.operationName, json.transactionName)
+    getMerchantIdValue(json.merchant) || getCanonicalOperationNameIdValue(json)
   ].map(getIdValue).join('|')
+}
+
+function getCanonicalOperationNameIdValue (json) {
+  const value = getFirstPresent(json.operationName, json.transactionName)
+  const normalizedValue = normalizeOperationName(value)
+  if (isGenericAccountIncomeName(normalizedValue) || isKnownGenericAccountIncomePeerName(normalizedValue)) {
+    return GENERIC_ACCOUNT_INCOME_ID_NAME
+  }
+  if (normalizedValue === CARD_SERVICE_FEE_HOLD_NAME || normalizedValue === CARD_SERVICE_FEE_POSTED_NAME) {
+    return CARD_SERVICE_FEE_HOLD_ID_NAME
+  }
+  return value
 }
 
 function getDuplicateIndex (json) {


### PR DESCRIPTION
## Причина

Мини-выписка и полная выписка по-разному называют одни и те же операции без мерчанта. Из-за строгого сравнения названий удержание и проведённая операция могли попадать в результат отдельно. После исчезновения записи из мини-выписки проведённая операция также могла получить новый идентификатор.

## Что изменено

- Добавлено точечное сопоставление двух банковских наименований платы за обслуживание.
- Стабилизированы идентификаторы платы за обслуживание, капитализации и money-back независимо от наличия записи в мини-выписке.
- Сохранено раздельное отображение других операций без мерчанта.
- Добавлены позитивный и негативный регрессионные тесты на полностью синтетических данных.

## Проверка

- 39 тестов SolutionBank.
- Проверка стиля изменённых файлов.
- Production-сборка плагина.
- Локальная синхронизация: соответствующая пара источников объединяется в одну операцию с одним стабильным идентификатором.

Локальные профили, ответы банка и реальные данные в коммит не включены.
