### PR TITLE
[mempool] add plugin for syncing BTC wallets via mempool.space

### DIFF
--- a/src/plugins/mempool/ZenmoneyManifest.xml
+++ b/src/plugins/mempool/ZenmoneyManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>mempool</id>
+    <company>0</company> <!-- internal zenmoney id, to be set during the merge -->
+    <description>
+        Плагин для синхронизации BTC через mempool.space.
+        Укажите адреса кошельков — адреса одного кошелька станут одним счётом.
+    </description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <api>public</api>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <codeRequired>false</codeRequired>
+</provider>

--- a/src/plugins/mempool/__tests__/api.test.ts
+++ b/src/plugins/mempool/__tests__/api.test.ts
@@ -1,0 +1,114 @@
+import { MempoolTransaction, PAGE_SIZE, Wallet } from '../models'
+
+const mockFetchAddressInfo = jest.fn()
+const mockFetchPage = jest.fn()
+
+jest.mock('../fetchApi', () => ({
+  fetchAddressInfo: mockFetchAddressInfo,
+  fetchAddressTransactionsPage: mockFetchPage
+}))
+
+function tx (txid: string, blockTime: number): MempoolTransaction {
+  return { txid, vin: [], vout: [], confirmed: true, block_time: blockTime }
+}
+
+function page (size: number, startTime: number, prefix: string): MempoolTransaction[] {
+  return Array.from({ length: size }, (_unused, index) => tx(`${prefix}${index}`, startTime - index * 3600))
+}
+
+describe('api', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchAddressInfos, fetchTransactions } = require('../api') as typeof import('../api')
+  const wallet: Wallet = { id: 'a1', title: 'Ledger_1', addresses: ['a1', 'a2'] }
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('собирает информацию по каждому адресу кошелька', async () => {
+    mockFetchAddressInfo.mockImplementation(async () => ({
+      funded_txo_sum: 1, spent_txo_sum: 0
+    }))
+    const infoByAddress = await fetchAddressInfos([wallet])
+    expect([...infoByAddress.keys()]).toEqual(['a1', 'a2'])
+  })
+
+  // Пагинация у mempool.space курсорная и описана в документации:
+  //   GET /address/:address/txs — до 50 мемпульных транзакций плюс первые 25 подтверждённых,
+  //     причём мемпульные идут первыми;
+  //   GET /address/:address/txs/chain/:last_seen_txid — по 25 подтверждённых на страницу,
+  //     новые сверху; следующая страница запрашивается по txid последней транзакции предыдущей.
+  // Проверено на живом API: у адреса с 12 транзакциями /txs отдаёт 12,
+  // а /txs/chain/<txid последней> отдаёт [].
+  it('листает страницы, пока страница полная и транзакции новее fromDate', async () => {
+    const fromDate = new Date('2020-01-01T00:00:00Z')
+    const recent = Math.floor(new Date('2024-01-01T00:00:00Z').getTime() / 1000)
+    mockFetchAddressInfo.mockResolvedValue({ funded_txo_sum: 0, spent_txo_sum: 0 })
+    mockFetchPage
+      .mockResolvedValueOnce(page(PAGE_SIZE, recent, 'p1_'))
+      .mockResolvedValueOnce(page(2, recent - 200000, 'p2_'))
+      .mockResolvedValue([])
+
+    const transactions = await fetchTransactions([{ id: 'a1', title: 'W', addresses: ['a1'] }], fromDate)
+
+    expect(mockFetchPage).toHaveBeenNthCalledWith(1, 'a1', undefined)
+    expect(mockFetchPage).toHaveBeenNthCalledWith(2, 'a1', `p1_${PAGE_SIZE - 1}`)
+    expect(transactions).toHaveLength(PAGE_SIZE + 2)
+  })
+
+  // Страницы приходят от новых к старым. Если самая старая транзакция на странице уже
+  // старше fromDate, то всё, что лежит за ней, — тем более старое, и листать дальше незачем.
+  // Здесь вся страница за январь 2024, а fromDate — июнь 2024: хватает одного запроса.
+  it('останавливается, когда самая старая транзакция страницы старше fromDate', async () => {
+    const fromDate = new Date('2024-06-01T00:00:00Z')
+    const old = Math.floor(new Date('2024-01-01T00:00:00Z').getTime() / 1000)
+    mockFetchPage.mockResolvedValueOnce(page(PAGE_SIZE, old, 'old_'))
+
+    const transactions = await fetchTransactions([{ id: 'a1', title: 'W', addresses: ['a1'] }], fromDate)
+
+    expect(mockFetchPage).toHaveBeenCalledTimes(1)
+    expect(transactions).toEqual([])
+  })
+
+  it('страница целиком из неподтверждённых не даёт курсора для следующей', async () => {
+    // /txs отдаёт мемпульные транзакции первыми, а /txs/chain/:txid ищет курсор только
+    // в подтверждённой истории. Неподтверждённый txid в роли курсора — заведомый промах.
+    const fromDate = new Date('2020-01-01T00:00:00Z')
+    const pending: MempoolTransaction[] = Array.from({ length: PAGE_SIZE }, (_unused, index) => ({
+      txid: `pending${index}`, vin: [], vout: [], confirmed: false, block_time: null
+    }))
+    mockFetchPage.mockResolvedValueOnce(pending).mockResolvedValue([])
+
+    const transactions = await fetchTransactions([{ id: 'a1', title: 'W', addresses: ['a1'] }], fromDate)
+
+    expect(mockFetchPage).toHaveBeenCalledTimes(1)
+    expect(transactions).toEqual([])
+  })
+
+  it('одна транзакция на двух адресах кошелька возвращается один раз', async () => {
+    const fromDate = new Date('2020-01-01T00:00:00Z')
+    const time = Math.floor(new Date('2024-01-01T00:00:00Z').getTime() / 1000)
+    mockFetchPage
+      .mockResolvedValueOnce([tx('shared', time)])
+      .mockResolvedValueOnce([tx('shared', time)])
+
+    const transactions = await fetchTransactions([wallet], fromDate)
+
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0].txid).toBe('shared')
+  })
+
+  // Страница приходит целиком и может содержать транзакции по обе стороны от fromDate,
+  // поэтому мало остановить пагинацию — лишнее надо ещё и выбросить. Пример здесь:
+  //   fromDate — 1 июня 2024
+  //   fresh    — 1 июля 2024   → новее, забираем
+  //   stale    — 1 января 2024 → старее, выбрасываем
+  it('отсекает транзакции старше fromDate', async () => {
+    const fromDate = new Date('2024-06-01T00:00:00Z')
+    const fresh = Math.floor(new Date('2024-07-01T00:00:00Z').getTime() / 1000)
+    const stale = Math.floor(new Date('2024-01-01T00:00:00Z').getTime() / 1000)
+    mockFetchPage.mockResolvedValueOnce([tx('fresh', fresh), tx('stale', stale)])
+
+    const transactions = await fetchTransactions([{ id: 'a1', title: 'W', addresses: ['a1'] }], fromDate)
+
+    expect(transactions.map(t => t.txid)).toEqual(['fresh'])
+  })
+})

--- a/src/plugins/mempool/__tests__/converters/accounts.test.ts
+++ b/src/plugins/mempool/__tests__/converters/accounts.test.ts
@@ -1,0 +1,43 @@
+import { AccountType } from '../../../../types/zenmoney'
+import { convertAccounts } from '../../converters'
+import { MempoolAddressInfo, Wallet } from '../../models'
+
+function info (funded: number, spent: number): MempoolAddressInfo {
+  return { funded_txo_sum: funded, spent_txo_sum: spent }
+}
+
+describe('convertAccounts', () => {
+  it('складывает баланс всех адресов кошелька и переводит сатоши в μBTC', () => {
+    const wallet: Wallet = { id: 'addr1', title: 'Ledger_1', addresses: ['addr1', 'addr2'] }
+    const infoByAddress = new Map([
+      ['addr1', info(150000000, 50000000)],
+      ['addr2', info(25000000, 0)]
+    ])
+    expect(convertAccounts([wallet], infoByAddress)).toEqual([{
+      id: 'addr1',
+      type: AccountType.checking,
+      title: 'Ledger_1',
+      instrument: 'μBTC',
+      balance: 1250000,
+      syncIds: ['addr1', 'addr2']
+    }])
+  })
+
+  it('адрес без данных считается нулевым и не ломает баланс', () => {
+    const wallet: Wallet = { id: 'addr1', title: 'Bitcoin', addresses: ['addr1', 'addr2'] }
+    const infoByAddress = new Map([['addr1', info(100000000, 0)]])
+    expect(convertAccounts([wallet], infoByAddress)[0].balance).toBe(1000000)
+  })
+
+  it('каждый кошелёк даёт свой счёт', () => {
+    const wallets: Wallet[] = [
+      { id: 'a', title: 'Ledger_1', addresses: ['a'] },
+      { id: 'b', title: 'Ledger_2', addresses: ['b'] }
+    ]
+    const infoByAddress = new Map([
+      ['a', info(50000000, 0)],
+      ['b', info(100000000, 0)]
+    ])
+    expect(convertAccounts(wallets, infoByAddress).map(account => account.balance)).toEqual([500000, 1000000])
+  })
+})

--- a/src/plugins/mempool/__tests__/converters/transactions.test.ts
+++ b/src/plugins/mempool/__tests__/converters/transactions.test.ts
@@ -1,0 +1,239 @@
+import { convertTransactions } from '../../converters'
+import { MempoolTransaction, MempoolVin, MempoolVout, Wallet } from '../../models'
+
+const BLOCK_TIME = 1700000000
+
+function out (address: string | null, value: number): MempoolVout {
+  return { scriptpubkey_address: address, value }
+}
+
+function inp (address: string | null, value: number): MempoolVin {
+  return { prevout: { scriptpubkey_address: address, value } }
+}
+
+function tx (overrides: Partial<MempoolTransaction> = {}): MempoolTransaction {
+  return { txid: 'tx1', vin: [], vout: [], confirmed: true, block_time: BLOCK_TIME, ...overrides }
+}
+
+const ledger1: Wallet = { id: 'a1', title: 'Ledger_1', addresses: ['a1', 'a2'] }
+const ledger2: Wallet = { id: 'b1', title: 'Ledger_2', addresses: ['b1'] }
+
+describe('convertTransactions', () => {
+  it('поступление извне — один положительный movement с адресом отправителя', () => {
+    const [transaction] = convertTransactions([ledger1], [tx({
+      vin: [inp('outsider', 60000000)],
+      vout: [out('a1', 50000000)]
+    })])
+    expect(transaction.movements).toEqual([{ id: 'tx1', account: { id: 'a1' }, invoice: null, sum: 500000, fee: 0 }])
+    expect(transaction.merchant).toEqual({ fullTitle: 'outsider', mcc: null, location: null })
+    expect(transaction.comment).toBe('tx1')
+    expect(transaction.date).toEqual(new Date(BLOCK_TIME * 1000))
+    expect(transaction.hold).toBeNull()
+  })
+
+  it('сдача на собственный адрес не превращается в доход', () => {
+    // В биткойне нельзя потратить часть монеты: вход тратится целиком, а остаток кошелёк
+    // возвращает тебе же — это и есть сдача. Пользователь её не видит, кошелёк делает это сам.
+    // Здесь на адресе a1 лежала монета 0.5 BTC. Другу уходит 0.1, майнеру 0.0001,
+    // оставшиеся 0.3999 возвращаются на a1.
+    // Именно на этом ошибается btcscan: он берёт первый подходящий выход, видит возврат
+    // 0.3999 на свой адрес и пишет доход. На самом деле это расход 0.1001.
+    const [transaction] = convertTransactions([ledger1], [tx({
+      vin: [inp('a1', 50000000)],
+      vout: [out('outsider', 10000000), out('a1', 39990000)]
+    })])
+    expect(transaction.movements[0].sum).toBe(-100100)
+    expect(transaction.merchant).toEqual({ fullTitle: 'outsider', mcc: null, location: null })
+  })
+
+  it('одна транзакция платит на два адреса одного кошелька — суммы складываются', () => {
+    // Ledger_1 — это два адреса, a1 и a2. Одна входящая транзакция платит на оба сразу:
+    // 0.3 на a1 и 0.2 на a2. Адреса принадлежат одному счёту, поэтому в операции должно
+    // быть 0.5, а не 0.3 (как вышло бы, если брать первый подходящий выход).
+    const [transaction] = convertTransactions([ledger1], [tx({
+      vin: [inp('outsider', 100000000)],
+      vout: [out('a1', 30000000), out('a2', 20000000)]
+    })])
+    expect(transaction.movements[0].sum).toBe(500000)
+  })
+
+  it('перемещение внутри одного кошелька оставляет только комиссию', () => {
+    const [transaction] = convertTransactions([ledger1], [tx({
+      vin: [inp('a1', 50000000)],
+      vout: [out('a2', 49990000)]
+    })])
+    expect(transaction.movements).toHaveLength(1)
+    expect(transaction.movements[0].sum).toBe(-100)
+  })
+
+  it('перевод между двумя своими счетами склеивается в два движения', () => {
+    // Оба кошелька — свои: Ledger_1 (a1, a2) и Ledger_2 (b1), оба заведены пользователем
+    // в настройках. Деньги не ушли наружу, а переехали между его же счетами, поэтому это
+    // одна операция с двумя движениями, а не расход и отдельный доход.
+    const transactions = convertTransactions([ledger1, ledger2], [tx({
+      vin: [inp('a1', 50000000)],
+      vout: [out('b1', 49990000)]
+    })])
+    expect(transactions).toHaveLength(1)
+    // Комиссия вынесена в fee. Движение по счёту считается как sum + fee
+    // (src/common/converters.js:250), поэтому со счёта всё равно уходит 500000.
+    // Отдельным полем комиссия видна только на ветке transactionDtoV2; на легаси-ветке
+    // она складывается обратно в сумму, и результат тот же, что был бы при fee: 0.
+    expect(transactions[0].movements).toEqual([
+      { id: 'tx1', account: { id: 'a1' }, invoice: null, sum: -499900, fee: -100 },
+      { id: 'tx1', account: { id: 'b1' }, invoice: null, sum: 499900, fee: 0 }
+    ])
+    expect(transactions[0].merchant).toBeNull()
+  })
+
+  it('порядок кошельков в настройках не переставляет стороны перевода', () => {
+    // Тот же перевод, но получатель идёт в списке первым. Без разворота пары
+    // списание и зачисление поменялись бы местами, а тесты выше этого не заметили бы.
+    const transactions = convertTransactions([ledger2, ledger1], [tx({
+      vin: [inp('a1', 50000000)],
+      vout: [out('b1', 49990000)]
+    })])
+    expect(transactions[0].movements).toEqual([
+      { id: 'tx1', account: { id: 'a1' }, invoice: null, sum: -499900, fee: -100 },
+      { id: 'tx1', account: { id: 'b1' }, invoice: null, sum: 499900, fee: 0 }
+    ])
+  })
+
+  it('транзакция, которая заодно платит наружу, переводом не считается', () => {
+    // Ledger_1 тратит 1.0: 0.3 уходит на Ledger_2, 0.6999 — постороннему.
+    // Склеив это в перевод, мы показали бы «-1.0 → +0.3», и ушедшие наружу 0.6999
+    // выглядели бы стоимостью перевода, а не платежом получателю.
+    const transactions = convertTransactions([ledger1, ledger2], [tx({
+      vin: [inp('a1', 100000000)],
+      vout: [out('b1', 30000000), out('outsider', 69990000)]
+    })])
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(t => t.movements[0].sum)).toEqual([-1000000, 300000])
+    expect(transactions[0].merchant).toEqual({ fullTitle: 'outsider', mcc: null, location: null })
+  })
+
+  it('чужой вход тоже снимает склейку в перевод', () => {
+    // Зеркальный случай к предыдущему: наружу ничего не ушло, но часть денег пришла
+    // снаружи. Склеив это, мы получили бы «недостачу» со знаком плюс — Zenmoney назвал
+    // бы её кэшбэком, а sum отправителя завысился бы на чужой вклад.
+    const transactions = convertTransactions([ledger1, ledger2], [tx({
+      vin: [inp('outsider', 10000000), inp('a1', 50000000)],
+      vout: [out('b1', 59990000)]
+    })])
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(t => t.movements[0].sum)).toEqual([-500000, 599900])
+    expect(transactions.map(t => t.movements[0].fee)).toEqual([0, 0])
+    expect(transactions[1].merchant).toEqual({ fullTitle: 'outsider', mcc: null, location: null })
+  })
+
+  it('вход без адреса тоже снимает склейку', () => {
+    // P2PK и bare multisig не имеют scriptpubkey_address, так что involvesOutsider их
+    // не видит. Но выход в биткойне никогда не больше входа, поэтому у настоящего
+    // перевода целиком из наших адресов недостача всегда ≤ 0. Плюс означает, что деньги
+    // пришли со стороны, и склеивать нельзя.
+    const transactions = convertTransactions([ledger1, ledger2], [tx({
+      vin: [inp(null, 10000000), inp('a1', 50000000)],
+      vout: [out('b1', 59990000)]
+    })])
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(t => t.movements[0].sum)).toEqual([-500000, 599900])
+  })
+
+  it('выплата сразу на два своих кошелька не склеивается в перевод', () => {
+    // Оба движения положительные — это не перемещение между счетами,
+    // а одна внешняя выплата, попавшая на два кошелька.
+    const transactions = convertTransactions([ledger1, ledger2], [tx({
+      vin: [inp('outsider', 100000000)],
+      vout: [out('a1', 40000000), out('b1', 50000000)]
+    })])
+    expect(transactions).toHaveLength(2)
+    expect(transactions.map(t => t.movements[0].sum)).toEqual([400000, 500000])
+  })
+
+  it('три затронутых кошелька дают три отдельные операции', () => {
+    const ledger3: Wallet = { id: 'c1', title: 'Ledger_3', addresses: ['c1'] }
+    const transactions = convertTransactions([ledger1, ledger2, ledger3], [tx({
+      vin: [inp('a1', 100000000)],
+      vout: [out('b1', 50000000), out('c1', 49990000)]
+    })])
+    expect(transactions).toHaveLength(3)
+    expect(transactions.every(t => t.movements.length === 1)).toBe(true)
+  })
+
+  it('контрагентом не становится адрес другого своего кошелька', () => {
+    // Здесь все стороны — свои счета. Если исключать только адреса текущего кошелька,
+    // в приложении получится «расход на bc1q…», где bc1q… — собственный счёт пользователя.
+    const ledger3: Wallet = { id: 'c1', title: 'Ledger_3', addresses: ['c1'] }
+    const transactions = convertTransactions([ledger1, ledger2, ledger3], [tx({
+      vin: [inp('a1', 100000000)],
+      vout: [out('b1', 50000000), out('c1', 49990000)]
+    })])
+    expect(transactions.map(t => t.merchant)).toEqual([null, null, null])
+  })
+
+  it('контрагентом становится посторонний адрес, а не соседний свой счёт', () => {
+    // Ledger_1 тратит 1.0: 0.4 уходит на Ledger_2 (свой счёт), 0.3 — постороннему,
+    // 0.2999 возвращается сдачей на a2. Посторонний выход есть, поэтому переводом это
+    // не считается и получаются две отдельные операции.
+    // У расхода Ledger_1 контрагент — 'outsider', единственный посторонний в транзакции.
+    // Взять b1 нельзя: это собственный счёт пользователя, и вышло бы «расход на свой счёт».
+    // У дохода Ledger_2 контрагента нет вовсе — деньги пришли с его же Ledger_1.
+    const transactions = convertTransactions([ledger1, ledger2], [tx({
+      vin: [inp('a1', 100000000)],
+      vout: [out('b1', 40000000), out('outsider', 30000000), out('a2', 29990000)]
+    })])
+    expect(transactions.map(t => t.merchant)).toEqual([
+      { fullTitle: 'outsider', mcc: null, location: null },
+      null
+    ])
+  })
+
+  it('неподтверждённая транзакция пропускается', () => {
+    expect(convertTransactions([ledger1], [tx({
+      confirmed: false,
+      block_time: null,
+      vin: [inp('outsider', 10000000)],
+      vout: [out('a1', 9990000)]
+    })])).toEqual([])
+  })
+
+  it('транзакция без наших адресов не порождает операций', () => {
+    // Ни один адрес пользователя не участвует ни во входах, ни в выходах: и 'outsider',
+    // и 'another' — посторонние. Конвертер чистый и получить может любую транзакцию,
+    // поэтому на такой он обязан молча вернуть пустой список.
+    expect(convertTransactions([ledger1], [tx({
+      vin: [inp('outsider', 10000000)],
+      vout: [out('another', 9990000)]
+    })])).toEqual([])
+  })
+
+  it('выход без адреса не ломает расчёт', () => {
+    // У выхода может не быть адреса вообще. Обычный случай — OP_RETURN: в транзакцию
+    // вшивают несколько байт данных (метка сервиса, привязка к другой сети), денег на
+    // таком выходе обычно 0. В ответе API поле scriptpubkey_address тогда просто
+    // отсутствует, и fetchApi подставляет null.
+    // Такой выход не засчитывается как ПОСТУПЛЕНИЕ — на наши адреса ничего не пришло.
+    // Если на нём всё же лежат деньги и они наши, потеря всё равно не теряется: нетто
+    // считается как «пришло нам минус ушло с наших адресов», и ушедшее видно по входу.
+    // Отдельный тест на это — ниже.
+    // Здесь же денег на безадресном выходе нет, поэтому приход равен 0.0999.
+    const [transaction] = convertTransactions([ledger1], [tx({
+      vin: [inp('outsider', 10000000)],
+      vout: [out(null, 0), out('a1', 9990000)]
+    })])
+    expect(transaction.movements[0].sum).toBe(99900)
+  })
+
+  it('сожжённые в OP_RETURN свои деньги остаются расходом', () => {
+    // Тратим 0.1 BTC со своего a1: 0.001 уходит в безадресный выход (сжигается),
+    // 0.0989 возвращается сдачей на a1, 0.0001 забирает майнер.
+    // Адреса у сожжённого выхода нет, приписать его некому — и приход по нему не
+    // засчитывается. Но деньги действительно ушли, и нетто это ловит с другой стороны:
+    // 0.0989 пришло минус 0.1 ушло = −0.0011, то есть сожжённое плюс комиссия.
+    const [transaction] = convertTransactions([ledger1], [tx({
+      vin: [inp('a1', 10000000)],
+      vout: [out(null, 100000), out('a1', 9890000)]
+    })])
+    expect(transaction.movements[0].sum).toBe(-1100)
+  })
+})

--- a/src/plugins/mempool/__tests__/fetchApi.test.ts
+++ b/src/plugins/mempool/__tests__/fetchApi.test.ts
@@ -1,0 +1,99 @@
+import { InvalidPreferencesError, TemporaryUnavailableError } from '../../../errors'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+const ok = (body: unknown): unknown => ({ status: 200, url: '', headers: {}, body })
+
+// Ретраи ждут 2+4+6 секунд, а дефолтный таймаут jest — 5. Выполняем колбэк таймера
+// сразу: проверяем число попыток, а не то, что паузы действительно случились.
+const immediateTimeout = (handler: () => void): number => { handler(); return 0 }
+
+describe('fetchApi', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchAddressInfo, fetchAddressTransactionsPage } = require('../fetchApi') as typeof import('../fetchApi')
+
+  beforeAll(() => {
+    jest.spyOn(global, 'setTimeout').mockImplementation(immediateTimeout as unknown as typeof global.setTimeout)
+  })
+
+  afterAll(() => { jest.restoreAllMocks() })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('fetchAddressInfo достаёт суммы из chain_stats', async () => {
+    mockFetchJson.mockResolvedValueOnce(ok({
+      address: 'bc1qtest',
+      chain_stats: { funded_txo_sum: 6182503, spent_txo_sum: 6182503, tx_count: 12 },
+      mempool_stats: { funded_txo_sum: 0, spent_txo_sum: 0 }
+    }))
+    await expect(fetchAddressInfo('bc1qtest')).resolves.toEqual({
+      funded_txo_sum: 6182503, spent_txo_sum: 6182503
+    })
+    expect(mockFetchJson).toHaveBeenCalledWith('https://mempool.space/api/address/bc1qtest')
+  })
+
+  it('fetchAddressTransactionsPage нормализует выход без адреса в null', async () => {
+    mockFetchJson.mockResolvedValueOnce(ok([{
+      txid: 'abc',
+      vin: [{ prevout: { scriptpubkey_address: 'bc1qsender', value: 1000 } }],
+      vout: [{ value: 0 }, { scriptpubkey_address: 'bc1qtest', value: 900 }],
+      status: { confirmed: true, block_time: 1700000000 }
+    }]))
+    const [transaction] = await fetchAddressTransactionsPage('bc1qtest')
+    expect(transaction.vout[0]).toEqual({ scriptpubkey_address: null, value: 0 })
+    expect(transaction.vin[0].prevout).toEqual({ scriptpubkey_address: 'bc1qsender', value: 1000 })
+    expect(transaction.confirmed).toBe(true)
+    expect(transaction.block_time).toBe(1700000000)
+  })
+
+  it('неподтверждённая транзакция приезжает без block_time', async () => {
+    mockFetchJson.mockResolvedValueOnce(ok([{
+      txid: 'abc', vin: [], vout: [], status: { confirmed: false }
+    }]))
+    const [transaction] = await fetchAddressTransactionsPage('bc1qtest')
+    expect(transaction.confirmed).toBe(false)
+    expect(transaction.block_time).toBeNull()
+  })
+
+  it('lastSeenTxId переключает на постраничный маршрут', async () => {
+    mockFetchJson.mockResolvedValueOnce(ok([]))
+    await fetchAddressTransactionsPage('bc1qtest', 'seen')
+    expect(mockFetchJson).toHaveBeenCalledWith('https://mempool.space/api/address/bc1qtest/txs/chain/seen')
+  })
+
+  it('429 повторяется и на успешной попытке отдаёт данные', async () => {
+    mockFetchJson
+      .mockResolvedValueOnce({ status: 429, url: '', headers: {}, body: '' })
+      .mockResolvedValueOnce(ok([]))
+    await expect(fetchAddressTransactionsPage('bc1qtest')).resolves.toEqual([])
+    expect(mockFetchJson).toHaveBeenCalledTimes(2)
+  })
+
+  it('после исчерпания попыток на 500 бросает TemporaryUnavailableError', async () => {
+    mockFetchJson.mockResolvedValue({ status: 500, url: '', headers: {}, body: '' })
+    await expect(fetchAddressInfo('bc1qtest')).rejects.toBeInstanceOf(TemporaryUnavailableError)
+    expect(mockFetchJson).toHaveBeenCalledTimes(4)
+  })
+
+  it('404 не ретраится', async () => {
+    mockFetchJson.mockResolvedValue({ status: 404, url: '', headers: {}, body: '' })
+    await expect(fetchAddressInfo('bc1qtest')).rejects.toBeInstanceOf(TemporaryUnavailableError)
+    expect(mockFetchJson).toHaveBeenCalledTimes(1)
+  })
+
+  it('200 с телом не-массивом не выдаётся за пустую страницу', async () => {
+    // Пустая страница останавливает пагинацию. Приняв за неё сломанный ответ,
+    // мы навсегда заморозили бы историю кошелька на последней виденной транзакции,
+    // и это было бы неотличимо от «операций больше нет».
+    mockFetchJson.mockResolvedValueOnce(ok({ error: 'maintenance' }))
+    await expect(fetchAddressTransactionsPage('bc1qtest')).rejects.toBeInstanceOf(TemporaryUnavailableError)
+  })
+
+  it('400 сообщает о невалидном адресе и не ретраится', async () => {
+    mockFetchJson.mockResolvedValue({ status: 400, url: '', headers: {}, body: '' })
+    await expect(fetchAddressInfo('bc1qtest')).rejects.toBeInstanceOf(InvalidPreferencesError)
+    expect(mockFetchJson).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/plugins/mempool/__tests__/preferences.test.ts
+++ b/src/plugins/mempool/__tests__/preferences.test.ts
@@ -1,0 +1,81 @@
+import { InvalidPreferencesError } from '../../../errors'
+import { Preferences } from '../models'
+import { parseWallets } from '../preferences'
+
+function prefs (overrides: Partial<Preferences> = {}): Preferences {
+  return { wallet1Addresses: 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps', ...overrides }
+}
+
+describe('parseWallets', () => {
+  it('единственный слот без имени получает заголовок Bitcoin и id первого адреса', () => {
+    expect(parseWallets(prefs())).toEqual([{
+      id: 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps',
+      title: 'Bitcoin',
+      addresses: ['bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps']
+    }])
+  })
+
+  it('режет список по запятым и игнорирует пробелы и пустые элементы', () => {
+    const wallets = parseWallets(prefs({
+      wallet1Addresses: ' bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps , ,1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2 '
+    }))
+    expect(wallets[0].addresses).toEqual([
+      'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps',
+      '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+    ])
+  })
+
+  it('второй и третий слоты дают отдельные кошельки со своими именами', () => {
+    const wallets = parseWallets(prefs({
+      wallet1Title: 'Ledger_1',
+      wallet2Title: 'Ledger_2',
+      wallet2Addresses: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+    }))
+    expect(wallets.map(w => w.title)).toEqual(['Ledger_1', 'Ledger_2'])
+  })
+
+  it('слот без адресов пропускается, даже если имя задано', () => {
+    expect(parseWallets(prefs({ wallet2Title: 'Пустой', wallet2Addresses: '  ' }))).toHaveLength(1)
+  })
+
+  it('имя по умолчанию берётся из номера слота, а не из позиции в списке', () => {
+    // Заполнены слоты 1 и 3, слот 2 пустой. Второй кошелёк в результате — это слот 3,
+    // и назвать его надо «Bitcoin 3» по номеру слота. Возьми мы позицию в списке, вышло бы
+    // «Bitcoin 2» — и счёт переименовался бы сам собой, стоит пользователю заполнить слот 2.
+    const wallets = parseWallets(prefs({
+      wallet3Addresses: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+    }))
+    expect(wallets.map(w => w.title)).toEqual(['Bitcoin', 'Bitcoin 3'])
+  })
+
+  it('дубль адреса внутри слота схлопывается', () => {
+    const address = 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps'
+    expect(parseWallets(prefs({ wallet1Addresses: `${address},${address}` }))[0].addresses).toEqual([address])
+  })
+
+  it('один адрес в двух слотах — ошибка настроек', () => {
+    const address = 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps'
+    expect(() => parseWallets(prefs({ wallet2Addresses: address }))).toThrow(InvalidPreferencesError)
+  })
+
+  it('bech32 в верхнем регистре принимается и приводится к нижнему', () => {
+    // BIP173 разрешает адрес целиком в верхнем регистре, и некоторые кошельки так
+    // и отдают его в QR. API же понимает только нижний.
+    const address = 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps'
+    expect(parseWallets(prefs({ wallet1Addresses: address.toUpperCase() }))[0].addresses).toEqual([address])
+  })
+
+  it('base58 не приводится к нижнему регистру — там он значащий', () => {
+    // Регистр в base58 меняет сам адрес, так что нормализовать можно только bech32.
+    const address = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+    expect(parseWallets(prefs({ wallet1Addresses: address }))[0].addresses).toEqual([address])
+  })
+
+  it('мусор вместо адреса — ошибка настроек', () => {
+    expect(() => parseWallets(prefs({ wallet1Addresses: 'не адрес' }))).toThrow(InvalidPreferencesError)
+  })
+
+  it('ни одного адреса — ошибка настроек', () => {
+    expect(() => parseWallets(prefs({ wallet1Addresses: '' }))).toThrow(InvalidPreferencesError)
+  })
+})

--- a/src/plugins/mempool/__tests__/scrape.test.ts
+++ b/src/plugins/mempool/__tests__/scrape.test.ts
@@ -1,0 +1,66 @@
+import { MempoolTransaction } from '../models'
+
+const mockFetchAddressInfos = jest.fn()
+const mockFetchTransactions = jest.fn()
+
+jest.mock('../api', () => ({
+  fetchAddressInfos: mockFetchAddressInfos,
+  fetchTransactions: mockFetchTransactions
+}))
+
+describe('scrape', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrape } = require('../index') as typeof import('../index')
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('собирает счета и операции из настроек в два кошелька', async () => {
+    const transfer: MempoolTransaction = {
+      txid: 'tx1',
+      vin: [{ prevout: { scriptpubkey_address: 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps', value: 50000000 } }],
+      vout: [{ scriptpubkey_address: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', value: 49990000 }],
+      confirmed: true,
+      block_time: 1700000000
+    }
+    mockFetchAddressInfos.mockResolvedValue(new Map([
+      ['bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps', { funded_txo_sum: 50000000, spent_txo_sum: 50000000 }],
+      ['1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2', { funded_txo_sum: 49990000, spent_txo_sum: 0 }]
+    ]))
+    mockFetchTransactions.mockResolvedValue([transfer])
+    const fromDate = new Date('2020-01-01T00:00:00Z')
+
+    const result = await scrape({
+      preferences: {
+        wallet1Title: 'Ledger_1',
+        wallet1Addresses: 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps',
+        wallet2Title: 'Ledger_2',
+        wallet2Addresses: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2'
+      },
+      fromDate,
+      isFirstRun: true,
+      isInBackground: false
+    })
+
+    // Настройки должны доехать до загрузки разобранными, а fromDate — нетронутой:
+    // без этой проверки потерянный проброс даты тихо сломал бы инкрементальный синк.
+    const wallets = [
+      {
+        id: 'bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps',
+        title: 'Ledger_1',
+        addresses: ['bc1q9m3zshmgyper308w9xp53kq2y2vs2c86ewcmps']
+      },
+      {
+        id: '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+        title: 'Ledger_2',
+        addresses: ['1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2']
+      }
+    ]
+    expect(mockFetchAddressInfos).toHaveBeenCalledWith(wallets)
+    expect(mockFetchTransactions).toHaveBeenCalledWith(wallets, fromDate)
+
+    expect(result.accounts.map(account => account.title)).toEqual(['Ledger_1', 'Ledger_2'])
+    expect(result.accounts.map(account => account.balance)).toEqual([0, 499900])
+    expect(result.transactions).toHaveLength(1)
+    expect(result.transactions[0].movements).toHaveLength(2)
+  })
+})

--- a/src/plugins/mempool/api.ts
+++ b/src/plugins/mempool/api.ts
@@ -1,0 +1,78 @@
+import { fetchAddressInfo, fetchAddressTransactionsPage } from './fetchApi'
+import { MempoolAddressInfo, MempoolTransaction, PAGE_SIZE, Wallet } from './models'
+
+// Страховка от бесконечного цикла, если API перестанет менять выдачу
+// при переданном lastSeenTxId. 200 страниц по 25 — пять тысяч транзакций на адрес.
+const MAX_PAGES = 200
+
+function walletAddresses (wallets: Wallet[]): string[] {
+  return wallets.flatMap(wallet => wallet.addresses)
+}
+
+export async function fetchAddressInfos (wallets: Wallet[]): Promise<Map<string, MempoolAddressInfo>> {
+  const infoByAddress = new Map<string, MempoolAddressInfo>()
+  // Последовательно, а не Promise.all: лимиты сервиса не опубликованы,
+  // а шесть адресов на первом синке дают десятки запросов.
+  for (const address of walletAddresses(wallets)) {
+    infoByAddress.set(address, await fetchAddressInfo(address))
+  }
+  return infoByAddress
+}
+
+// Курсор /txs/chain/:txid определён только по подтверждённой истории, а первая страница
+// /txs отдаёт мемпульные транзакции первыми. Берём самую старую подтверждённую на странице:
+// если подтверждённых нет вовсе, листать дальше не по чему.
+function oldestConfirmed (page: MempoolTransaction[]): { txid: string, blockTime: number } | null {
+  for (let index = page.length - 1; index >= 0; index--) {
+    const { txid, block_time: blockTime } = page[index]
+    if (blockTime != null) {
+      return { txid, blockTime }
+    }
+  }
+  return null
+}
+
+async function fetchAddressTransactions (address: string, fromDate: Date): Promise<MempoolTransaction[]> {
+  const collected: MempoolTransaction[] = []
+  let lastSeenTxId: string | undefined
+
+  let pageIndex = 0
+  for (; pageIndex < MAX_PAGES; pageIndex++) {
+    const page = await fetchAddressTransactionsPage(address, lastSeenTxId)
+    if (page.length === 0) {
+      break
+    }
+    collected.push(...page)
+
+    if (page.length < PAGE_SIZE) {
+      break
+    }
+    const oldest = oldestConfirmed(page)
+    if (oldest == null || oldest.blockTime * 1000 <= fromDate.getTime()) {
+      break
+    }
+    lastSeenTxId = oldest.txid
+  }
+
+  // Молча оборванная история при отладке выглядит как «часть операций просто не пришла».
+  if (pageIndex === MAX_PAGES) {
+    console.log(`mempool: обход адреса ${address} остановлен на пределе ${MAX_PAGES} страниц, история могла обрезаться`)
+  }
+
+  return collected
+}
+
+export async function fetchTransactions (wallets: Wallet[], fromDate: Date): Promise<MempoolTransaction[]> {
+  const byTxId = new Map<string, MempoolTransaction>()
+
+  for (const address of walletAddresses(wallets)) {
+    for (const transaction of await fetchAddressTransactions(address, fromDate)) {
+      // Одна транзакция приходит повторно, если в ней участвуют несколько наших адресов.
+      if (transaction.block_time != null && transaction.block_time * 1000 > fromDate.getTime()) {
+        byTxId.set(transaction.txid, transaction)
+      }
+    }
+  }
+
+  return [...byTxId.values()]
+}

--- a/src/plugins/mempool/converters.ts
+++ b/src/plugins/mempool/converters.ts
@@ -1,0 +1,155 @@
+import { Account, AccountType, Movement, Transaction } from '../../types/zenmoney'
+import { INSTRUMENT, MempoolAddressInfo, MempoolTransaction, MempoolVout, SATOSHI_IN_UBTC, Wallet } from './models'
+
+// Баланс считается только по chain_stats. mempool_stats сознательно игнорируется: мы
+// не показываем и неподтверждённые транзакции, так что иначе баланс разошёлся бы с суммой
+// операций. Цена решения — при висящем неподтверждённом расходе баланс будет завышен
+// до попадания транзакции в блок. Так же устроен btcscan.
+export function convertAccounts (wallets: Wallet[], infoByAddress: Map<string, MempoolAddressInfo>): Account[] {
+  return wallets.map(wallet => {
+    const balanceSatoshi = wallet.addresses.reduce((sum, address) => {
+      const info = infoByAddress.get(address)
+      return info == null ? sum : sum + info.funded_txo_sum - info.spent_txo_sum
+    }, 0)
+
+    return {
+      id: wallet.id,
+      type: AccountType.checking,
+      title: wallet.title,
+      instrument: INSTRUMENT,
+      balance: balanceSatoshi / SATOSHI_IN_UBTC,
+      syncIds: wallet.addresses
+    }
+  })
+}
+
+function sumOwn (outputs: Array<MempoolVout | null>, addresses: Set<string>): number {
+  return outputs.reduce((sum: number, output) => {
+    if (output?.scriptpubkey_address == null || !addresses.has(output.scriptpubkey_address)) {
+      return sum
+    }
+    return sum + output.value
+  }, 0)
+}
+
+// Нетто по кошельку: сколько пришло на его адреса минус сколько с них ушло.
+// Именно так сдача на собственный адрес перестаёт выглядеть доходом, а перемещение
+// внутри кошелька схлопывается до комиссии.
+function walletNetSatoshi (wallet: Wallet, transaction: MempoolTransaction): number {
+  const addresses = new Set(wallet.addresses)
+  const received = sumOwn(transaction.vout, addresses)
+  const spent = sumOwn(transaction.vin.map(vin => vin.prevout), addresses)
+  return received - spent
+}
+
+// ownAddresses — адреса ВСЕХ кошельков пользователя, а не только того, для которого
+// строится движение.
+// Пример из жизни: пользователь платит подрядчику 0.7 BTC и в той же транзакции
+// перекладывает 0.3 BTC со своего Ledger_1 на свой же Ledger_2. Так делают ради комиссии:
+// у транзакции может быть сколько угодно получателей, а майнеру платится один раз, и
+// десктопные кошельки (Electrum, Sparrow, Bitcoin Core) дают кнопку «добавить получателя».
+// Посторонний получатель снимает склейку в перевод, поэтому выходят две операции.
+// Контрагентом расхода Ledger_1 должен стать подрядчик. Исключай мы только собственные
+// адреса Ledger_1, первым «чужим» выходом оказался бы адрес Ledger_2 — и в приложении
+// получился бы «расход на bc1q…», где этот bc1q… и есть соседний счёт самого пользователя.
+function findCounterparty (transaction: MempoolTransaction, ownAddresses: Set<string>, isIncome: boolean): string | null {
+  const candidates = isIncome
+    ? transaction.vin.map(vin => vin.prevout?.scriptpubkey_address ?? null)
+    : transaction.vout.map(output => output.scriptpubkey_address)
+  return candidates.find((address): address is string => address != null && !ownAddresses.has(address)) ?? null
+}
+
+// Участвует ли в транзакции адрес, не принадлежащий ни одному кошельку пользователя.
+// Смотрим обе стороны: чужой выход означает, что часть денег ушла наружу, чужой вход —
+// что часть пришла снаружи. И то и другое ломает трактовку «перемещение между своими
+// счетами», потому что разница нетто перестаёт быть комиссией майнеру: при чужом выходе
+// в неё попадёт платёж постороннему, при чужом входе она вообще станет положительной
+// и Zenmoney покажет её кэшбэком.
+// Вход или выход без адреса (OP_RETURN, coinbase) не считается: приписать его некому.
+function involvesOutsider (transaction: MempoolTransaction, ownAddresses: Set<string>): boolean {
+  const participants = [
+    ...transaction.vout.map(output => output.scriptpubkey_address),
+    ...transaction.vin.map(vin => vin.prevout?.scriptpubkey_address ?? null)
+  ]
+  return participants.some(address => address != null && !ownAddresses.has(address))
+}
+
+function makeMovement (walletId: string, netSatoshi: number, txid: string, feeSatoshi = 0): Movement {
+  return {
+    id: txid,
+    account: { id: walletId },
+    invoice: null,
+    sum: netSatoshi / SATOSHI_IN_UBTC,
+    fee: feeSatoshi / SATOSHI_IN_UBTC
+  }
+}
+
+export function convertTransactions (wallets: Wallet[], transactions: MempoolTransaction[]): Transaction[] {
+  const result: Transaction[] = []
+  const ownAddresses = new Set(wallets.flatMap(wallet => wallet.addresses))
+
+  for (const transaction of transactions) {
+    if (!transaction.confirmed || transaction.block_time == null) {
+      continue
+    }
+
+    const date = new Date(transaction.block_time * 1000)
+    const parts = wallets
+      .map(wallet => ({ wallet, net: walletNetSatoshi(wallet, transaction) }))
+      .filter(part => part.net !== 0)
+
+    if (parts.length === 0) {
+      continue
+    }
+
+    // Склеиваем в перевод, только если выполнено всё сразу:
+    //   затронуто ровно два кошелька — на третье движение в Transaction нет места;
+    //   знаки противоположны — два плюса это не перевод, а одна выплата на два счёта;
+    //   посторонних адресов нет — иначе деньги пришли или ушли на сторону.
+    const isTransfer = parts.length === 2 &&
+      Math.sign(parts[0].net) !== Math.sign(parts[1].net) &&
+      !involvesOutsider(transaction, ownAddresses)
+
+    // Выход в биткойне никогда не больше входа, поэтому у перевода целиком из наших
+    // адресов недостача всегда ≤ 0 и равна комиссии майнеру. Плюс означает, что деньги
+    // пришли со стороны — например со входа без scriptpubkey_address (P2PK, bare
+    // multisig), которого involvesOutsider не видит. Склеивать такое нельзя: комиссия
+    // вышла бы положительной, и Zenmoney показал бы её кэшбэком.
+    // isTransfer уже гарантирует ровно два кошелька, а && закорачивает, поэтому
+    // обращение к parts[1] здесь безопасно.
+    if (isTransfer && parts[0].net + parts[1].net <= 0) {
+      const [from, to] = parts[0].net < 0 ? parts : [parts[1], parts[0]]
+      // Посторонних участников здесь нет, поэтому вся недостача — комиссия майнеру.
+      // Разносим её отдельным полем: движение по счёту Zenmoney считает как sum + fee
+      // (src/common/converters.js:250), так что со счёта отправителя уходит ровно from.net
+      // при любой раскладке. Отдельным полем комиссия доезжает до приложения только на
+      // ветке transactionDtoV2 — там движения передаются как есть; на легаси-ветке
+      // toZenMoneyTransaction складывает sum + fee обратно, и результат неотличим от fee: 0.
+      const feeSatoshi = from.net + to.net
+      result.push({
+        hold: null,
+        date,
+        movements: [
+          makeMovement(from.wallet.id, from.net - feeSatoshi, transaction.txid, feeSatoshi),
+          makeMovement(to.wallet.id, to.net, transaction.txid)
+        ],
+        merchant: null,
+        comment: transaction.txid
+      })
+      continue
+    }
+
+    for (const part of parts) {
+      const counterparty = findCounterparty(transaction, ownAddresses, part.net > 0)
+      result.push({
+        hold: null,
+        date,
+        movements: [makeMovement(part.wallet.id, part.net, transaction.txid)],
+        merchant: counterparty == null ? null : { fullTitle: counterparty, mcc: null, location: null },
+        comment: transaction.txid
+      })
+    }
+  }
+
+  return result
+}

--- a/src/plugins/mempool/fetchApi.ts
+++ b/src/plugins/mempool/fetchApi.ts
@@ -1,0 +1,90 @@
+import { fetchJson } from '../../common/network'
+import { InvalidPreferencesError, TemporaryUnavailableError } from '../../errors'
+import { getArray, getBoolean, getNumber, getOptNumber, getOptString, getString } from '../../types/get'
+import { BASE_URL, MempoolAddressInfo, MempoolTransaction, MempoolVin, MempoolVout } from './models'
+
+const MAX_ATTEMPTS = 4
+const RETRY_DELAY_MS = 2000
+
+async function sleep (ms: number): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, ms))
+}
+
+// mempool.space лимиты числом не публикует, но обещает 429 и блокировки,
+// поэтому 429 и 5xx повторяем с растущей паузой, а прочие коды считаем окончательными.
+// 400 — особый случай: адрес прошёл структурную проверку в preferences.ts, но сам API
+// его не принял. TemporaryUnavailableError ретраил бы это молча вечно, allowRetry: true
+// не сообщил бы пользователю про опечатку; InvalidPreferencesError фатален и возвращает
+// на экран настроек (см. src/plugins/jupitercard/fetchApi.ts:83-87 для того же паттерна).
+// 403/404 и прочее — не вина пользователя (блокировка по рейт-лимиту, чужой роут), поэтому
+// они остаются TemporaryUnavailableError.
+async function requestJson (path: string, address: string): Promise<unknown> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const response = await fetchJson(`${BASE_URL}${path}`)
+    if (response.status === 200) {
+      return response.body
+    }
+    if (response.status === 400) {
+      throw new InvalidPreferencesError(
+        `mempool.space не принял адрес «${address}» (400). Проверьте его среди адресов кошельков в настройках плагина.`
+      )
+    }
+    if (response.status !== 429 && response.status < 500) {
+      break
+    }
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(RETRY_DELAY_MS * attempt)
+    }
+  }
+  throw new TemporaryUnavailableError()
+}
+
+function parseVout (raw: unknown): MempoolVout {
+  return {
+    scriptpubkey_address: getOptString(raw, 'scriptpubkey_address') ?? null,
+    value: getNumber(raw, 'value')
+  }
+}
+
+// prevout отсутствует у coinbase-входов, поэтому опираемся на наличие value.
+function parseVin (raw: unknown): MempoolVin {
+  const value = getOptNumber(raw, 'prevout.value')
+  if (value == null) {
+    return { prevout: null }
+  }
+  return { prevout: { scriptpubkey_address: getOptString(raw, 'prevout.scriptpubkey_address') ?? null, value } }
+}
+
+function parseTransaction (raw: unknown): MempoolTransaction {
+  return {
+    txid: getString(raw, 'txid'),
+    vin: getArray(raw, 'vin').map(parseVin),
+    vout: getArray(raw, 'vout').map(parseVout),
+    confirmed: getBoolean(raw, 'status.confirmed'),
+    block_time: getOptNumber(raw, 'status.block_time') ?? null
+  }
+}
+
+export async function fetchAddressInfo (address: string): Promise<MempoolAddressInfo> {
+  const body = await requestJson(`/address/${address}`, address)
+  return {
+    funded_txo_sum: getNumber(body, 'chain_stats.funded_txo_sum'),
+    spent_txo_sum: getNumber(body, 'chain_stats.spent_txo_sum')
+  }
+}
+
+export async function fetchAddressTransactionsPage (address: string, lastSeenTxId?: string): Promise<MempoolTransaction[]> {
+  const path = lastSeenTxId != null
+    ? `/address/${address}/txs/chain/${lastSeenTxId}`
+    : `/address/${address}/txs`
+  const body = await requestJson(path, address)
+  // Тело ответа — массив в корне, а getArray работает по пути внутри объекта,
+  // поэтому проверяем тип напрямую. Не массив при 200 — это сломанный ответ:
+  // страница обслуживания от прокси, объект ошибки, смена контракта API. Подставить
+  // здесь пустой массив значило бы выдать поломку за конец истории: пагинация
+  // остановилась бы, и кошелёк навсегда замер бы на последней виденной транзакции.
+  if (!Array.isArray(body)) {
+    throw new TemporaryUnavailableError()
+  }
+  return body.map(parseTransaction)
+}

--- a/src/plugins/mempool/index.ts
+++ b/src/plugins/mempool/index.ts
@@ -1,0 +1,16 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { fetchAddressInfos, fetchTransactions } from './api'
+import { convertAccounts, convertTransactions } from './converters'
+import { Preferences } from './models'
+import { parseWallets } from './preferences'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate }) => {
+  const wallets = parseWallets(preferences)
+  const infoByAddress = await fetchAddressInfos(wallets)
+  const transactions = await fetchTransactions(wallets, fromDate)
+
+  return {
+    accounts: convertAccounts(wallets, infoByAddress),
+    transactions: convertTransactions(wallets, transactions)
+  }
+}

--- a/src/plugins/mempool/models.ts
+++ b/src/plugins/mempool/models.ts
@@ -1,0 +1,51 @@
+export const BASE_URL = 'https://mempool.space/api'
+// Суммы отдаются в микро-биткойнах, как в btcscan и etherscan (μETH): Zenmoney хранит
+// эти валюты в микро-единицах, срезает у инструмента «μ» и подставляет настоящий BTC.
+// Отдавать целые монеты с instrument 'BTC' тоже можно — харнесс домножит на 1e6, — но
+// тогда деление на 1e8 и обратное умножение набирают хвосты в последнем разряде.
+export const SATOSHI_IN_UBTC = 100
+export const INSTRUMENT = 'μBTC'
+export const PAGE_SIZE = 25
+export const WALLET_SLOT_COUNT = 3
+
+export interface Preferences {
+  wallet1Title?: string
+  wallet1Addresses: string
+  wallet2Title?: string
+  wallet2Addresses?: string
+  wallet3Title?: string
+  wallet3Addresses?: string
+}
+
+// Кошелёк пользователя: набор адресов, которые он считает одним счётом.
+export interface Wallet {
+  id: string
+  title: string
+  addresses: string[]
+}
+
+// Плоский срез chain_stats. Адрес в структуре не хранится: идентичность задаёт ключ
+// Map в api.ts, а сам адрес мы и так подставляли в URL запроса.
+export interface MempoolAddressInfo {
+  funded_txo_sum: number
+  spent_txo_sum: number
+}
+
+// scriptpubkey_address отсутствует у непривязанных выходов (например OP_RETURN),
+// поэтому поле nullable, а не обязательное.
+export interface MempoolVout {
+  scriptpubkey_address: string | null
+  value: number
+}
+
+export interface MempoolVin {
+  prevout: MempoolVout | null
+}
+
+export interface MempoolTransaction {
+  txid: string
+  vin: MempoolVin[]
+  vout: MempoolVout[]
+  confirmed: boolean
+  block_time: number | null
+}

--- a/src/plugins/mempool/preferences.ts
+++ b/src/plugins/mempool/preferences.ts
@@ -1,0 +1,75 @@
+import { InvalidPreferencesError } from '../../errors'
+import { Preferences, Wallet, WALLET_SLOT_COUNT } from './models'
+
+// Легаси-адреса (P2PKH/P2SH) в base58 и bech32/bech32m (P2WPKH, P2WSH, P2TR).
+// Проверка структурная: она отсеивает опечатки и посторонний текст, а окончательный
+// вердикт по адресу всё равно выносит API.
+const ADDRESS_REGEXP = /^(bc1[023456789acdefghjklmnpqrstuvwxyz]{8,87}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})$/
+
+// BIP173 разрешает bech32 целиком в верхнем регистре, и некоторые кошельки так отдают
+// адрес в QR, а API понимает только нижний. Приводим к нижнему только bech32: в base58
+// регистр значащий, и `toLowerCase()` там дал бы другой адрес, а не тот же самый.
+function normalizeAddress (address: string): string {
+  return /^BC1[0-9A-Z]*$/.test(address) ? address.toLowerCase() : address
+}
+
+function slotAddresses (preferences: Preferences, slot: number): string {
+  switch (slot) {
+    case 1: return preferences.wallet1Addresses ?? ''
+    case 2: return preferences.wallet2Addresses ?? ''
+    default: return preferences.wallet3Addresses ?? ''
+  }
+}
+
+function slotTitle (preferences: Preferences, slot: number): string {
+  switch (slot) {
+    case 1: return preferences.wallet1Title ?? ''
+    case 2: return preferences.wallet2Title ?? ''
+    default: return preferences.wallet3Title ?? ''
+  }
+}
+
+function defaultTitle (slot: number): string {
+  return slot === 1 ? 'Bitcoin' : `Bitcoin ${slot}`
+}
+
+export function parseWallets (preferences: Preferences): Wallet[] {
+  const wallets: Wallet[] = []
+  const slotByAddress = new Map<string, number>()
+
+  for (let slot = 1; slot <= WALLET_SLOT_COUNT; slot++) {
+    const addresses: string[] = []
+
+    for (const raw of slotAddresses(preferences, slot).split(',')) {
+      const address = normalizeAddress(raw.trim())
+      if (address === '') {
+        continue
+      }
+      if (!ADDRESS_REGEXP.test(address)) {
+        throw new InvalidPreferencesError(`«${address}» не похож на биткойн-адрес. Проверьте поле «Адреса ${slot}».`)
+      }
+      const seenIn = slotByAddress.get(address)
+      if (seenIn === slot) {
+        continue
+      }
+      if (seenIn !== undefined) {
+        throw new InvalidPreferencesError(`Адрес ${address} указан и в кошельке ${seenIn}, и в кошельке ${slot}. Оставьте его в одном.`)
+      }
+      slotByAddress.set(address, slot)
+      addresses.push(address)
+    }
+
+    if (addresses.length === 0) {
+      continue
+    }
+
+    const title = slotTitle(preferences, slot).trim()
+    wallets.push({ id: addresses[0], title: title === '' ? defaultTitle(slot) : title, addresses })
+  }
+
+  if (wallets.length === 0) {
+    throw new InvalidPreferencesError('Укажите хотя бы один адрес кошелька.')
+  }
+
+  return wallets
+}

--- a/src/plugins/mempool/preferences.xml
+++ b/src/plugins/mempool/preferences.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="wallet1Title"
+        obligatory="false"
+        inputType="text"
+        title="Название кошелька 1"
+        dialogTitle="Название кошелька 1"
+        dialogMessage="Как назвать счёт в приложении. По умолчанию Bitcoin"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Название кошелька 1|{@s}"
+    />
+    <EditTextPreference
+        key="wallet1Addresses"
+        obligatory="true"
+        inputType="textPassword"
+        title="Адреса кошелька 1"
+        dialogTitle="Адреса кошелька 1"
+        dialogMessage="Адреса одного кошелька через запятую. Все они станут одним счётом"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Адреса кошелька 1|{@s}"
+    />
+    <EditTextPreference
+        key="wallet2Title"
+        obligatory="false"
+        inputType="text"
+        title="Название кошелька 2"
+        dialogTitle="Название кошелька 2"
+        dialogMessage="Как назвать счёт в приложении. По умолчанию Bitcoin 2"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Название кошелька 2|{@s}"
+    />
+    <EditTextPreference
+        key="wallet2Addresses"
+        obligatory="false"
+        inputType="textPassword"
+        title="Адреса кошелька 2"
+        dialogTitle="Адреса кошелька 2"
+        dialogMessage="Оставьте пустым, если второго кошелька нет"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Адреса кошелька 2|{@s}"
+    />
+    <EditTextPreference
+        key="wallet3Title"
+        obligatory="false"
+        inputType="text"
+        title="Название кошелька 3"
+        dialogTitle="Название кошелька 3"
+        dialogMessage="Как назвать счёт в приложении. По умолчанию Bitcoin 3"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Название кошелька 3|{@s}"
+    />
+    <EditTextPreference
+        key="wallet3Addresses"
+        obligatory="false"
+        inputType="textPassword"
+        title="Адреса кошелька 3"
+        dialogTitle="Адреса кошелька 3"
+        dialogMessage="Оставьте пустым, если третьего кошелька нет"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|Адреса кошелька 3|{@s}"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2018-01-01T00:00:00.000Z"
+        dialogTitle="Дата начала загрузки"
+        dialogMessage="Введите дату, с которой загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>


### PR DESCRIPTION
A new plugin that syncs Bitcoin wallets through mempool.space.

## Why another Bitcoin plugin when btcscan already exists

Two reasons.

First, btcscan.org is down. It answered 502 on every check I made, while
mempool.space answered 200 to the same request. Both services run Esplora and
return an identical response format, so moving over was only a question of the
host.

The second reason matters more. btcscan takes the first matching input or
output from a transaction, which makes it wrong about change. When you pay
0.1 BTC, your wallet cannot spend part of a coin — it spends the whole one and
returns the remainder to an address of your own. btcscan sees that return and
books income where there was an expense.

This plugin nets per wallet instead: satoshi arriving at the wallet's addresses
minus satoshi leaving them. Checked against live data — the sum of all
operations for an address matched the balance from `chain_stats` to the
satoshi.

## An account is a wallet, not an address

Hardware wallets hand out a new address per receipt, but a person thinks of
them as one account. So the settings have three wallet slots, and every address
listed in one slot (comma-separated) becomes a single account. The addresses go
into `syncIds`, while the account id is taken from the first address, so
renaming a wallet does not duplicate the account.

A transfer between two of the user's own wallets is merged into one operation
with two movements.

## Things worth knowing before merging

Accounts are matched between synchronizations through `syncIds`, so renaming a
wallet and reordering addresses inside a slot are both safe. Moving an address
from one slot to another is not: the same transactions are then re-derived
under the new grouping, and what used to be a move inside a single wallet can
become a transfer between two accounts. How the app reacts to that cannot be
verified from this repository.

xpub is not supported yet. The API does not serve it — `/api/xpub/{zpub}`
returns 404 on both mempool.space and blockstream.info — and deriving addresses
client-side means BIP32 plus a new dependency. Worth a separate task once this
lands.

## Verification

- 47 tests for the plugin; the repository-wide `yarn test` is green
  (532 suites, 2081 tests)
- `yarn build mempool` builds
- Live run against real wallets: two accounts, 13 operations, the transfer
  between the two own accounts was detected correctly, and each account's
  balance matched the sum of its movements

## A question for the maintainers

I left `<company>0</company>` in the manifest with a comment saying the number
is filled in at merge time, following what `example` does. If you would rather
see a specific id in the pull request itself, tell me which one and I will
update it.
