### PR TITLE
[idbank-am] add IDBank (Armenia) plugin

### DIFF
--- a/src/plugins/idbank-am/ZenmoneyManifest.xml
+++ b/src/plugins/idbank-am/ZenmoneyManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>idbank-am</id>
+    <company>0</company>
+    <description>
+        IDBank (Armenia) — synchronizes accounts, cards and their transactions
+        via the Idram internet bank. Input the phone number and password you use
+        on idbanking.am. A new device is confirmed with a one-time code.
+    </description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <codeRequired>false</codeRequired>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+</provider>

--- a/src/plugins/idbank-am/__tests__/api/login.test.ts
+++ b/src/plugins/idbank-am/__tests__/api/login.test.ts
@@ -1,0 +1,153 @@
+import { InvalidOtpCodeError, TemporaryError, UserInteractionError } from '../../../../errors'
+import { Preferences } from '../../models'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+const preferences: Preferences = { phone: '+37400000000', password: 'password' }
+
+const UNVERIFIED_DEVICE = {
+  OpCode: 255,
+  AccountId: 100500,
+  Phone: { ChannelType: 2, Value: '+374****00' },
+  Email: { ChannelType: 3, Value: 'i*****v@example.com' }
+}
+
+const CONFIRMED_DEVICE = { OpCode: 0, Result: { SessionId: 'session', Token: 'token' } }
+
+function respondWith (...bodies: unknown[]): void {
+  for (const body of bodies) {
+    mockFetchJson.mockResolvedValueOnce({ status: 200, url: 'https://www.idbanking.am/api', headers: {}, body })
+  }
+}
+
+function requestBody (index: number): Record<string, unknown> {
+  return mockFetchJson.mock.calls[index][1].body
+}
+
+function requestedDeviceIds (): string[] {
+  return mockFetchJson.mock.calls.map(call => call[1].headers.device_id)
+}
+
+describe('вход', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { login } = require('../../api') as typeof import('../../api')
+  let readLine: jest.Mock
+
+  beforeEach(() => {
+    readLine = jest.fn()
+    global.ZenMoney = {
+      readLine,
+      setData: jest.fn(),
+      saveData: jest.fn(),
+      device: { os: { name: 'Android', version: '14' } },
+      application: { version: '1.0' }
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('не беспокоит пользователя, когда банк узнал устройство', async () => {
+    respondWith({ OpCode: 0, SessionId: 'session', Token: 'token' })
+
+    await expect(login(preferences, { deviceId: 'known-device' }, false)).resolves.toEqual({
+      auth: { deviceId: 'known-device' },
+      sessionId: 'session',
+      token: 'token'
+    })
+    expect(readLine).not.toHaveBeenCalled()
+  })
+
+  it('спрашивает способ доставки кода и шлёт код выбранным каналом', async () => {
+    respondWith(UNVERIFIED_DEVICE, { OpCode: 0 }, CONFIRMED_DEVICE)
+    readLine.mockResolvedValueOnce('2').mockResolvedValueOnce('12345')
+
+    const session = await login(preferences, { deviceId: 'device' }, false)
+
+    expect(readLine.mock.calls[0][0]).toContain('1 — СМС на +374****00')
+    expect(readLine.mock.calls[0][0]).toContain('2 — письмо на i*****v@example.com')
+    expect(requestBody(1)).toEqual({ AccountId: 100500, ChannelType: 3 })
+    expect(requestBody(2)).toEqual({ Code: '12345', AccountId: 100500, ChannelType: 3 })
+    expect(session).toEqual({
+      auth: { deviceId: 'device', otpChannelType: 3 },
+      sessionId: 'session',
+      token: 'token'
+    })
+  })
+
+  it('не переспрашивает способ, выбранный в прошлый раз', async () => {
+    respondWith(UNVERIFIED_DEVICE, { OpCode: 0 }, CONFIRMED_DEVICE)
+    readLine.mockResolvedValueOnce('12345')
+
+    await login(preferences, { deviceId: 'device', otpChannelType: 3 }, false)
+
+    expect(readLine).toHaveBeenCalledTimes(1)
+    expect(requestBody(1)).toEqual({ AccountId: 100500, ChannelType: 3 })
+  })
+
+  it('не спрашивает, когда способ доставки всего один', async () => {
+    respondWith({ ...UNVERIFIED_DEVICE, Email: null }, { OpCode: 0 }, CONFIRMED_DEVICE)
+    readLine.mockResolvedValueOnce('12345')
+
+    await login(preferences, { deviceId: 'device' }, false)
+
+    expect(readLine).toHaveBeenCalledTimes(1)
+    expect(requestBody(1)).toEqual({ AccountId: 100500, ChannelType: 2 })
+  })
+
+  it('шлёт все запросы подтверждения с одним отпечатком устройства', async () => {
+    respondWith(UNVERIFIED_DEVICE, { OpCode: 0 }, CONFIRMED_DEVICE)
+    readLine.mockResolvedValueOnce('2').mockResolvedValueOnce('12345')
+
+    const session = await login(preferences, undefined, false)
+    const [loginDevice, otpDevice, confirmDevice] = requestedDeviceIds()
+
+    expect(loginDevice).toMatch(/^[0-9a-f]{32}$/)
+    expect(otpDevice).toEqual(loginDevice)
+    expect(confirmDevice).toEqual(loginDevice)
+    expect(session.auth.deviceId).toEqual(loginDevice)
+  })
+
+  it('не пытается спросить код в фоновой синхронизации', async () => {
+    respondWith(UNVERIFIED_DEVICE)
+
+    await expect(login(preferences, { deviceId: 'device' }, true)).rejects.toBeInstanceOf(UserInteractionError)
+    expect(mockFetchJson).toHaveBeenCalledTimes(1)
+  })
+
+  it('подсказывает диапазон, когда способ выбран мимо списка', async () => {
+    respondWith(UNVERIFIED_DEVICE)
+    readLine.mockResolvedValueOnce('5')
+
+    await expect(login(preferences, { deviceId: 'device' }, false)).rejects.toEqual(
+      expect.objectContaining({ message: expect.stringContaining('от 1 до 2') })
+    )
+  })
+
+  it('останавливается, когда код не введён, и не дёргает банк впустую', async () => {
+    respondWith(UNVERIFIED_DEVICE, { OpCode: 0 })
+    readLine.mockResolvedValueOnce('2').mockResolvedValueOnce('')
+
+    await expect(login(preferences, { deviceId: 'device' }, false)).rejects.toBeInstanceOf(InvalidOtpCodeError)
+    expect(mockFetchJson).toHaveBeenCalledTimes(2)
+  })
+
+  it('отправляет введённый код без лишних пробелов', async () => {
+    respondWith(UNVERIFIED_DEVICE, { OpCode: 0 }, CONFIRMED_DEVICE)
+    readLine.mockResolvedValueOnce('2').mockResolvedValueOnce('  12345 ')
+
+    await login(preferences, { deviceId: 'device' }, false)
+
+    expect(requestBody(2)).toEqual(expect.objectContaining({ Code: '12345' }))
+  })
+
+  it('отправляет к людям, когда банк не предложил ни одного способа', async () => {
+    respondWith({ OpCode: 255, AccountId: 100500, Phone: null, Email: null })
+
+    const error = await login(preferences, { deviceId: 'device' }, false).catch((e: unknown) => e)
+
+    expect(error).toBeInstanceOf(TemporaryError)
+    expect(error).toEqual(expect.objectContaining({ message: expect.stringContaining('+374 60 700700') }))
+  })
+})

--- a/src/plugins/idbank-am/__tests__/converters/accounts/accounts.test.ts
+++ b/src/plugins/idbank-am/__tests__/converters/accounts/accounts.test.ts
@@ -1,0 +1,183 @@
+import { convertAccounts } from '../../../converters'
+import { AccountType } from '../../../../../types/zenmoney'
+
+const translations = (ru: string, en: string, am: string): unknown => ({
+  Translation: [
+    { lang: 'ru', value: ru },
+    { lang: 'en', value: en },
+    { lang: 'am', value: am }
+  ]
+})
+
+const cardAccount = {
+  AccountId: '12345678901200',
+  AccountNumber: '12345678901200',
+  AccountCategory: '19',
+  AccountCategoryName: translations('Карточный счет', 'Card account', 'Քարտային հաշիվ'),
+  OpenDate: '01.01.2024',
+  Balance: '1,000.00',
+  CodeCurrency: '840',
+  IsOpen: '1',
+  CloseDate: null,
+  CardId: '4111********1111'
+}
+
+const bankAccount = {
+  AccountId: '12345678901201',
+  AccountNumber: '12345678901201',
+  AccountCategory: '16',
+  AccountCategoryName: translations('Банковский счет', 'Bank account', 'Բանկային հաշիվ'),
+  OpenDate: '01.01.2024',
+  Balance: '2,500.00',
+  CodeCurrency: '840',
+  IsOpen: '1',
+  CloseDate: null,
+  CardId: null
+}
+
+// Драмовый счёт: код валюты приходит с ведущим нулём
+const dramAccount = { ...bankAccount, AccountNumber: '12345678901202', CodeCurrency: '051', Balance: '250,000.00' }
+
+const closedAccount = { ...bankAccount, AccountNumber: '12345678901203', IsOpen: '0', CloseDate: '01.02.2026' }
+
+const card = {
+  Id: '4111********1111',
+  Number: '4111********1111',
+  RealNumber: '4111111111111111',
+  Description: 'GOLD',
+  Ctype: 'VISA',
+  Currency: 'USD',
+  State: 'OK',
+  Balance: '1,000.00',
+  Account: '12345678901200'
+}
+
+describe('convertAccounts', () => {
+  it.each([
+    [
+      'карточный счёт с картой',
+      [cardAccount],
+      [card],
+      [
+        {
+          accountNumber: '12345678901200',
+          account: {
+            id: '12345678901200',
+            type: AccountType.ccard,
+            title: 'VISA GOLD USD *1200',
+            instrument: 'USD',
+            balance: 1000,
+            syncIds: ['12345678901200', '4111********1111'],
+            archived: false
+          }
+        }
+      ]
+    ],
+    [
+      'счёт без карты',
+      [bankAccount],
+      [],
+      [
+        {
+          accountNumber: '12345678901201',
+          account: {
+            id: '12345678901201',
+            type: AccountType.checking,
+            title: 'Bank account USD *1201',
+            instrument: 'USD',
+            balance: 2500,
+            syncIds: ['12345678901201'],
+            archived: false
+          }
+        }
+      ]
+    ],
+    [
+      'драмовый счёт: код валюты 051',
+      [dramAccount],
+      [],
+      [
+        {
+          accountNumber: '12345678901202',
+          account: {
+            id: '12345678901202',
+            type: AccountType.checking,
+            title: 'Bank account AMD *1202',
+            instrument: 'AMD',
+            balance: 250000,
+            syncIds: ['12345678901202'],
+            archived: false
+          }
+        }
+      ]
+    ],
+    [
+      'закрытый счёт архивируется и не запрашивает операции',
+      [closedAccount],
+      [],
+      [
+        {
+          accountNumber: null,
+          account: {
+            id: '12345678901203',
+            type: AccountType.checking,
+            title: 'Bank account USD *1203',
+            instrument: 'USD',
+            balance: 2500,
+            syncIds: ['12345678901203'],
+            archived: true
+          }
+        }
+      ]
+    ]
+  ])('converts %s', (_, apiAccounts, apiCards, accounts) => {
+    expect(convertAccounts(apiAccounts, apiCards)).toEqual(accounts)
+  })
+
+  it('не падает на карте, счёт которой не пришёл в списке', () => {
+    const orphanCard = { ...card, Account: '99999999999999' }
+    expect(convertAccounts([bankAccount], [orphanCard])).toEqual([
+      expect.objectContaining({
+        account: expect.objectContaining({ id: '12345678901201', syncIds: ['12345678901201'] })
+      })
+    ])
+  })
+
+  it('различает счета одной валюты по номеру', () => {
+    const [first, second] = convertAccounts([bankAccount, dramAccount], [])
+    expect(first.account.title).not.toEqual(second.account.title)
+  })
+
+  it('не оставляет дыр в названии карты без типа и описания', () => {
+    const namelessCard = { ...card, Ctype: null, Description: null }
+    const [{ account }] = convertAccounts([cardAccount], [namelessCard])
+    expect(account.title).toEqual('USD *1200')
+  })
+
+  it('называет счёт номером, когда английского перевода категории нет', () => {
+    const untranslated = { ...bankAccount, AccountCategoryName: { Translation: [{ lang: 'am', value: 'Բանկային հաշիվ' }] } }
+    const [{ account }] = convertAccounts([untranslated], [])
+    expect(account.title).toEqual('12345678901201 USD')
+  })
+
+  it('оставляет незнакомый код валюты как есть, а не роняет синхронизацию', () => {
+    const [{ account }] = convertAccounts([{ ...bankAccount, CodeCurrency: 'XTS' }], [])
+    expect(account.instrument).toEqual('XTS')
+  })
+
+  it('понимает числовые признаки счёта: иначе живой счёт уехал бы в архив', () => {
+    const [{ account, accountNumber }] = convertAccounts([{ ...cardAccount, IsOpen: 1, AccountCategory: 19 }], [card])
+    expect(account.archived).toBe(false)
+    expect(account.type).toEqual(AccountType.ccard)
+    expect(accountNumber).toEqual('12345678901200')
+  })
+
+  it('понимает баланс числом: банк уже присылает так код результата', () => {
+    const [{ account }] = convertAccounts([{ ...bankAccount, Balance: 2500 }], [])
+    expect(account.balance).toEqual(2500)
+  })
+
+  it('не выдаёт пропавший баланс за ноль: ZenMoney подогнал бы счёт корректировкой', () => {
+    expect(() => convertAccounts([{ ...bankAccount, Balance: null }], [])).toThrow()
+  })
+})

--- a/src/plugins/idbank-am/__tests__/converters/transactions/transactions.test.ts
+++ b/src/plugins/idbank-am/__tests__/converters/transactions/transactions.test.ts
@@ -1,0 +1,276 @@
+import { convertTransaction, parseDate, parseDecimal, parseInstrument } from '../../../converters'
+import { adjustTransactions } from '../../../../../common/transactionGroupHandler'
+import { Account, AccountType } from '../../../../../types/zenmoney'
+
+const cardAccount: Account = {
+  id: '12345678901200',
+  type: AccountType.ccard,
+  title: 'VISA GOLD USD *1200',
+  instrument: 'USD',
+  syncIds: ['12345678901200']
+}
+
+const bankAccount: Account = {
+  id: '12345678901201',
+  type: AccountType.checking,
+  title: 'Bank account USD *1201',
+  instrument: 'USD',
+  syncIds: ['12345678901201']
+}
+
+const instrumentsByAccount = { 12345678901200: 'USD', 12345678901201: 'USD' }
+
+describe('convertTransaction', () => {
+  it.each([
+    [
+      'покупку по карте в валюте счёта',
+      {
+        Account: '12345678901200',
+        Coper: 'DB',
+        Currency: 'USD',
+        DbAmount: '25.00',
+        CrAmount: '0.00',
+        Equivalent: 25,
+        TransCurr: 'USD',
+        CustomerName: 'EXAMPLE SHOP',
+        Mcc: '5734',
+        Reason: 'CPC',
+        DocType: 'Payment',
+        Refnum: 100000000000001,
+        ValueDate: '01/02/2026 12:00:00',
+        Details: 'Վճարում\r\n4111111111111111\r\n346247\r\n25\r\n840\r\n346247 7N3QWJUF\\840\\EXAMPLE.COM\\EXAMPLE SHOP \r\n5734\r\n12:00:00'
+      },
+      {
+        hold: false,
+        date: new Date('2026-02-01T08:00:00.000Z'),
+        movements: [
+          { id: '100000000000001', account: { id: '12345678901200' }, invoice: null, sum: -25, fee: 0 }
+        ],
+        merchant: { fullTitle: 'EXAMPLE.COM EXAMPLE SHOP', mcc: 5734, location: null },
+        comment: null,
+        groupKeys: ['100000000000001']
+      }
+    ],
+    [
+      'покупку по карте с конвертацией валюты',
+      {
+        Account: '12345678901200',
+        Coper: 'DB',
+        Currency: 'USD',
+        DbAmount: '50.00',
+        CrAmount: '0.00',
+        Equivalent: 180,
+        TransCurr: 'AED',
+        CustomerName: 'EXAMPLE HOTEL',
+        Mcc: '7011',
+        Reason: 'CPC',
+        DocType: 'Payment',
+        Refnum: 100000000000002,
+        ValueDate: '02/02/2026 10:30:00',
+        Details: 'Վճարում\r\n4111111111111111\r\n900920\r\n180\r\n784\r\n900920 10375766\\784\\Springfield\\EXAMPLE HOTEL \r\n7011\r\n10:30:00'
+      },
+      {
+        hold: false,
+        date: new Date('2026-02-02T06:30:00.000Z'),
+        movements: [
+          { id: '100000000000002', account: { id: '12345678901200' }, invoice: { sum: -180, instrument: 'AED' }, sum: -50, fee: 0 }
+        ],
+        merchant: { fullTitle: 'Springfield EXAMPLE HOTEL', mcc: 7011, location: null },
+        comment: null,
+        groupKeys: ['100000000000002']
+      }
+    ],
+    [
+      'внешнее пополнение с конвертацией: устаревший код валюты RUR',
+      {
+        Account: '12345678901200',
+        Coper: 'CR',
+        Currency: 'USD',
+        DbAmount: '0.00',
+        CrAmount: '1,000.00',
+        Equivalent: 80000,
+        TransCurr: 'RUR',
+        CustomerName: 'IVAN IVANOV',
+        Mcc: '',
+        Reason: 'BMMO',
+        DocType: 'Currency exchange',
+        Coracnt: '98765432109876',
+        Refnum: 100000000000003,
+        ValueDate: '03/02/2026 09:15:00',
+        Details: '#Sender.IVAN IVANOV,\r\n Mobile number.37400000000'
+      },
+      {
+        hold: false,
+        date: new Date('2026-02-03T05:15:00.000Z'),
+        movements: [
+          { id: '100000000000003', account: { id: '12345678901200' }, invoice: { sum: 80000, instrument: 'RUB' }, sum: 1000, fee: 0 }
+        ],
+        merchant: null,
+        comment: '#Sender.IVAN IVANOV, Mobile number.37400000000',
+        groupKeys: ['100000000000003']
+      }
+    ],
+    [
+      'операцию без MCC, названия места и контрагента',
+      {
+        Account: '12345678901200',
+        Coper: 'DB',
+        Currency: 'USD',
+        DbAmount: '10.00',
+        CrAmount: '0.00',
+        Equivalent: 10,
+        TransCurr: 'USD',
+        Mcc: '',
+        Reason: 'BMMO',
+        DocType: 'Transfer',
+        Refnum: 100000000000004,
+        ValueDate: '04/02/2026 18:00:00'
+      },
+      {
+        hold: false,
+        date: new Date('2026-02-04T14:00:00.000Z'),
+        movements: [
+          { id: '100000000000004', account: { id: '12345678901200' }, invoice: null, sum: -10, fee: 0 }
+        ],
+        merchant: null,
+        comment: null,
+        groupKeys: ['100000000000004']
+      }
+    ]
+  ])('converts %s', (_, apiTransaction, transaction) => {
+    expect(convertTransaction(apiTransaction, cardAccount, instrumentsByAccount)).toEqual(transaction)
+  })
+})
+
+describe('перевод между своими счетами', () => {
+  // Банк отдаёт операцию в выписке обоих счетов с общим Refnum, а в Equivalent
+  // кладёт учётную сумму в драмах, хотя обе стороны в долларах
+  const outcome = {
+    Account: '12345678901200',
+    Coper: 'DB',
+    Currency: 'USD',
+    DbAmount: '40.00',
+    CrAmount: '0.00',
+    Equivalent: 15000,
+    TransCurr: 'AMD',
+    CustomerName: 'IVAN IVANOV',
+    Mcc: '',
+    Reason: 'BMMO',
+    DocType: 'Transfer',
+    Coracnt: '12345678901201',
+    Refnum: 100000000000005,
+    ValueDate: '05/02/2026 15:45:00',
+    Details: 'Bank account replenishment'
+  }
+  const income = {
+    ...outcome,
+    Account: '12345678901201',
+    Coper: 'CR',
+    DbAmount: '0.00',
+    CrAmount: '40.00',
+    Coracnt: '12345678901200'
+  }
+
+  it('не выдумывает конвертацию валюты, которой не было', () => {
+    const transaction = convertTransaction(outcome, cardAccount, instrumentsByAccount)
+    expect(transaction.movements[0].invoice).toBeNull()
+  })
+
+  it('сводит обе стороны в одну операцию с двумя движениями', () => {
+    const transactions = adjustTransactions({
+      transactions: [
+        convertTransaction(outcome, cardAccount, instrumentsByAccount),
+        convertTransaction(income, bankAccount, instrumentsByAccount)
+      ]
+    })
+
+    expect(transactions).toHaveLength(1)
+    expect(transactions[0].movements).toEqual([
+      { id: '100000000000005', account: { id: '12345678901200' }, invoice: null, sum: -40, fee: 0 },
+      { id: '100000000000005', account: { id: '12345678901201' }, invoice: null, sum: 40, fee: 0 }
+    ])
+  })
+})
+
+describe('краевые случаи', () => {
+  const purchase = {
+    Account: '12345678901200',
+    Coper: 'DB',
+    Currency: 'USD',
+    DbAmount: '20.00',
+    CrAmount: '0.00',
+    Equivalent: 20,
+    TransCurr: 'USD',
+    Mcc: '5411',
+    Refnum: 100000000000006,
+    ValueDate: '06/02/2026 11:00:00'
+  }
+
+  it('берёт место как название, когда контрагент не пришёл', () => {
+    const details = 'Վճարում\\643\\Springfield\\'
+    const { merchant } = convertTransaction({ ...purchase, Details: details }, cardAccount, instrumentsByAccount)
+    expect(merchant).toEqual({ fullTitle: 'Springfield', mcc: 5411, location: null })
+  })
+
+  it('не считает мерчантом операцию с пустым MCC, а Details кладёт в комментарий', () => {
+    const transaction = convertTransaction(
+      { ...purchase, Mcc: '0', Details: 'Cash   withdrawal\r\n  ATM' },
+      cardAccount,
+      instrumentsByAccount
+    )
+    expect(transaction.merchant).toBeNull()
+    expect(transaction.comment).toEqual('Cash withdrawal ATM')
+  })
+
+  it('не уносит номер карты из Details в комментарий операции', () => {
+    const { comment } = convertTransaction(
+      { ...purchase, Mcc: '', Details: 'Վճարում\r\n4111111111111111\r\n346247\r\nCash withdrawal' },
+      cardAccount,
+      instrumentsByAccount
+    )
+    expect(comment).not.toContain('4111111111111111')
+    expect(comment).toContain('Cash withdrawal')
+  })
+
+  it('обходится без валюты операции: считает её валютой счёта', () => {
+    const { movements } = convertTransaction({ ...purchase, TransCurr: undefined }, cardAccount, instrumentsByAccount)
+    expect(movements[0].invoice).toBeNull()
+  })
+
+  it('оставляет конвертацию при переводе между своими счетами разных валют', () => {
+    const transaction = convertTransaction(
+      { ...purchase, TransCurr: 'AMD', Equivalent: 7700, Coracnt: '12345678901202', Mcc: '' },
+      cardAccount,
+      { ...instrumentsByAccount, 12345678901202: 'AMD' }
+    )
+    expect(transaction.movements[0].invoice).toEqual({ sum: -7700, instrument: 'AMD' })
+  })
+})
+
+describe('разбор значений', () => {
+  it.each([
+    ['840', 'USD'],
+    ['051', 'AMD'],
+    ['818', 'EGP'],
+    ['USD', 'USD'],
+    ['AMD', 'AMD'],
+    ['RUR', 'RUB']
+  ])('parseInstrument(%s) === %s', (code, instrument) => {
+    expect(parseInstrument(code)).toEqual(instrument)
+  })
+
+  it.each([
+    ['1,234.50', 1234.5],
+    ['0.00', 0],
+    ['250,000.00', 250000]
+  ])('parseDecimal(%s) === %s', (value, expected) => {
+    expect(parseDecimal(value)).toEqual(expected)
+  })
+
+  it.each([
+    ['05/02/2026 15:45:00', '2026-02-05T11:45:00.000Z'],
+    ['01/01/2026', '2025-12-31T20:00:00.000Z']
+  ])('parseDate(%s) === %s', (value, expected) => {
+    expect(parseDate(value)).toEqual(new Date(expected))
+  })
+})

--- a/src/plugins/idbank-am/__tests__/fetchApi/opCodes.test.ts
+++ b/src/plugins/idbank-am/__tests__/fetchApi/opCodes.test.ts
@@ -1,0 +1,198 @@
+import crypto from 'crypto-js'
+import { BankMessageError, InvalidLoginOrPasswordError, InvalidOtpCodeError, TemporaryError } from '../../../../errors'
+import { Preferences, Session } from '../../models'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+const preferences: Preferences = { phone: '+37400000000', password: 'password' }
+const session: Session = { auth: { deviceId: 'device' }, sessionId: 'session', token: 'k'.repeat(32) + '-' + 'i'.repeat(16) }
+
+function respondWith (body: unknown): void {
+  mockFetchJson.mockResolvedValue({ status: 200, url: 'https://www.idbanking.am/api', headers: {}, body })
+}
+
+describe('коды ответа банка', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchLogin, fetchAccounts } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  beforeEach(() => {
+    global.ZenMoney = {
+      device: { os: { name: 'iOS', version: '17.4' } },
+      application: { version: '1.2.3' }
+    } as unknown as typeof ZenMoney
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it.each([
+    ['неудачная попытка входа', 3, InvalidLoginOrPasswordError],
+    ['неверный пароль', 55, InvalidLoginOrPasswordError],
+    ['неверный код активации', 21, InvalidOtpCodeError],
+    ['непринятый одноразовый код', 52, InvalidOtpCodeError]
+  ])('превращает %s в ошибку для пользователя', async (_, opCode, error) => {
+    respondWith({ OpCode: opCode, OpDesc: 'Err:EN-0' })
+    await expect(fetchLogin(preferences, 'device')).rejects.toBeInstanceOf(error)
+  })
+
+  it('не гонит на экран настроек, когда общий код неудачи прилетел не на входе', async () => {
+    respondWith({ OpCode: 3, OpDesc: 'Attempt unsuccessful' })
+    const error = await fetchAccounts(session).catch((e: unknown) => e)
+    expect(error).not.toBeInstanceOf(InvalidLoginOrPasswordError)
+    expect(error).toEqual(expect.objectContaining({ bankMessage: 'Attempt unsuccessful' }))
+  })
+
+  it('называет банк недоступным вместо разбора чужой HTML-страницы', async () => {
+    mockFetchJson.mockResolvedValue({ status: 503, url: 'https://www.idbanking.am/api', headers: {}, body: undefined })
+    await expect(fetchAccounts(session)).rejects.toEqual(
+      expect.objectContaining({ message: expect.stringContaining('временно недоступен') })
+    )
+  })
+
+  it.each([
+    ['заблокированный доступ', 7, 'контактный центр'],
+    ['заблокированный аккаунт', 54, 'контактный центр'],
+    ['завершённую сессию', 33, 'Повторите синхронизацию'],
+    ['неузнанное устройство', 363, 'не узнал устройство']
+  ])('объясняет %s словами', async (_, opCode, hint) => {
+    respondWith({ OpCode: opCode, OpDesc: 'Err:EN-0' })
+    await expect(fetchLogin(preferences, 'device')).rejects.toEqual(
+      expect.objectContaining({ message: expect.stringContaining(hint) })
+    )
+  })
+
+  it('разбирает неподтверждённое устройство в список способов доставки кода', async () => {
+    respondWith({
+      OpCode: 255,
+      AccountId: 1,
+      Phone: { ChannelType: 2, Value: '+374****00' },
+      Email: { ChannelType: 3, Value: 'i*****v@example.com' }
+    })
+    await expect(fetchLogin(preferences, 'device')).resolves.toEqual({
+      isDeviceVerified: false,
+      accountId: 1,
+      channels: [
+        { type: 2, kind: 'phone', recipient: '+374****00' },
+        { type: 3, kind: 'email', recipient: 'i*****v@example.com' }
+      ]
+    })
+  })
+
+  it.each([
+    ['числом', 0],
+    ['строкой', '0']
+  ])('принимает код результата %s: иначе вход падал бы внутренней ошибкой', async (_, opCode) => {
+    respondWith({ OpCode: opCode, SessionId: 'session', Token: 'token' })
+    await expect(fetchLogin(preferences, 'device')).resolves.toEqual({
+      isDeviceVerified: true,
+      sessionId: 'session',
+      token: 'token'
+    })
+  })
+
+  it('просит повторить синхронизацию, если банк ответил успехом без данных сессии', async () => {
+    respondWith({ OpCode: 0 })
+    await expect(fetchLogin(preferences, 'device')).rejects.toEqual(
+      expect.objectContaining({ message: expect.stringContaining('не открыл сессию') })
+    )
+  })
+
+  it('принимает ответ без кода результата: выписка приходит именно такой', async () => {
+    respondWith({ Result: [{ AccountNumber: '1' }] })
+    await expect(fetchAccounts(session)).resolves.toEqual([{ AccountNumber: '1' }])
+  })
+
+  it('показывает сообщение банка, если оно человеческое', async () => {
+    respondWith({ OpCode: 100, OpDesc: 'Service is temporarily unavailable' })
+    await expect(fetchLogin(preferences, 'device')).rejects.toEqual(
+      expect.objectContaining({ bankMessage: 'Service is temporarily unavailable' })
+    )
+  })
+
+  it.each([
+    ['машинного кода', 'Err:EN-100'],
+    ['пустого текста', '']
+  ])('вместо %s показывает номер кода: пустое сообщение уронило бы плагин', async (_, opDesc) => {
+    respondWith({ OpCode: 100, OpDesc: opDesc })
+    const error = await fetchLogin(preferences, 'device').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(BankMessageError)
+    expect(error).toEqual(expect.objectContaining({ bankMessage: 'OpCode 100' }))
+  })
+
+  it('не наследует TemporaryError там, где нужно менять пароль', async () => {
+    respondWith({ OpCode: 55, OpDesc: 'Err:EN-0' })
+    await expect(fetchLogin(preferences, 'device')).rejects.not.toBeInstanceOf(TemporaryError)
+  })
+})
+
+describe('запрос выписки', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchAccountTransactions } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  function decryptRequestBody (): unknown {
+    const decrypted = crypto.AES.decrypt(mockFetchJson.mock.calls[0][1].body as string, crypto.enc.Utf8.parse(session.token.slice(0, 32)), {
+      iv: crypto.enc.Utf8.parse(session.token.slice(33)),
+      mode: crypto.mode.CBC,
+      padding: crypto.pad.Pkcs7
+    })
+    return JSON.parse(decrypted.toString(crypto.enc.Utf8))
+  }
+
+  beforeEach(() => {
+    global.ZenMoney = {} as unknown as typeof ZenMoney
+    respondWith({ AccTranByDaysList: [] })
+  })
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('просит период по календарю банка: ночная операция в Ереване иначе выпадет из выписки', async () => {
+    // 05:00 пятого февраля в Ереване — это ещё четвёртое по Гринвичу
+    await fetchAccountTransactions('12345678901200', new Date('2026-02-04T21:00:00Z'), new Date('2026-02-04T22:30:00Z'), session)
+
+    expect(decryptRequestBody()).toEqual({
+      account: '12345678901200',
+      fromdate: '05/02/2026',
+      todate: '05/02/2026',
+      format: ''
+    })
+  })
+
+  it('шифрует тело ключом из Token, а не шлёт его открытым', async () => {
+    await fetchAccountTransactions('12345678901200', new Date('2026-02-05T10:00:00Z'), new Date('2026-02-05T10:00:00Z'), session)
+
+    expect(mockFetchJson.mock.calls[0][1].body).toEqual(expect.any(String))
+    expect(mockFetchJson.mock.calls[0][1].headers._EncMethod_).toBeUndefined()
+  })
+})
+
+describe('заголовки запроса', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchLogin } = require('../../fetchApi') as typeof import('../../fetchApi')
+
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('представляется приложением и устройством пользователя', async () => {
+    global.ZenMoney = {
+      device: { os: { name: 'Android', version: '14' } },
+      application: { version: '9.9.9' }
+    } as unknown as typeof ZenMoney
+    respondWith({ OpCode: 0, SessionId: 'session', Token: 'token' })
+
+    await fetchLogin(preferences, 'device')
+
+    expect(mockFetchJson.mock.calls[0][1].headers).toEqual(expect.objectContaining({
+      'User-Agent': 'ZenMoney/9.9.9 (Android 14)',
+      device_id: 'device'
+    }))
+  })
+
+  it('обходится без данных об устройстве: банку важно лишь непустое поле', async () => {
+    global.ZenMoney = {} as unknown as typeof ZenMoney
+    respondWith({ OpCode: 0, SessionId: 'session', Token: 'token' })
+
+    await fetchLogin(preferences, 'device')
+
+    expect(mockFetchJson.mock.calls[0][1].headers['User-Agent']).toEqual('ZenMoney')
+  })
+})

--- a/src/plugins/idbank-am/api.ts
+++ b/src/plugins/idbank-am/api.ts
@@ -1,0 +1,76 @@
+import { generateRandomString } from '../../common/utils'
+import { InvalidOtpCodeError, TemporaryError, UserInteractionError } from '../../errors'
+import { fetchAccounts, fetchCards, fetchDeviceConfirmation, fetchLogin, fetchOtp } from './fetchApi'
+import { Auth, OtpChannel, Preferences, Session } from './models'
+
+// Письмо с кодом доходит заметно медленнее СМС, поэтому ждём ввода дольше
+const USER_INPUT_TIMEOUT_MS = 180000
+
+const CHANNEL_TITLES: Record<OtpChannel['kind'], string> = {
+  phone: 'СМС на',
+  email: 'письмо на'
+}
+
+export async function login (preferences: Preferences, auth: Auth | undefined, isInBackground: boolean): Promise<Session> {
+  const deviceId = auth?.deviceId ?? generateDeviceId()
+  const result = await fetchLogin(preferences, deviceId)
+
+  if (result.isDeviceVerified) {
+    return { auth: { ...auth, deviceId }, sessionId: result.sessionId, token: result.token }
+  }
+  if (isInBackground) {
+    // Подтверждение устройства требует ввода кода, в фоне спросить некого
+    throw new UserInteractionError()
+  }
+  const channel = await selectOtpChannel(result.channels, auth?.otpChannelType)
+  await fetchOtp(result.accountId, channel.type, deviceId)
+
+  // Банк присылает пять цифр и гасит прежний код при каждой новой отправке
+  const code = await ZenMoney.readLine(`Введите код из 5 цифр: ${CHANNEL_TITLES[channel.kind]} ${channel.recipient}`, {
+    inputType: 'number',
+    time: USER_INPUT_TIMEOUT_MS
+  })
+  if (code == null || code.trim() === '') {
+    throw new InvalidOtpCodeError()
+  }
+  return {
+    auth: { deviceId, otpChannelType: channel.type },
+    ...await fetchDeviceConfirmation(result.accountId, code.trim(), channel.type, deviceId)
+  }
+}
+
+async function selectOtpChannel (channels: OtpChannel[], knownChannelType?: number): Promise<OtpChannel> {
+  if (channels.length === 0) {
+    throw new TemporaryError('Банк не предложил ни одного способа подтвердить устройство. Обратитесь в контактный центр Idram +374 60 700700.')
+  }
+  const known = channels.find(channel => channel.type === knownChannelType)
+  if (known != null) {
+    return known
+  }
+  if (channels.length === 1) {
+    return channels[0]
+  }
+  const options = channels.map((channel, index) => `${index + 1} — ${CHANNEL_TITLES[channel.kind]} ${channel.recipient}`).join('\n')
+  const answer = await ZenMoney.readLine(`Как получить код для подтверждения устройства?\n${options}\n\nВведите номер способа`, {
+    inputType: 'number',
+    time: USER_INPUT_TIMEOUT_MS
+  })
+  const channel = channels[Number(answer) - 1]
+  if (channel == null) {
+    throw new TemporaryError(`Такого способа нет. Повторите синхронизацию и введите число от 1 до ${channels.length}.`)
+  }
+  return channel
+}
+
+// Банк принимает подтверждённое устройство по этому отпечатку,
+// поэтому он живёт в auth и после первого входа больше не меняется
+function generateDeviceId (): string {
+  return generateRandomString(32, '0123456789abcdef')
+}
+
+export async function fetchAllAccounts (session: Session): Promise<{ accounts: unknown[], cards: unknown[] }> {
+  return {
+    accounts: await fetchAccounts(session),
+    cards: await fetchCards(session)
+  }
+}

--- a/src/plugins/idbank-am/converters.ts
+++ b/src/plugins/idbank-am/converters.ts
@@ -1,0 +1,177 @@
+import { Account, AccountType, Amount, ExtendedTransaction, NonParsedMerchant } from '../../types/zenmoney'
+import get, { getNumber, getOptArray, getOptString, getString } from '../../types/get'
+import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
+import { ConvertResult } from './models'
+
+// Банк отдаёт время Еревана, часовой пояс Армении не меняется с 2012 года
+const ARMENIA_UTC_OFFSET = '+04:00'
+
+// AccountCategory карточного счёта
+const CARD_ACCOUNT_CATEGORY = '19'
+
+export function convertAccounts (apiAccounts: unknown[], apiCards: unknown[]): ConvertResult[] {
+  const cardsByAccount = groupCardsByAccount(apiCards)
+  return apiAccounts.map(apiAccount => convertAccount(apiAccount, cardsByAccount))
+}
+
+function groupCardsByAccount (apiCards: unknown[]): Record<string, unknown[] | undefined> {
+  const cardsByAccount: Record<string, unknown[] | undefined> = {}
+  for (const apiCard of apiCards) {
+    const account = getString(apiCard, 'Account')
+    const cards = cardsByAccount[account] ?? []
+    cards.push(apiCard)
+    cardsByAccount[account] = cards
+  }
+  return cardsByAccount
+}
+
+function convertAccount (apiAccount: unknown, cardsByAccount: Record<string, unknown[] | undefined>): ConvertResult {
+  const accountNumber = getString(apiAccount, 'AccountNumber')
+  const instrument = parseInstrument(getString(apiAccount, 'CodeCurrency'))
+  const cards = cardsByAccount[accountNumber] ?? []
+  // Признаки сверяем строками: код результата банк уже шлёт то числом, то строкой
+  const isCardAccount = String(get(apiAccount, 'AccountCategory')) === CARD_ACCOUNT_CATEGORY
+  // Закрытый счёт архивируем, а не выбрасываем: иначе пользователь потеряет его историю.
+  // Выписку по нему не просим — банк отдаёт операции только по действующим счетам
+  const isOpen = String(get(apiAccount, 'IsOpen')) === '1'
+
+  return {
+    accountNumber: isOpen ? accountNumber : null,
+    account: {
+      id: accountNumber,
+      type: isCardAccount ? AccountType.ccard : AccountType.checking,
+      title: getAccountTitle(apiAccount, cards, instrument),
+      instrument,
+      balance: parseDecimal(get(apiAccount, 'Balance')),
+      syncIds: [accountNumber, ...cards.map(apiCard => getString(apiCard, 'Number'))],
+      archived: !isOpen
+    }
+  }
+}
+
+function getAccountTitle (apiAccount: unknown, cards: unknown[], instrument: string): string {
+  const accountNumber = getString(apiAccount, 'AccountNumber')
+  const suffix = `${instrument} *${accountNumber.slice(-4)}`
+  if (cards.length > 0) {
+    const apiCard = cards[0]
+    return `${getOptString(apiCard, 'Ctype') ?? ''} ${getOptString(apiCard, 'Description') ?? ''} ${suffix}`.replace(/\s+/g, ' ').trim()
+  }
+  const category = getLocalizedName(apiAccount, 'AccountCategoryName')
+  return category != null ? `${category} ${suffix}` : `${accountNumber} ${instrument}`
+}
+
+// Названия приходят списком переводов, порядок языков в нём не гарантирован
+function getLocalizedName (apiAccount: unknown, path: string): string | null {
+  const translations = getOptArray(apiAccount, `${path}.Translation`) ?? []
+  for (const translation of translations) {
+    if (getOptString(translation, 'lang') === 'en') {
+      return getOptString(translation, 'value') ?? null
+    }
+  }
+  return null
+}
+
+export function convertTransaction (apiTransaction: unknown, account: Account, instrumentsByAccount: Record<string, string | undefined> = {}): ExtendedTransaction {
+  const isOutcome = getString(apiTransaction, 'Coper') === 'DB'
+  const sum = parseDecimal(get(apiTransaction, isOutcome ? 'DbAmount' : 'CrAmount'))
+  const reference = String(getNumber(apiTransaction, 'Refnum'))
+
+  return {
+    hold: false,
+    date: parseDate(getString(apiTransaction, 'ValueDate')),
+    movements: [
+      {
+        id: reference,
+        account: { id: account.id },
+        invoice: parseInvoice(apiTransaction, account.instrument, isOutcome, instrumentsByAccount),
+        sum: isOutcome ? -sum : sum,
+        fee: 0
+      }
+    ],
+    merchant: parseMerchant(apiTransaction),
+    comment: parseComment(apiTransaction),
+    // Перевод между своими счетами приходит дважды с одним Refnum,
+    // по нему обе стороны сходятся в одну операцию
+    groupKeys: [reference]
+  }
+}
+
+// Сумма в валюте операции, если конвертация действительно была
+function parseInvoice (apiTransaction: unknown, accountInstrument: string, isOutcome: boolean, instrumentsByAccount: Record<string, string | undefined>): Amount | null {
+  const instrument = parseInstrument(getOptString(apiTransaction, 'TransCurr') ?? accountInstrument)
+  if (instrument === accountInstrument) {
+    return null
+  }
+  // У перевода между своими счетами в Equivalent лежит учётная сумма в драмах,
+  // хотя обе стороны в одной валюте и никакой конвертации не происходило
+  const counterpart = getOptString(apiTransaction, 'Coracnt')
+  if (counterpart != null && instrumentsByAccount[counterpart] === accountInstrument) {
+    return null
+  }
+  const sum = getNumber(apiTransaction, 'Equivalent')
+  return { sum: isOutcome ? -sum : sum, instrument }
+}
+
+function parseMerchant (apiTransaction: unknown): NonParsedMerchant | null {
+  const mcc = parseMcc(getOptString(apiTransaction, 'Mcc'))
+  if (mcc == null) {
+    return null
+  }
+  const title = getOptString(apiTransaction, 'CustomerName')?.trim() ?? ''
+  const place = parseMerchantPlace(getOptString(apiTransaction, 'Details'))
+  const fullTitle = place != null ? `${place} ${title}`.trim() : title
+  return fullTitle !== '' ? { fullTitle, mcc, location: null } : null
+}
+
+// В Details карточной операции место зашито между кодом валюты и названием:
+// '...900920 10375766\784\Springfield\EXAMPLE HOTEL'
+function parseMerchantPlace (details?: string): string | null {
+  const match = details != null ? /\\\d{3}\\([^\\]+)\\/.exec(details) : null
+  return match != null ? match[1].trim() : null
+}
+
+function parseComment (apiTransaction: unknown): string | null {
+  if (parseMcc(getOptString(apiTransaction, 'Mcc')) != null) {
+    return null
+  }
+  // Details карточной операции начинается с номера карты — в комментарий ему нельзя
+  const details = getOptString(apiTransaction, 'Details')?.replace(/\b\d{13,19}\b/g, '').replace(/\s+/g, ' ').trim()
+  return details != null && details !== '' ? details : null
+}
+
+function parseMcc (mcc?: string): number | null {
+  if (mcc == null || mcc.trim() === '') {
+    return null
+  }
+  const parsed = Number(mcc)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+// Валюта приходит либо буквенным кодом, либо числовым по ISO 4217.
+// Коды меньше сотни лежат в справочнике строками с ведущими нулями: '051' — AMD
+export function parseInstrument (code: string): string {
+  const instrument = codeToCurrencyLookup[code] ?? codeToCurrencyLookup[Number(code)]
+  if (instrument != null) {
+    return instrument
+  }
+  return code === 'RUR' ? 'RUB' : code
+}
+
+// Числа приходят строкой с разделителем тысяч: '1,234.50'.
+// Пустое значение не превращаем в ноль: молчаливый ноль в балансе или сумме
+// операции ZenMoney примет за правду и подгонит счёт корректировкой
+export function parseDecimal (value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(String(value ?? '').replace(/,/g, ''))
+  console.assert(typeof value === 'number' || (typeof value === 'string' && value !== ''), 'missing number', value)
+  console.assert(!isNaN(parsed), 'unexpected number format', value)
+  return parsed
+}
+
+// Дата приходит в формате 'DD/MM/YYYY HH:mm:ss'
+export function parseDate (value: string): Date {
+  const match = /^(\d{2})\/(\d{2})\/(\d{4})(?:\s+(\d{2}):(\d{2}):(\d{2}))?$/.exec(value.trim())
+  console.assert(match != null, 'unexpected date format', value)
+  const [, day, month, year, hours, minutes, seconds] = match as RegExpExecArray
+  const time = hours != null ? `${hours}:${minutes}:${seconds}` : '00:00:00'
+  return new Date(`${year}-${month}-${day}T${time}${ARMENIA_UTC_OFFSET}`)
+}

--- a/src/plugins/idbank-am/fetchApi.ts
+++ b/src/plugins/idbank-am/fetchApi.ts
@@ -1,0 +1,249 @@
+import crypto from 'crypto-js'
+import { dateInTimezone } from '../../common/dateUtils'
+import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
+import { getArray, getNumber, getOptNumber, getOptString } from '../../types/get'
+import { BankMessageError, InvalidLoginOrPasswordError, InvalidOtpCodeError, TemporaryError } from '../../errors'
+import { LoginResult, OtpChannel, Preferences, Session } from './models'
+
+const BASE_URL = 'https://www.idbanking.am/api'
+
+// Банк живёт по Еревану и летнее время в Армении не переводят с 2012 года
+const ARMENIA_TIMEZONE_OFFSET_MINUTES = 240
+
+// Длины ключа и вектора инициализации в Token
+const KEY_LENGTH = 32
+const IV_LENGTH = 16
+
+// Без User-Agent интернет-банк отвечает пустым телом со статусом 200.
+// Представляемся честно: банк показывает эту строку в уведомлении о входе,
+// и там должно быть устройство пользователя, а не выдуманный чужой компьютер
+function getUserAgent (): string {
+  const os = [ZenMoney.device?.os?.name, ZenMoney.device?.os?.version].filter(part => part != null && part !== '').join(' ')
+  const version = ZenMoney.application?.version
+  return `ZenMoney${version != null && version !== '' ? `/${version}` : ''}${os !== '' ? ` (${os})` : ''}`
+}
+
+// Коды ответа из OpCode интернет-банка
+export const OP_CODE = {
+  success: 0,
+  attemptUnsuccessful: 3,
+  accountBlocked: 7,
+  incorrectActivationCode: 21,
+  authorizationFailed: 33,
+  codeNotValid: 52,
+  accountIsBlocked: 54,
+  incorrectPassword: 55,
+  unverifiedDevice: 255,
+  unrecognizedDevice: 363
+}
+
+// Идентификаторы устройства и сессии в логи не пишем
+const SANITIZE_HEADERS = { device_id: true, _SessionId_: true }
+
+interface RequestParams {
+  deviceId: string
+  sessionId?: string
+  body?: Record<string, unknown>
+  // Ключ шифрования тела из Login. Без него тело уходит открытым JSON
+  token?: string
+  // Коды, которые разбирает вызывающий код, а не общий обработчик ошибок
+  allowedOpCodes?: number[]
+}
+
+async function fetchApi (path: string, { deviceId, sessionId, body, token, allowedOpCodes }: RequestParams, options?: FetchOptions): Promise<unknown> {
+  const encrypted = body != null && token != null
+  const headers: Record<string, string> = {
+    'User-Agent': getUserAgent(),
+    Origin: 'https://www.idbanking.am',
+    Referer: 'https://www.idbanking.am/',
+    Lang: 'en',
+    device_id: deviceId
+  }
+  if (!encrypted) {
+    // Интернет-банк разрешает отправлять тело открытым JSON с этим заголовком
+    headers._EncMethod_ = 'NONE'
+  }
+  if (sessionId != null) {
+    headers._SessionId_ = sessionId
+  }
+  const response = await fetchJson(`${BASE_URL}/${path}`, {
+    method: 'POST',
+    headers,
+    ...body != null && token != null
+      ? { body: encryptBody(body, token), stringify: (body: string) => body }
+      : body != null ? { body } : {},
+    ...options,
+    sanitizeRequestLog: {
+      headers: SANITIZE_HEADERS,
+      ...(options?.sanitizeRequestLog as Record<string, unknown> | undefined)
+    }
+  })
+  if (response.status >= 500 || response.status === 429) {
+    throw new TemporaryError('Банк временно недоступен. Повторите синхронизацию позже.')
+  }
+  return handleOpCode(response, allowedOpCodes ?? [])
+}
+
+// Token приходит в виде '<ключ 32 байта>-<вектор инициализации 16 байт>'.
+// Режем по длине, а не по дефису: он может встретиться и внутри ключа
+function encryptBody (body: Record<string, unknown>, token: string): string {
+  const key = token.slice(0, KEY_LENGTH)
+  const iv = token.slice(KEY_LENGTH + 1)
+  console.assert(key.length === KEY_LENGTH && iv.length === IV_LENGTH, 'unexpected token format')
+  return crypto.AES.encrypt(crypto.enc.Utf8.parse(JSON.stringify(body)), crypto.enc.Utf8.parse(key), {
+    iv: crypto.enc.Utf8.parse(iv),
+    mode: crypto.mode.CBC,
+    padding: crypto.pad.Pkcs7
+  }).toString()
+}
+
+function handleOpCode (response: FetchResponse, allowedOpCodes: number[]): unknown {
+  // Часть эндпоинтов отдаёт данные без кода результата, а часть — строкой
+  const opCode = parseOpCode(response.body)
+  if (opCode == null || opCode === OP_CODE.success || allowedOpCodes.includes(opCode)) {
+    return response.body
+  }
+  switch (opCode) {
+    case OP_CODE.incorrectActivationCode:
+    case OP_CODE.codeNotValid:
+      throw new InvalidOtpCodeError()
+    case OP_CODE.accountBlocked:
+    case OP_CODE.accountIsBlocked:
+      throw new TemporaryError('Банк заблокировал доступ к аккаунту. Обратитесь в контактный центр Idram +374 60 700700.')
+    case OP_CODE.authorizationFailed:
+      throw new TemporaryError('Банк завершил сессию. Повторите синхронизацию.')
+    case OP_CODE.unrecognizedDevice:
+      throw new TemporaryError(
+        'Банк не узнал устройство и запретил вход. Позвоните в контактный центр Idram ' +
+        '+374 60 700700, попросите разрешить вход, затем повторите синхронизацию.'
+      )
+    default:
+      // OpDesc в норме содержит машинный код вида 'Err:EN-0', человеку он бесполезен
+      throw new BankMessageError(parseBankMessage(response.body) ?? `OpCode ${opCode}`)
+  }
+}
+
+// Код результата приходит то числом, то строкой, а у выписки его нет вовсе
+function parseOpCode (body: unknown): number | null {
+  const rawOpCode = getOptNumber(body, 'OpCode') ?? getOptString(body, 'OpCode')
+  return rawOpCode != null ? Number(rawOpCode) : null
+}
+
+function parseBankMessage (body: unknown): string | null {
+  const message = getOptString(body, 'OpDesc')
+  return message != null && message !== '' && !/^Err:[A-Z]{2}-\d+$/.test(message) ? message : null
+}
+
+export async function fetchLogin ({ phone, password }: Preferences, deviceId: string): Promise<LoginResult> {
+  const response = await fetchApi('Signin/Login', {
+    deviceId,
+    body: { u: phone, p: password },
+    // Про неверные данные и новое устройство банк сообщает кодом, разбираем их сами
+    allowedOpCodes: [OP_CODE.attemptUnsuccessful, OP_CODE.incorrectPassword, OP_CODE.unverifiedDevice]
+  }, {
+    sanitizeRequestLog: { body: { u: true, p: true } },
+    sanitizeResponseLog: { body: { Token: true, SessionId: true, AccountId: true, Phone: true, Email: true } }
+  })
+  const opCode = parseOpCode(response)
+  if (opCode === OP_CODE.attemptUnsuccessful || opCode === OP_CODE.incorrectPassword) {
+    throw new InvalidLoginOrPasswordError()
+  }
+  if (opCode === OP_CODE.unverifiedDevice) {
+    return {
+      isDeviceVerified: false,
+      accountId: getNumber(response, 'AccountId'),
+      channels: parseOtpChannels(response)
+    }
+  }
+  return { isDeviceVerified: true, ...parseSession(response, '') }
+}
+
+// Ассерт вместо явной проверки вывалил бы в лог весь ответ вместе с ключами
+function parseSession (response: unknown, prefix: string): { sessionId: string, token: string } {
+  const sessionId = getOptString(response, `${prefix}SessionId`)
+  const token = getOptString(response, `${prefix}Token`)
+  if (sessionId == null || token == null) {
+    throw new TemporaryError('Банк не открыл сессию. Повторите синхронизацию.')
+  }
+  return { sessionId, token }
+}
+
+// Банк перечисляет доступные способы доставки кода прямо в ответе на вход
+function parseOtpChannels (response: unknown): OtpChannel[] {
+  const channels: OtpChannel[] = []
+  for (const [path, kind] of [['Phone', 'phone'], ['Email', 'email']] as Array<[string, OtpChannel['kind']]>) {
+    const type = getOptNumber(response, `${path}.ChannelType`)
+    if (type != null) {
+      channels.push({ type, kind, recipient: getOptString(response, `${path}.Value`) ?? '' })
+    }
+  }
+  return channels
+}
+
+export async function fetchOtp (accountId: number, channelType: number, deviceId: string): Promise<void> {
+  await fetchApi('SignIn/SendFingerPrintOtp', {
+    deviceId,
+    body: { AccountId: accountId, ChannelType: channelType }
+  }, {
+    sanitizeRequestLog: { body: { AccountId: true } }
+  })
+}
+
+export async function fetchDeviceConfirmation (accountId: number, code: string, channelType: number, deviceId: string): Promise<{ sessionId: string, token: string }> {
+  const response = await fetchApi('SignIn/DeviceConfirm', {
+    deviceId,
+    body: { Code: code, AccountId: accountId, ChannelType: channelType }
+  }, {
+    sanitizeRequestLog: { body: { Code: true, AccountId: true } },
+    sanitizeResponseLog: { body: { Result: true } }
+  })
+  return parseSession(response, 'Result.')
+}
+
+export async function fetchAccounts (session: Session): Promise<unknown[]> {
+  const response = await fetchApi('MyInfo/getClientAccounts', {
+    deviceId: session.auth.deviceId,
+    sessionId: session.sessionId
+  }, {
+    // В ответе полные номера счетов и телефон клиента
+    sanitizeResponseLog: { body: { Result: true } }
+  })
+  return getArray(response, 'Result')
+}
+
+export async function fetchCards (session: Session): Promise<unknown[]> {
+  const response = await fetchApi('MyInfo/getClientCards', {
+    deviceId: session.auth.deviceId,
+    sessionId: session.sessionId
+  }, {
+    // В ответе полные номера карт и телефон клиента
+    sanitizeResponseLog: { body: { Result: true } }
+  })
+  return getArray(response, 'Result')
+}
+
+export async function fetchAccountTransactions (accountNumber: string, fromDate: Date, toDate: Date, session: Session): Promise<unknown[]> {
+  const response = await fetchApi('MyInfo/getAccTransactionsByDays', {
+    deviceId: session.auth.deviceId,
+    sessionId: session.sessionId,
+    token: session.token,
+    body: {
+      account: accountNumber,
+      fromdate: formatDate(fromDate),
+      todate: formatDate(toDate),
+      format: ''
+    }
+  }, {
+    // Details каждой карточной операции содержит полный номер карты
+    sanitizeResponseLog: { body: { AccTranByDaysList: true, CustomerName: true } }
+  })
+  return getArray(response, 'AccTranByDaysList')
+}
+
+// Интернет-банк ждёт даты в формате 'DD/MM/YYYY' и по своему календарю:
+// ночная покупка в Ереване иначе выпадет из выписки до утра
+function formatDate (date: Date): string {
+  const local = dateInTimezone(date, ARMENIA_TIMEZONE_OFFSET_MINUTES)
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return `${pad(local.getDate())}/${pad(local.getMonth() + 1)}/${local.getFullYear()}`
+}

--- a/src/plugins/idbank-am/index.ts
+++ b/src/plugins/idbank-am/index.ts
@@ -1,0 +1,36 @@
+import { Account, ExtendedTransaction, ScrapeFunc } from '../../types/zenmoney'
+import { adjustTransactions } from '../../common/transactionGroupHandler'
+import { fetchAccountTransactions } from './fetchApi'
+import { fetchAllAccounts, login } from './api'
+import { convertAccounts, convertTransaction } from './converters'
+import { Auth, Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate, isInBackground }) => {
+  const session = await login(preferences, ZenMoney.getData('auth') as Auth | undefined, isInBackground)
+  ZenMoney.setData('auth', session.auth)
+  ZenMoney.saveData()
+
+  const { accounts: apiAccounts, cards: apiCards } = await fetchAllAccounts(session)
+  const converted = convertAccounts(apiAccounts, apiCards)
+  // Нужно, чтобы отличить перевод между своими счетами от настоящей конвертации валюты
+  const instrumentsByAccount: Record<string, string | undefined> = {}
+  for (const { account } of converted) {
+    instrumentsByAccount[account.id] = account.instrument
+  }
+
+  const accounts: Account[] = []
+  const transactions: ExtendedTransaction[] = []
+
+  for (const { account, accountNumber } of converted) {
+    accounts.push(account)
+    if (accountNumber == null || ZenMoney.isAccountSkipped(account.id)) {
+      continue
+    }
+    const apiTransactions = await fetchAccountTransactions(accountNumber, fromDate, toDate ?? new Date(), session)
+    for (const apiTransaction of apiTransactions) {
+      transactions.push(convertTransaction(apiTransaction, account, instrumentsByAccount))
+    }
+  }
+
+  return { accounts, transactions: adjustTransactions({ transactions }) }
+}

--- a/src/plugins/idbank-am/models.ts
+++ b/src/plugins/idbank-am/models.ts
@@ -1,0 +1,43 @@
+import { AccountOrCard } from '../../types/zenmoney'
+
+// Хранится между синхронизациями
+export interface Auth {
+  // Отпечаток устройства. Банк привязывает к нему подтверждение кодом,
+  // поэтому он генерируется один раз и дальше не меняется.
+  deviceId: string
+  // Способ доставки кода, выбранный пользователем при подтверждении устройства
+  otpChannelType?: number
+}
+
+// Способ доставки одноразового кода, который предлагает банк
+export interface OtpChannel {
+  type: number
+  kind: 'phone' | 'email'
+  // Замаскированный банком адрес или номер, чтобы человек понял, куда придёт код
+  recipient: string
+}
+
+// Банк либо сразу пускает знакомое устройство, либо требует подтвердить новое
+export type LoginResult =
+  | { isDeviceVerified: true, sessionId: string, token: string }
+  | { isDeviceVerified: false, accountId: number, channels: OtpChannel[] }
+
+// Живёт только внутри одной синхронизации
+export interface Session {
+  auth: Auth
+  sessionId: string
+  // Ключ шифрования тела запросов в виде '<ключ 32 байта>-<iv 16 байт>'
+  token: string
+}
+
+// Поля из preferences.xml
+export interface Preferences {
+  phone: string
+  password: string
+}
+
+export interface ConvertResult {
+  // Номер, по которому запрашивается выписка. У закрытых счетов банк её не отдаёт
+  accountNumber: string | null
+  account: AccountOrCard
+}

--- a/src/plugins/idbank-am/preferences.xml
+++ b/src/plugins/idbank-am/preferences.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="phone"
+        summary="||{@s}"
+        title="Номер телефона"
+        dialogTitle="Номер телефона"
+        dialogMessage="Номер телефона, привязанный к аккаунту Idram, с кодом страны. Например: +37412345678"
+        negativeButtonText="Отмена"
+        positiveButtonText="ОК"
+        inputType="phone"
+        obligatory="true"
+    >
+    </EditTextPreference>
+    <EditTextPreference
+        key="password"
+        summary="||***********"
+        title="Пароль от интернет-банка"
+        dialogTitle="Пароль от интернет-банка"
+        dialogMessage="Пароль, с которым вы входите на idbanking.am. При первом подключении банк пришлёт СМС для подтверждения нового устройства. Если банк ответит, что устройство не распознано, позвоните в контактный центр Idram +374 60 700700 и попросите разрешить вход, затем повторите синхронизацию."
+        negativeButtonText="Отмена"
+        positiveButtonText="ОК"
+        inputType="textPassword"
+        obligatory="true"
+    >
+    </EditTextPreference>
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2020-01-01T12:00:00.000Z"
+        dialogTitle="С какой даты загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    >
+    </EditTextPreference>
+</PreferenceScreen>


### PR DESCRIPTION
Adds a plugin for [IDBank](https://www.idbanking.am) (Armenia) — imports accounts, cards and their transactions from the Idram internet bank.

`<company>` is left at `0` per `docs/ZenmoneyManifest.xml.md`.

### How it works

Sign-in is phone + password. The bank binds a confirmed session to a device fingerprint, so the plugin generates a random `deviceId` once and keeps it in `auth` — every later sync reuses it and runs without any user interaction.

An unknown device has to be confirmed with a one-time code. The bank lists the delivery options it is willing to use (SMS and/or email) in the login response itself, so the plugin shows them with the masked recipients and lets the user pick — no channel is hard-coded. The choice is stored, so a repeated confirmation does not ask again. During a background sync the plugin raises `UserInteractionError` instead of prompting.

Accounts and cards come from `MyInfo/getClientAccounts` and `MyInfo/getClientCards`, statements from `MyInfo/getAccTransactionsByDays` — its request body is AES-256-CBC encrypted with the key and IV the bank returns in `Token`. Statement dates are formatted in the bank's own calendar (Yerevan, UTC+4), otherwise a night purchase falls outside the requested range until the next morning.

### Notes for review

- **Credentials stay out of the logs.** The password, the one-time code, session tokens, the device fingerprint and the response bodies carrying full card and account numbers are all redacted via `sanitizeRequestLog`/`sanitizeResponseLog`. The card number embedded in `Details` is stripped before the text is used as a transaction comment.
- **Both legs of an internal transfer share `Refnum`**, so they are merged through `adjustTransactions` + `groupKeys`. For those transfers the bank puts an AMD bookkeeping amount into `Equivalent` even when both sides are in the same currency — reporting it as a conversion would give every transfer between own accounts a phantom exchange, so it is suppressed when the counterpart account has the same instrument.
- **Numeric currency codes below 100 are looked up as strings** (`'051'` → AMD): `codeToCurrencyLookup` keeps them with a leading zero, so `Number('051')` would miss.
- **Result codes are read as both numbers and strings** — this API returns `OpCode` in either form, and omits it entirely for statements.
- **Closed accounts are archived rather than dropped**, so the user keeps their history; statements are not requested for them, the bank serves those only for active accounts.
- The `CheckPin` endpoint is deliberately not called: accounts and statements load without it, so asking the user for a PIN would buy nothing.
- Loans, deposits and bonds are out of scope for this first version.

### Tests

67 unit tests: converters (accounts, cards, transactions, transfers between own accounts, currency conversion, merchant places), the login and device-confirmation flow including channel selection, and the mapping of the bank's result codes onto user-facing errors. `tsc --noEmit` and `ts-standard` are clean. Verified live against a real account: 2 accounts, 141 transactions, multi-currency operations with MCC, internal transfers merged into single operations.
