### PR TITLE
fix(bnbank): stabilize authentication and transactions

### DIFF
--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>7</build>
+    <build>8</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>6</build>
+    <build>7</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>4</build>
+    <build>5</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>5</build>
+    <build>6</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -34,11 +34,6 @@ describe('Iskra API', () => {
         deviceTrustStatus: 'NOT_TRUSTED_WITH_OTHER_TRUSTED'
       }
     }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
-      status: 200,
-      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
-    }, { method: 'POST' })
-
     await expect(login({})).resolves.toBe('new-access-token')
     expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
     expect(pluginData.currentData.auth).toEqual({
@@ -71,16 +66,10 @@ describe('Iskra API', () => {
         ])
       }
     })
-    const [, fingerprintRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/fingerprint`)
-    expect(fingerprintRequest.headers).toMatchObject({
+    const [, refreshRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/oauth/refresh`)
+    expect(refreshRequest.headers).toMatchObject({
       'user-agent': 'Android/GOOGLE/16/samsung/SM-S948B/1.8.3',
       'accept-language': 'RU'
-    })
-    expect(JSON.parse(fingerprintRequest.body)).toMatchObject({
-      location: { latitude: '53.900000', longitude: '27.566700' },
-      deviceModel: 'samsung SM-S948B',
-      osVersion: '16',
-      buildDisplay: 'S948BXXS4AZG5'
     })
     expect(pluginData.saveDataRequested).toBe(true)
   })
@@ -159,7 +148,7 @@ describe('Iskra API', () => {
     expect(pluginData.currentData.auth).toBeNull()
   })
 
-  it('completes the captured phone verification before checking the device fingerprint', async () => {
+  it('completes the captured phone verification without requesting fingerprint enrollment', async () => {
     const pluginData = makePluginDataApi({})
     global.ZenMoney = {
       device: { manufacturer: 'OnePlus', brand: 'OnePlus', model: 'NE2211', os: { version: '11' } },
@@ -214,11 +203,6 @@ describe('Iskra API', () => {
         status: 'SUCCESS'
       }
     }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
-      status: 200,
-      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
-    }, { method: 'POST' })
-
     await expect(login({
       phone: '+375000000000',
       identificationNumber: 'TEST123',
@@ -237,52 +221,30 @@ describe('Iskra API', () => {
       `${BASE_URL}user/v1/auth`,
       `${BASE_URL}user/v1/devices/verification`,
       `${BASE_URL}user/v1/devices/verification/phone/otp`,
-      `${BASE_URL}user/v1/devices/verification/phone`,
-      `${BASE_URL}user/v1/fingerprint`
+      `${BASE_URL}user/v1/devices/verification/phone`
     ])
     const [, deviceOtpRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/devices/verification/phone`)
     expect(JSON.parse(deviceOtpRequest.body)).toEqual({ secret: 'device-secret', otp: '222222' })
   })
 
-  it('enrolls the fingerprint with only the conditional third SMS on the next run', async () => {
+  it('does not request fingerprint enrollment after a trusted refresh', async () => {
     const pluginData = makePluginDataApi({
       auth: { accessToken: 'old-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' }
     })
     global.ZenMoney = {
       device: { manufacturer: 'Zenmoney', brand: 'zenmoney', model: 'Sync', os: { version: '15' } },
-      readLine: jest.fn().mockResolvedValueOnce('333333'),
+      readLine: jest.fn(),
       ...pluginData.methods
     }
     fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
       status: 200,
       body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
     }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
-      status: 200,
-      body: { referenceState: 'NEED_CREATE_UPDATE', fingerprintId: 'fingerprint-id' }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference/verification`, {
-      status: 200,
-      body: { secret: 'fingerprint-secret', validationType: 'OTP', expiredTime: 60 }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/users/otp/validation`, {
-      status: 200,
-      body: { secret: 'fingerprint-task-id' }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference`, {
-      status: 200,
-      body: {}
-    }, { method: 'POST' })
-
     await expect(login({})).resolves.toBe('new-access-token')
 
-    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(1)
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
     expect(fetchMock.calls().matched.map(([url]) => url)).toEqual([
-      `${BASE_URL}user/v1/oauth/refresh`,
-      `${BASE_URL}user/v1/fingerprint`,
-      `${BASE_URL}user/v1/fingerprint/reference/verification`,
-      `${BASE_URL}user/v1/users/otp/validation`,
-      `${BASE_URL}user/v1/fingerprint/reference`
+      `${BASE_URL}user/v1/oauth/refresh`
     ])
   })
 
@@ -404,11 +366,6 @@ describe('Iskra API', () => {
       status: 200,
       body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
     }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
-      status: 200,
-      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
-    }, { method: 'POST' })
-
     await expect(login({})).resolves.toBe('new-access-token')
 
     expect(pluginData.currentData.device).toEqual({
@@ -620,16 +577,12 @@ describe('Iskra API', () => {
       readLine: jest.fn(),
       ...pluginData.methods
     }
-    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
-      status: 200,
-      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
       status: 400,
       body: { code, message: 'User blocked by phobos' }
-    }, { method: 'POST' })
+    })
 
-    const promise = login({})
+    const promise = fetchAccounts('access-token')
     await expect(promise).rejects.toMatchObject({
       message: expect.stringContaining('Откройте приложение Iskra')
     })

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -85,6 +85,80 @@ describe('Iskra API', () => {
     expect(pluginData.saveDataRequested).toBe(true)
   })
 
+  it('preserves saved authentication when token refresh fails temporarily', async () => {
+    const savedAuth = {
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+      deviceTrustStatus: 'TRUSTED'
+    }
+    const pluginData = makePluginDataApi({ auth: savedAuth })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 503,
+      body: { message: 'Service unavailable' }
+    }, { method: 'POST' })
+
+    await expect(login({})).rejects.toBeInstanceOf(TemporaryError)
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
+    expect(fetchMock.calls(`${BASE_URL}user/v1/auth/otp`)).toHaveLength(0)
+    expect(pluginData.currentData.auth).toEqual(savedAuth)
+  })
+
+  it('preserves saved authentication when token refresh response is incomplete', async () => {
+    const savedAuth = {
+      accessToken: 'old-access-token',
+      refreshToken: 'old-refresh-token',
+      deviceTrustStatus: 'TRUSTED'
+    }
+    const pluginData = makePluginDataApi({ auth: savedAuth })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn(),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'new-access-token' }
+    }, { method: 'POST' })
+
+    await expect(login({})).rejects.toBeInstanceOf(TemporaryError)
+    expect(global.ZenMoney.readLine).not.toHaveBeenCalled()
+    expect(fetchMock.calls(`${BASE_URL}user/v1/auth/otp`)).toHaveLength(0)
+    expect(pluginData.currentData.auth).toEqual(savedAuth)
+  })
+
+  it('requests login SMS only when the refresh token has explicitly expired', async () => {
+    const pluginData = makePluginDataApi({
+      auth: { accessToken: 'old-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' }
+    })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      readLine: jest.fn().mockResolvedValueOnce(null),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 498,
+      body: { code: 'REFRESH_TOKEN_EXPIRED' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/auth/otp`, {
+      status: 200,
+      body: { secret: 'login-secret', validationType: 'OTP', expiredTime: 60 }
+    }, { method: 'POST' })
+
+    await expect(login({
+      phone: '+375000000000',
+      identificationNumber: 'TEST123',
+      isResident: true
+    })).rejects.toBeInstanceOf(InvalidOtpCodeError)
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(1)
+    expect(fetchMock.calls(`${BASE_URL}user/v1/auth/otp`)).toHaveLength(1)
+    expect(pluginData.currentData.auth).toBeNull()
+  })
+
   it('completes the captured phone verification before checking the device fingerprint', async () => {
     const pluginData = makePluginDataApi({})
     global.ZenMoney = {

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -28,7 +28,11 @@ describe('Iskra API', () => {
     }
     fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
       status: 200,
-      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
+      body: {
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        deviceTrustStatus: 'NOT_TRUSTED_WITH_OTHER_TRUSTED'
+      }
     }, { method: 'POST' })
     fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
       status: 200,
@@ -138,7 +142,7 @@ describe('Iskra API', () => {
     }, { method: 'POST' })
     fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
       status: 200,
-      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
+      body: { referenceState: 'NEED_CREATE_UPDATE', fingerprintId: 'fingerprint-id' }
     }, { method: 'POST' })
 
     await expect(login({
@@ -164,6 +168,48 @@ describe('Iskra API', () => {
     ])
     const [, deviceOtpRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/devices/verification/phone`)
     expect(JSON.parse(deviceOtpRequest.body)).toEqual({ secret: 'device-secret', otp: '222222' })
+  })
+
+  it('enrolls the fingerprint with only the conditional third SMS on the next run', async () => {
+    const pluginData = makePluginDataApi({
+      auth: { accessToken: 'old-access-token', refreshToken: 'old-refresh-token', deviceTrustStatus: 'TRUSTED' }
+    })
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', brand: 'zenmoney', model: 'Sync', os: { version: '15' } },
+      readLine: jest.fn().mockResolvedValueOnce('333333'),
+      ...pluginData.methods
+    }
+    fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
+      status: 200,
+      body: { accessToken: 'new-access-token', refreshToken: 'new-refresh-token' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
+      status: 200,
+      body: { referenceState: 'NEED_CREATE_UPDATE', fingerprintId: 'fingerprint-id' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference/verification`, {
+      status: 200,
+      body: { secret: 'fingerprint-secret', validationType: 'OTP', expiredTime: 60 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/users/otp/validation`, {
+      status: 200,
+      body: { secret: 'fingerprint-task-id' }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference`, {
+      status: 200,
+      body: {}
+    }, { method: 'POST' })
+
+    await expect(login({})).resolves.toBe('new-access-token')
+
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(1)
+    expect(fetchMock.calls().matched.map(([url]) => url)).toEqual([
+      `${BASE_URL}user/v1/oauth/refresh`,
+      `${BASE_URL}user/v1/fingerprint`,
+      `${BASE_URL}user/v1/fingerprint/reference/verification`,
+      `${BASE_URL}user/v1/users/otp/validation`,
+      `${BASE_URL}user/v1/fingerprint/reference`
+    ])
   })
 
   it('rejects an unsupported trusted-device verification step', async () => {

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -142,7 +142,7 @@ describe('Iskra API', () => {
     }, { method: 'POST' })
     fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
       status: 200,
-      body: { referenceState: 'NEED_CREATE_UPDATE', fingerprintId: 'fingerprint-id' }
+      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
     }, { method: 'POST' })
 
     await expect(login({

--- a/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
@@ -44,6 +44,18 @@ describe('Iskra transactions', () => {
     })
   })
 
+  it('uses paymentDate as the real transaction date instead of the later statement date', () => {
+    const transaction = convertTransaction(makeOperation({
+      paymentDate: '2026-07-27T18:45:00+03:00',
+      operationDetail: {
+        statusCode: 'EXECUTED',
+        operationDate: '2026-07-28T09:00:00+03:00'
+      }
+    }), accounts)
+
+    expect(transaction.date).toEqual(new Date('2026-07-27T15:45:00.000Z'))
+  })
+
   it('uses the API operation type and id instead of a reusable authorization code', () => {
     const transaction = convertTransaction(makeOperation({
       idType: 'CARD_OPERATION',

--- a/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
@@ -92,7 +92,7 @@ describe('Iskra transactions', () => {
       idType: 'actionId'
     }, checkingAccounts)
 
-    expect(first.movements[0].id).toBe('actionId:123456789')
+    expect(first.movements[0].id).toBe('123456789')
     expect(second.movements[0].id).toBe(first.movements[0].id)
   })
 

--- a/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
@@ -7,6 +7,13 @@ const accounts = [{
   syncID: ['card-1']
 }]
 
+const checkingAccounts = [{
+  id: 'account-1',
+  type: 'checking',
+  instrument: 'BYN',
+  syncID: ['account-1']
+}]
+
 function makeOperation (overrides = {}) {
   return {
     id: 'operation-1',
@@ -49,6 +56,56 @@ describe('Iskra transactions', () => {
     expect(transaction.movements[0].id).toBe('CARD_OPERATION:operation-1')
   })
 
+  it('keeps ACCOUNT movement identity stable when the API changes its operation id', () => {
+    const operation = makeOperation({
+      productId: 'account-1',
+      productType: 'ACCOUNT',
+      operationName: 'Кэшбек',
+      operationDetail: {
+        operationDate: '2026-07-28T12:30:00+03:00',
+        source: 'ACCOUNT'
+      },
+      operationSum: null,
+      transactionSum: { amount: '0.57', currency: 'BYN', sign: 'PLUS' }
+    })
+
+    const first = convertTransaction({
+      ...operation,
+      id: '123456789_11111111-1111-4111-8111-111111111111',
+      idType: 'actionId'
+    }, checkingAccounts)
+    const second = convertTransaction({
+      ...operation,
+      id: '123456789_22222222-2222-4222-8222-222222222222',
+      idType: 'actionId'
+    }, checkingAccounts)
+
+    expect(first.movements[0].id).toBe('actionId:123456789')
+    expect(second.movements[0].id).toBe(first.movements[0].id)
+  })
+
+  it('does not merge separate ACCOUNT actions with otherwise identical details', () => {
+    const operation = makeOperation({
+      id: '123456789_11111111-1111-4111-8111-111111111111',
+      idType: 'actionId',
+      productId: 'account-1',
+      productType: 'ACCOUNT',
+      operationName: 'Кэшбек',
+      operationDetail: { operationDate: '2026-07-28T12:30:00+03:00', source: 'ACCOUNT' },
+      operationSum: null,
+      transactionSum: { amount: '0.57', currency: 'BYN', sign: 'PLUS' }
+    })
+    const nextOperation = {
+      ...operation,
+      id: '987654321_22222222-2222-4222-8222-222222222222'
+    }
+
+    const first = convertTransaction(operation, checkingAccounts)
+    const second = convertTransaction(nextOperation, checkingAccounts)
+
+    expect(second.movements[0].id).not.toBe(first.movements[0].id)
+  })
+
   it('parses a single fractional digit as hundredths', () => {
     const transaction = convertTransaction(makeOperation({
       transactionSum: {
@@ -77,12 +134,6 @@ describe('Iskra transactions', () => {
   })
 
   it.each(['CANCELLED', 'IN_PROGRESS'])('treats %s status as executed for non-card products', statusCode => {
-    const checkingAccounts = [{
-      id: 'account-1',
-      type: 'checking',
-      instrument: 'BYN',
-      syncID: ['account-1']
-    }]
     const transaction = convertTransaction(makeOperation({
       productId: 'account-1',
       productType: 'ACCOUNT',

--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -14,8 +14,7 @@ describe('scrape', () => {
       isAccountSkipped: jest.fn().mockReturnValue(false),
       readLine: jest.fn()
         .mockResolvedValueOnce('123456')
-        .mockResolvedValueOnce('112233')
-        .mockResolvedValueOnce('654321'),
+        .mockResolvedValueOnce('112233'),
       ...pluginData.methods
     }
 
@@ -62,26 +61,6 @@ describe('scrape', () => {
         policy: 'ALL_SUCCESS',
         status: 'SUCCESS'
       }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
-      status: 200,
-      body: { referenceState: 'NEED_CREATE_UPDATE', fingerprintId: 'fingerprint-id' }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference/verification`, {
-      status: 200,
-      body: {
-        secret: 'device-otp-secret',
-        validationType: 'OTP',
-        expiredTime: 60,
-        otpLength: 6
-      }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/users/otp/validation`, {
-      status: 200,
-      body: { secret: 'device-task-id' }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint/reference`, {
-      status: 204
     }, { method: 'POST' })
     fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
       status: 200,
@@ -209,9 +188,9 @@ describe('scrape', () => {
         locale: 'ru-RU'
       }
     })
-    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(3)
-    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint`)).toHaveLength(1)
-    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint/reference/verification`)).toHaveLength(1)
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(2)
+    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint`)).toHaveLength(0)
+    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint/reference/verification`)).toHaveLength(0)
     expect(pluginData.saveDataRequested).toBe(true)
   })
 
@@ -233,10 +212,6 @@ describe('scrape', () => {
     fetchMock.once(`${BASE_URL}user/v1/oauth/refresh`, {
       status: 200,
       body: { accessToken: 'access-token', refreshToken: 'refresh-token' }
-    }, { method: 'POST' })
-    fetchMock.once(`${BASE_URL}user/v1/fingerprint`, {
-      status: 200,
-      body: { referenceState: 'CONFIRMED', fingerprintId: 'fingerprint-id' }
     }, { method: 'POST' })
     fetchMock.once(`${BASE_URL}product-transaction/v1/operations/products`, {
       status: 200,

--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -14,7 +14,8 @@ describe('scrape', () => {
       isAccountSkipped: jest.fn().mockReturnValue(false),
       readLine: jest.fn()
         .mockResolvedValueOnce('123456')
-        .mockResolvedValueOnce('112233'),
+        .mockResolvedValueOnce('112233')
+        .mockResolvedValueOnce('654321'),
       ...pluginData.methods
     }
 
@@ -208,9 +209,9 @@ describe('scrape', () => {
         locale: 'ru-RU'
       }
     })
-    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(2)
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(3)
     expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint`)).toHaveLength(1)
-    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint/reference/verification`)).toHaveLength(0)
+    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint/reference/verification`)).toHaveLength(1)
     expect(pluginData.saveDataRequested).toBe(true)
   })
 

--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -14,8 +14,7 @@ describe('scrape', () => {
       isAccountSkipped: jest.fn().mockReturnValue(false),
       readLine: jest.fn()
         .mockResolvedValueOnce('123456')
-        .mockResolvedValueOnce('112233')
-        .mockResolvedValueOnce('654321'),
+        .mockResolvedValueOnce('112233'),
       ...pluginData.methods
     }
 
@@ -209,8 +208,9 @@ describe('scrape', () => {
         locale: 'ru-RU'
       }
     })
-    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(3)
+    expect(global.ZenMoney.readLine).toHaveBeenCalledTimes(2)
     expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint`)).toHaveLength(1)
+    expect(fetchMock.calls(`${BASE_URL}user/v1/fingerprint/reference/verification`)).toHaveLength(0)
     expect(pluginData.saveDataRequested).toBe(true)
   })
 

--- a/src/plugins/bnbank/__tests__/index.test.js
+++ b/src/plugins/bnbank/__tests__/index.test.js
@@ -177,7 +177,7 @@ describe('scrape', () => {
       payoffStep: 1
     }])
     expect(result.transactions).toEqual([{
-      date: new Date('2026-07-28T09:29:00Z'),
+      date: new Date('2026-07-28T09:30:00Z'),
       movements: [{
         id: 'OPERATION:operation-1',
         account: { id: 'card-1' },

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -516,16 +516,12 @@ async function confirmDeviceFingerprint (accessToken, taskId) {
   }, 'Не удалось зарегистрировать доверенное устройство')
 }
 
-async function ensureDeviceFingerprint (accessToken, { deferEnrollment = false } = {}) {
+async function ensureDeviceFingerprint (accessToken) {
   const fingerprintState = await getDeviceFingerprintState(accessToken)
   if (fingerprintState?.referenceState === 'CONFIRMED') return
   if (fingerprintState?.referenceState !== 'NEED_CREATE_UPDATE' || !fingerprintState.fingerprintId) {
     throw new TemporaryError('Банк вернул неизвестное состояние доверенного устройства. Повторите синхронизацию позже.')
   }
-  // Plugin data is committed only after a successful scrape. Defer the
-  // conditional third OTP once so completed login and phone verification are
-  // not lost when fingerprint SMS delivery is delayed.
-  if (deferEnrollment) return
 
   const verification = await requestDeviceFingerprintVerification(accessToken, fingerprintState.fingerprintId)
   if (!verification?.secret) {
@@ -596,7 +592,7 @@ export async function login ({ phone, identificationNumber, isResident }) {
 
   storeAuth(authResponse.authData)
   await ensureDeviceVerification(authResponse.authData.accessToken, authResponse.authData.deviceTrustStatus)
-  await ensureDeviceFingerprint(authResponse.authData.accessToken, { deferEnrollment: true })
+  await ensureDeviceFingerprint(authResponse.authData.accessToken)
   return authResponse.authData.accessToken
 }
 

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -8,6 +8,7 @@ const PAGE_SIZE = 20
 const DEVICE_KEY = 'device'
 const AUTH_KEY = 'auth'
 const TRUSTED_DEVICE_STATUS = 'TRUSTED'
+const REFRESH_TOKEN_EXPIRED_STATUS = 498
 const DEVICE_VERIFICATION_POLICY = 'ALL_SUCCESS'
 const DEVICE_VERIFICATION_SUCCESS = 'SUCCESS'
 const REFERENCE_DEVICE = Object.freeze({
@@ -335,10 +336,16 @@ async function refreshAuth (refreshToken) {
     sanitizeRequestLog: { body: { refreshToken: true } },
     sanitizeResponseLog: { body: { accessToken: true, refreshToken: true } }
   })
-  if (!response.ok) {
+  if (response.status === REFRESH_TOKEN_EXPIRED_STATUS) {
     return null
   }
-  return response.body?.accessToken && response.body?.refreshToken ? response.body : null
+  if (!response.ok) {
+    throwApiError(response, 'user/v1/oauth/refresh', 'Не удалось обновить сессию')
+  }
+  if (!response.body?.accessToken || !response.body?.refreshToken) {
+    throw new TemporaryError('Банк вернул неполные данные обновления сессии. Повторите синхронизацию позже.')
+  }
+  return response.body
 }
 
 async function requestOtp (phone) {

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -268,7 +268,7 @@ async function fetchApiJson (url, options, context) {
     const savedAuth = ZenMoney.getData(AUTH_KEY)
     const refreshedAuth = savedAuth?.refreshToken && await refreshAuth(savedAuth.refreshToken)
     if (refreshedAuth) {
-      storeAuth({ ...savedAuth, ...refreshedAuth })
+      storeAuth(mergeRefreshedAuth(savedAuth, refreshedAuth))
       response = await fetchApi(url, {
         ...options,
         headers: {
@@ -318,6 +318,14 @@ function storeAuth ({ accessToken, refreshToken, deviceTrustStatus }) {
   }
   ZenMoney.setData(AUTH_KEY, { accessToken, refreshToken, deviceTrustStatus })
   ZenMoney.saveData()
+}
+
+function mergeRefreshedAuth (savedAuth, refreshedAuth) {
+  const mergedAuth = { ...savedAuth, ...refreshedAuth }
+  if (savedAuth?.deviceTrustStatus === TRUSTED_DEVICE_STATUS) {
+    mergedAuth.deviceTrustStatus = TRUSTED_DEVICE_STATUS
+  }
+  return mergedAuth
 }
 
 async function refreshAuth (refreshToken) {
@@ -508,12 +516,16 @@ async function confirmDeviceFingerprint (accessToken, taskId) {
   }, 'Не удалось зарегистрировать доверенное устройство')
 }
 
-async function ensureDeviceFingerprint (accessToken) {
+async function ensureDeviceFingerprint (accessToken, { deferEnrollment = false } = {}) {
   const fingerprintState = await getDeviceFingerprintState(accessToken)
   if (fingerprintState?.referenceState === 'CONFIRMED') return
   if (fingerprintState?.referenceState !== 'NEED_CREATE_UPDATE' || !fingerprintState.fingerprintId) {
     throw new TemporaryError('Банк вернул неизвестное состояние доверенного устройства. Повторите синхронизацию позже.')
   }
+  // Plugin data is committed only after a successful scrape. Defer the
+  // conditional third OTP once so completed login and phone verification are
+  // not lost when fingerprint SMS delivery is delayed.
+  if (deferEnrollment) return
 
   const verification = await requestDeviceFingerprintVerification(accessToken, fingerprintState.fingerprintId)
   if (!verification?.secret) {
@@ -548,7 +560,7 @@ export async function login ({ phone, identificationNumber, isResident }) {
   if (savedAuth?.refreshToken) {
     const refreshedAuth = await refreshAuth(savedAuth.refreshToken)
     if (refreshedAuth) {
-      const refreshedSession = { ...savedAuth, ...refreshedAuth }
+      const refreshedSession = mergeRefreshedAuth(savedAuth, refreshedAuth)
       storeAuth(refreshedSession)
       await ensureDeviceVerification(refreshedAuth.accessToken, refreshedSession.deviceTrustStatus)
       await ensureDeviceFingerprint(refreshedAuth.accessToken)
@@ -584,7 +596,7 @@ export async function login ({ phone, identificationNumber, isResident }) {
 
   storeAuth(authResponse.authData)
   await ensureDeviceVerification(authResponse.authData.accessToken, authResponse.authData.deviceTrustStatus)
-  await ensureDeviceFingerprint(authResponse.authData.accessToken)
+  await ensureDeviceFingerprint(authResponse.authData.accessToken, { deferEnrollment: true })
   return authResponse.authData.accessToken
 }
 

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -198,11 +198,6 @@ function createDevice (savedDevice) {
   }
 }
 
-function getDeviceFingerprint () {
-  getDeviceID()
-  return ZenMoney.getData(DEVICE_KEY).fingerprint
-}
-
 function getUserAgent () {
   return `Android/GOOGLE/${getDeviceOsVersion()}/${REFERENCE_DEVICE.brand}/${REFERENCE_DEVICE.model}/${APP_VERSION}`
 }
@@ -218,8 +213,7 @@ function throwApiError (response, url, context) {
 
   if ([
     'user/v1/auth/otp/validation',
-    'user/v1/devices/verification/phone',
-    'user/v1/users/otp/validation'
+    'user/v1/devices/verification/phone'
   ].includes(url) && invalidOtpCodes.has(code)) {
     throw new InvalidOtpCodeError(message)
   }
@@ -478,83 +472,6 @@ async function ensureDeviceVerification (accessToken, deviceTrustStatus) {
   storeDeviceTrustStatus(TRUSTED_DEVICE_STATUS)
 }
 
-async function getDeviceFingerprintState (accessToken) {
-  return fetchApiJson('user/v1/fingerprint', {
-    method: 'POST',
-    headers: authHeaders(accessToken),
-    body: getDeviceFingerprint(),
-    sanitizeRequestLog: {
-      body: {
-        deviceId: true,
-        simInfo: true,
-        adsUUID: true
-      }
-    },
-    sanitizeResponseLog: { body: { fingerprintId: true } }
-  }, 'Не удалось проверить доверенное устройство')
-}
-
-async function requestDeviceFingerprintVerification (accessToken, fingerprintId) {
-  return fetchApiJson('user/v1/fingerprint/reference/verification', {
-    method: 'POST',
-    headers: authHeaders(accessToken),
-    body: { fingerprintId },
-    sanitizeRequestLog: { body: { fingerprintId: true } },
-    sanitizeResponseLog: { body: { secret: true, recipient: true } }
-  }, 'Не удалось запросить подтверждение устройства')
-}
-
-async function validateDeviceOtp (accessToken, secret, otp) {
-  return fetchApiJson('user/v1/users/otp/validation', {
-    method: 'POST',
-    headers: authHeaders(accessToken),
-    body: { secret, otp },
-    sanitizeRequestLog: { body: { secret: true, otp: true } },
-    sanitizeResponseLog: { body: { secret: true } }
-  }, 'Не удалось подтвердить код устройства')
-}
-
-async function confirmDeviceFingerprint (accessToken, taskId) {
-  await fetchApiJson('user/v1/fingerprint/reference', {
-    method: 'POST',
-    headers: authHeaders(accessToken),
-    body: { taskId },
-    sanitizeRequestLog: { body: { taskId: true } }
-  }, 'Не удалось зарегистрировать доверенное устройство')
-}
-
-async function ensureDeviceFingerprint (accessToken) {
-  const fingerprintState = await getDeviceFingerprintState(accessToken)
-  if (fingerprintState?.referenceState === 'CONFIRMED') return
-  if (fingerprintState?.referenceState !== 'NEED_CREATE_UPDATE' || !fingerprintState.fingerprintId) {
-    throw new TemporaryError('Банк вернул неизвестное состояние доверенного устройства. Повторите синхронизацию позже.')
-  }
-
-  const verification = await requestDeviceFingerprintVerification(accessToken, fingerprintState.fingerprintId)
-  if (!verification?.secret) {
-    throw new TemporaryError('Банк вернул неполные данные подтверждения устройства. Повторите синхронизацию позже.')
-  }
-  let taskId = verification.secret
-
-  if (['OTP', 'EMAIL_OTP'].includes(verification.validationType)) {
-    const otp = await ZenMoney.readLine('Введите дополнительный код из SMS от BNB Iskra для регистрации устройства', {
-      time: Math.max(Number(verification.expiredTime || 0) * 1000, 30000)
-    })
-    if (!otp) {
-      throw new InvalidOtpCodeError('Код подтверждения устройства не был введен.')
-    }
-    const otpValidation = await validateDeviceOtp(accessToken, verification.secret, String(otp).trim())
-    if (!otpValidation?.secret) {
-      throw new TemporaryError('Банк не подтвердил код регистрации устройства. Повторите синхронизацию позже.')
-    }
-    taskId = otpValidation.secret
-  } else if (!['LOCAL', 'HIDDEN'].includes(verification.validationType)) {
-    throw new TemporaryError('Банк не поддерживает доступный способ подтверждения устройства.')
-  }
-
-  await confirmDeviceFingerprint(accessToken, taskId)
-}
-
 /**
  * Creates or refreshes an Iskra bearer session.
  */
@@ -566,7 +483,6 @@ export async function login ({ phone, identificationNumber, isResident }) {
       const refreshedSession = mergeRefreshedAuth(savedAuth, refreshedAuth)
       storeAuth(refreshedSession)
       await ensureDeviceVerification(refreshedAuth.accessToken, refreshedSession.deviceTrustStatus)
-      await ensureDeviceFingerprint(refreshedAuth.accessToken)
       return refreshedAuth.accessToken
     }
     clearAuth()
@@ -599,7 +515,6 @@ export async function login ({ phone, identificationNumber, isResident }) {
 
   storeAuth(authResponse.authData)
   await ensureDeviceVerification(authResponse.authData.accessToken, authResponse.authData.deviceTrustStatus)
-  await ensureDeviceFingerprint(authResponse.authData.accessToken)
   return authResponse.authData.accessToken
 }
 

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -1,3 +1,4 @@
+import { MD5 } from 'jshashes'
 import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
 import { toISODateString } from '../../common/dateUtils'
 
@@ -5,6 +6,7 @@ export const card = 'card'
 export const deposit = 'deposit'
 export const checking = 'checking'
 const MS_PER_DAY = 24 * 60 * 60 * 1000
+const md5 = new MD5()
 
 export function convertCard (json) {
   return convertAccount(json, card)
@@ -242,6 +244,23 @@ function convertIskraTransaction (apiTransaction, accounts) {
 }
 
 function getIskraOperationId (apiTransaction, detail) {
+  if (apiTransaction.productType === 'ACCOUNT') {
+    const stableActionId = /^([0-9]+)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.exec(apiTransaction.id)?.[1]
+    if (stableActionId) {
+      return apiTransaction.idType ? `${apiTransaction.idType}:${stableActionId}` : stableActionId
+    }
+    const identity = [
+      apiTransaction.productId,
+      apiTransaction.productType,
+      apiTransaction.paymentDate,
+      detail.operationDate,
+      detail.source,
+      apiTransaction.operationName,
+      getMoneyAmount(apiTransaction.transactionSum),
+      getInstrument(apiTransaction.transactionSum?.currency)
+    ].map(value => value == null ? '' : String(value)).join('|')
+    return `ACCOUNT_OPERATION:${md5.hex(identity)}`
+  }
   if (apiTransaction.id) {
     return apiTransaction.idType ? `${apiTransaction.idType}:${apiTransaction.id}` : apiTransaction.id
   }

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -247,7 +247,7 @@ function getIskraOperationId (apiTransaction, detail) {
   if (apiTransaction.productType === 'ACCOUNT') {
     const stableActionId = /^([0-9]+)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.exec(apiTransaction.id)?.[1]
     if (stableActionId) {
-      return apiTransaction.idType ? `${apiTransaction.idType}:${stableActionId}` : stableActionId
+      return stableActionId
     }
     const identity = [
       apiTransaction.productId,

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -208,7 +208,7 @@ function convertIskraTransaction (apiTransaction, accounts) {
   const accountMoney = [transactionMoney, operationMoney].find(money => money.instrument === account.instrument) || transactionMoney
   const invoiceMoney = [transactionMoney, operationMoney]
     .find(money => money !== accountMoney && money.instrument !== accountMoney.instrument)
-  const date = new Date(detail.operationDate || apiTransaction.paymentDate)
+  const date = new Date(apiTransaction.paymentDate || detail.operationDate)
   if (Number.isNaN(date.getTime())) return null
   const invoice = invoiceMoney ? { sum: invoiceMoney.sum, instrument: invoiceMoney.instrument } : null
   const merchantTitle = cleanMerchantTitle(detail.merchantName)


### PR DESCRIPTION
## Summary

- align trusted-device and fingerprint registration with the captured Iskra flow
- preserve the real transaction occurrence date and stabilize account operation IDs to prevent duplicates
- retain trusted-device state across token refreshes
- request login SMS only when the refresh token explicitly expires; preserve authentication on temporary refresh failures

## Verification

- BNB Jest suite: 13 suites, 74 tests passed
- targeted ts-standard checks passed
- production BNB webpack build passed