### PR TITLE
fix(vtb-by): stabilize transaction identifiers

### DIFF
--- a/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
+++ b/src/plugins/vtb-by/__tests__/converters/convert-card-statement-operation.test.ts
@@ -30,7 +30,7 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Покупка\nSTORE',
       movements: [
         {
-          id: 'test-card-contract-1:auth:1777561115000:999',
+          id: '470f17b250bf56e32c63e8767925e05f',
           account: { id: 'test-card-contract-1' },
           fee: 0,
           invoice: {
@@ -131,7 +131,7 @@ describe('convertMiniCardStatementOperation', () => {
     }
 
     expect(convertMiniCardStatementOperation(operation, account).movements[0].id)
-      .toBe('test-card-contract-1:details:1777561115000:-10:840:32:933:Покупка:STORE:5411')
+      .toBe('3ede197e1c640a5a0f227b721b25d842')
   })
 
   it('converts a full statement operation for deposit accounts', () => {
@@ -173,7 +173,7 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Капитализация',
       movements: [
         {
-          id: 'test-deposit-contract-1:1778389322000:999:19:1:13155.4:13155.4:965877.97:Капитализация',
+          id: '8327cff1ec0ad829d1182cc3e68c02a8',
           account: { id: 'test-deposit-contract-1' },
           fee: 0,
           invoice: null,
@@ -182,6 +182,10 @@ describe('convertMiniCardStatementOperation', () => {
       ],
       merchant: null
     })
+
+    const repeatedOperation = convertFullStatementOperation({ ...operation }, account)
+    expect(repeatedOperation.movements[0].id).toBe('8327cff1ec0ad829d1182cc3e68c02a8')
+    expect(repeatedOperation.movements[0].id).toHaveLength(32)
   })
 
   it('keeps outgoing full statement operations distinct and negative', () => {
@@ -223,7 +227,7 @@ describe('convertMiniCardStatementOperation', () => {
       comment: 'Списание',
       movements: [
         {
-          id: 'test-deposit-contract-1:1778389322000:1:1:-1:-1000:-1000:964877.97:Списание',
+          id: '5cfbc2511a95ef70afaaa0d74bc484fa',
           account: { id: 'test-deposit-contract-1' },
           fee: 0,
           invoice: null,

--- a/src/plugins/vtb-by/converters.ts
+++ b/src/plugins/vtb-by/converters.ts
@@ -1,4 +1,5 @@
 import { getIntervalBetweenDates } from '../../common/momentDateUtils'
+import md5 from 'crypto-js/md5'
 import { Account, AccountType, Transaction } from '../../types/zenmoney'
 import { ensureCurrency, getMaskedCardLastDigits, isNonEmptyString } from './helpers'
 import type { FetchAccountMeta } from './types/base'
@@ -157,15 +158,17 @@ const getFullStatementSign = (fetchTransaction: FetchCardStatementOperation): nu
 
 const getMiniCardOperationId = (fetchTransaction: FetchMiniCardStatementOperation, account: Account): string => {
   if (isNonEmptyString(fetchTransaction.transactionAuthCode)) {
-    return [
+    const source = [
       account.id,
       'auth',
       fetchTransaction.operationDate,
       fetchTransaction.transactionAuthCode
     ].join(':')
+
+    return md5(source).toString()
   }
 
-  return [
+  const source = [
     account.id,
     'details',
     fetchTransaction.operationDate,
@@ -177,6 +180,30 @@ const getMiniCardOperationId = (fetchTransaction: FetchMiniCardStatementOperatio
     fetchTransaction.operationPlace ?? '',
     fetchTransaction.mcc ?? ''
   ].join(':')
+
+  return md5(source).toString()
+}
+
+const getFullStatementOperationId = (
+  fetchTransaction: FetchCardStatementOperation,
+  account: Account,
+  operationSign: number,
+  transactionAmount: number,
+  operationAmount: number
+): string => {
+  const source = [
+    account.id,
+    fetchTransaction.operationDate,
+    fetchTransaction.operationCode,
+    fetchTransaction.actionGroup,
+    operationSign,
+    transactionAmount,
+    operationAmount,
+    fetchTransaction.operationClosingBalance,
+    fetchTransaction.operationName
+  ].join(':')
+
+  return md5(source).toString()
 }
 
 export const convertMiniCardStatementOperation = (fetchTransaction: FetchMiniCardStatementOperation, account: Account): Transaction => {
@@ -227,17 +254,7 @@ export const convertFullStatementOperation = (fetchTransaction: FetchCardStateme
     comment: fetchTransaction.operationName,
     movements: [
       {
-        id: [
-          account.id,
-          fetchTransaction.operationDate,
-          fetchTransaction.operationCode,
-          fetchTransaction.actionGroup,
-          operationSign,
-          transactionAmount,
-          operationAmount,
-          fetchTransaction.operationClosingBalance,
-          fetchTransaction.operationName
-        ].join(':'),
+        id: getFullStatementOperationId(fetchTransaction, account, operationSign, transactionAmount, operationAmount),
         account: { id: account.id },
         fee: 0,
         invoice: hasInvoice


### PR DESCRIPTION
## Что исправлено

- Идентификаторы операций VTB теперь формируются как детерминированные MD5-хеши длиной 32 символа без текстовых префиксов.
- Для кратких и полных данных выписки используется стабильный источник идентичности операции.
- Повторная синхронизация одной и той же капитализации возвращает тот же идентификатор и не создаёт новую операцию.
- Добавлены проверки формата и стабильности идентификаторов.

## Причина

Капитализации вкладов могли приходить в разных представлениях ответа банка. Из-за различий в формировании идентификатора уже импортированные операции повторно появлялись как новые.

## Проверка

- 6 наборов тестов, 12 тестов — успешно.
- Проверка стиля изменённых файлов — успешно.
- Сборка плагина `vtb-by` — успешно.
- `git diff --check` — успешно.

## Важно

Из-за перехода на новый формат идентификаторов существующие операции VTB могут один раз определиться как новые. После этой одноразовой миграции идентификаторы остаются стабильными.