### PR TITLE
fix(zepterbank-by): reconcile partial settlements

### DIFF
--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -1,24 +1,12 @@
 import { convertCardAccount, convertCardTransaction, convertStatementTransaction } from '../../converters'
+import { mergeTransactions } from '../../mergeTransactions'
 import { TEST_ACCOUNTS } from '../../__mocks__/accounts.sample'
 import { TEST_CARD_TRANSACTIONS, TEST_STATEMENT_TRANSACTIONS } from '../../__mocks__/transactions.sample'
 import type { Transaction } from '../../../../types/zenmoney'
-import type { FetchCardTransaction, FetchProductStatementOutput, FetchTransactionsOutput } from '../../types/fetch.types'
+import type { FetchCardTransaction, FetchProductStatementOutput, FetchStatementOperation, FetchTransactionsOutput } from '../../types/fetch.types'
 
 const mockFetchCardTransactions = jest.fn()
 const mockFetchProductStatement = jest.fn()
-
-const usePluginData = (data: Record<string, unknown> = {}): Record<string, unknown> => {
-  const zenMoneyMock = {
-    getData: jest.fn((name: string, defaultValue: unknown) => data[name] ?? defaultValue),
-    setData: jest.fn((name: string, value: unknown) => {
-      data[name] = value
-    }),
-    saveData: jest.fn(),
-    getPreferences: jest.fn(() => ({}))
-  }
-  Object.assign(global, { ZenMoney: zenMoneyMock })
-  return data
-}
 
 const withAnyMovementIds = (transaction: Transaction): Transaction => {
   const [firstMovement, secondMovement] = transaction.movements
@@ -39,6 +27,11 @@ const withAnyMovementIds = (transaction: Transaction): Transaction => {
           }
         ]
   }
+}
+
+const expectBareMovementIdHash = (id: string | null): void => {
+  expect(id).toMatch(/^[a-f0-9]{32}$/)
+  expect(id).toHaveLength(32)
 }
 
 jest.mock('../../fetchApi', () => ({
@@ -483,6 +476,122 @@ describe('getTransactions', () => {
     })
   })
 
+  it('replaces an unambiguous railway hold with its smaller final commission', async () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const makeHistoryTransaction = (effectiveDate: string, amount: string): FetchCardTransaction => ({
+      effectiveDate,
+      transacName: 'EPOS PRE-PURCHASE',
+      amount,
+      currencyIso: 'BYN',
+      cardAcceptor: 'I.-SHOP"WWW.PASS.RW.BY"',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС4112'
+    })
+    const makeStatementOperation = (amount: string): FetchStatementOperation => ({
+      transactionDate: '2026-08-10T00:00:00',
+      balanceDate: '2026-08-12',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: amount,
+      transactionSum: amount,
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'I.-SHOP"WWW.PASS.RW.BY"',
+      MCC: 'MCC 4112'
+    })
+
+    mockFetchCardTransactions.mockResolvedValue({
+      status: 200,
+      data: [
+        makeHistoryTransaction('2026-08-10T21:17:23', '30.99'),
+        makeHistoryTransaction('2026-08-10T20:47:52', '30.99'),
+        makeHistoryTransaction('2026-08-10T20:42:50', '57.90')
+      ],
+      error: null
+    })
+    mockFetchProductStatement.mockResolvedValue({
+      status: 200,
+      data: {
+        incomeForPeriod: '0.00',
+        outcomeForPeriod: '79.80',
+        ibanNum: rawCardAccount.ibanNum,
+        contractCurrency: String(rawCardAccount.currency),
+        contractCurrencyISO: rawCardAccount.currencyIso,
+        operations: [
+          makeStatementOperation('30.99'),
+          makeStatementOperation('30.99'),
+          makeStatementOperation('17.82')
+        ]
+      },
+      error: null
+    })
+
+    const transactions = await getTransactions({
+      sessionToken: 'session-token',
+      fromDate: new Date('2026-08-10T00:00:00.000Z'),
+      toDate: new Date('2026-08-12T23:59:59.000Z')
+    }, account)
+
+    expect(transactions.map((transaction) => transaction.movements[0].sum)).toEqual([-30.99, -30.99, -17.82])
+    expect(transactions.some((transaction) => transaction.movements[0].sum === -57.9)).toBe(false)
+    expect(new Set(transactions.map((transaction) => transaction.movements[0].id)).size).toBe(3)
+    for (const transaction of transactions) {
+      expectBareMovementIdHash(transaction.movements[0].id)
+    }
+  })
+
+  it('does not guess between ambiguous partial railway settlements', () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const makeHistoryTransaction = (amount: string): Transaction => convertCardTransaction({
+      effectiveDate: '2026-08-10T20:42:50',
+      transacName: 'EPOS PRE-PURCHASE',
+      amount,
+      currencyIso: 'BYN',
+      cardAcceptor: 'I.-SHOP"WWW.PASS.RW.BY"',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС4112'
+    }, account)
+    const statementTransaction = convertStatementTransaction({
+      transactionDate: '2026-08-10T00:00:00',
+      balanceDate: '2026-08-12',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: '17.82',
+      transactionSum: '17.82',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'I.-SHOP"WWW.PASS.RW.BY"',
+      MCC: 'MCC 4112'
+    }, account)
+
+    const transactions = mergeTransactions([
+      makeHistoryTransaction('57.90'),
+      makeHistoryTransaction('40.00')
+    ], [statementTransaction])
+
+    expect(transactions.map((transaction) => transaction.movements[0].sum)).toEqual([-57.9, -40, -17.82])
+  })
+
   it('keeps the same final id when bank changes merchant and mcc between syncs', async () => {
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 
@@ -563,8 +672,7 @@ describe('getTransactions', () => {
     expect(statementOnly[0].movements[0].id).toBe(historyOnly[0].movements[0].id)
   })
 
-  it('preserves legacy history id through persisted alias when bank later returns only statement', async () => {
-    usePluginData()
+  it('uses the same bare hash when history later becomes statement-only', async () => {
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 
     if (rawCardAccount == null) {
@@ -640,13 +748,83 @@ describe('getTransactions', () => {
     }, account)
 
     expect(historyOnly).toHaveLength(1)
-    expect(historyOnly[0].movements[0].id).toContain('|2026-06-24|sum|-65.84|4111|st. m. Grushevka|0')
+    expectBareMovementIdHash(historyOnly[0].movements[0].id)
     expect(statementOnly).toHaveLength(1)
     expect(statementOnly[0].movements[0].id).toBe(historyOnly[0].movements[0].id)
   })
 
+  it('returns bare hashes for statement transactions regardless source identity length', () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = {
+      ...convertCardAccount(rawCardAccount),
+      id: 'a'.repeat(43)
+    }
+    const statementOperation = {
+      transactionDate: '2026-08-03T00:00:00',
+      balanceDate: '2026-08-03',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      transactionSum: '41.10',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSum: '41.10',
+      operationSign: -1 as const,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'I.-SHOP"WWW.PASS.RW.BY"',
+      MCC: 'MCC 4112'
+    }
+    const atLimitTransaction = convertStatementTransaction(statementOperation, account)
+    const overLimitTransaction = convertStatementTransaction({
+      ...statementOperation,
+      transactionSum: '65.84',
+      operationSum: '65.84',
+      terminalLocation: 'st. m. Mikhalovo',
+      MCC: 'MCC 4111'
+    }, account)
+
+    const [atLimit, overLimit] = mergeTransactions([], [atLimitTransaction, overLimitTransaction])
+
+    expectBareMovementIdHash(atLimit.movements[0].id)
+    expectBareMovementIdHash(overLimit.movements[0].id)
+    expect(atLimit.movements[0].id).not.toBe(overLimit.movements[0].id)
+    expect(mergeTransactions([], [overLimitTransaction])[0].movements[0].id).toBe(overLimit.movements[0].id)
+  })
+
+  it('returns bare hashes for history transactions with Unicode merchant data', () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = {
+      ...convertCardAccount(rawCardAccount),
+      id: 'a'.repeat(20)
+    }
+    const merchant = 'К'.repeat(10)
+    const historyTransaction = convertCardTransaction({
+      effectiveDate: '2026-08-03T12:00:00',
+      transacName: 'POS PURCHASE ',
+      amount: '1.22',
+      currencyIso: 'BYN',
+      cardAcceptor: merchant,
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5300'
+    }, account)
+    const merged = mergeTransactions([historyTransaction], [])[0]
+
+    expectBareMovementIdHash(historyTransaction.movements[0].id)
+    expectBareMovementIdHash(merged.movements[0].id)
+  })
+
   it('keeps pending card id stable after the bank returns it as a posted purchase', async () => {
-    usePluginData()
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 
     if (rawCardAccount == null) {
@@ -704,8 +882,7 @@ describe('getTransactions', () => {
     }, account)
 
     expect(pendingOnly).toHaveLength(1)
-    expect(pendingOnly[0].movements[0].id).toContain('|2026-06-25|sum|-1.22|0')
-    expect(pendingOnly[0].movements[0].id).not.toContain('|5300|21VEK.BY|')
+    expectBareMovementIdHash(pendingOnly[0].movements[0].id)
     expect(postedOnly).toHaveLength(1)
     expect(postedOnly[0].movements[0].id).toBe(pendingOnly[0].movements[0].id)
   })

--- a/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/converters/convert-card-transaction.test.ts
@@ -261,7 +261,10 @@ describe('convertCardTransaction', () => {
       throw new Error('Matching transactions not found')
     }
 
-    expect(convertCardTransaction(rawCardTransaction, cardAccount1).movements[0].id)
-      .toBe(convertStatementTransaction(rawStatementTransaction, cardAccount1).movements[0].id)
+    const cardMovementId = convertCardTransaction(rawCardTransaction, cardAccount1).movements[0].id
+    const statementMovementId = convertStatementTransaction(rawStatementTransaction, cardAccount1).movements[0].id
+
+    expect(cardMovementId).toMatch(/^[a-f0-9]{32}$/)
+    expect(statementMovementId).toBe(cardMovementId)
   })
 })

--- a/src/plugins/zepterbank-by/converters.ts
+++ b/src/plugins/zepterbank-by/converters.ts
@@ -1,4 +1,5 @@
 import { Account, AccountType, Transaction } from '../../types/zenmoney'
+import md5 from 'crypto-js/md5'
 import {
   FetchCardAccount,
   FetchCurrentAccount,
@@ -49,7 +50,7 @@ const buildMovementId = ({
   sum: number | null
   invoice: { sum: number, instrument: string } | null
 }): string => {
-  return [
+  const source = [
     'zepterbank-by',
     accountId,
     getBusinessDateIdentityKey(date),
@@ -58,6 +59,8 @@ const buildMovementId = ({
     String(mcc ?? ''),
     normalizeIdPart(merchantTitle)
   ].join('|')
+
+  return md5(source).toString()
 }
 
 const parseMcc = (mcc: string | undefined): number | null => {

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -1,4 +1,5 @@
 import { Transaction } from '../../types/zenmoney'
+import md5 from 'crypto-js/md5'
 import type { TransactionWithIdentityStage } from './converters'
 import { getBusinessDateIdentityKey } from './helpers'
 
@@ -7,13 +8,10 @@ type TransactionSource = 'history' | 'statement'
 interface SourcedTransaction {
   source: TransactionSource
   transaction: Transaction
-  legacyIdentityTransaction?: Transaction
+  matchedHistory?: boolean
 }
 
 type TransactionWithDedupDate = Transaction & { dedupDate?: Date }
-
-const STABLE_ID_ALIASES_KEY = 'zepterbank-by/stableMovementIdAliases'
-const STABLE_ID_ALIAS_MAX_COUNT = 1000
 
 const normalizeText = (text: string | null | undefined): string =>
   (text ?? '').replace(/\s+/g, ' ').trim()
@@ -80,43 +78,38 @@ const getStableIdFingerprint = (transaction: Transaction): string => [
   getAmountSignature(transaction)
 ].join('|')
 
+const getMovementInstrumentSignature = (transaction: Transaction): string =>
+  transaction.movements[0]?.invoice?.instrument ?? 'account'
+
+const getMovementDirection = (transaction: Transaction): number => {
+  const movement = transaction.movements[0]
+  return Math.sign(movement?.invoice?.sum ?? movement?.sum ?? 0)
+}
+
+const getPartialSettlementFingerprint = (transaction: Transaction): string => [
+  getMovementAccountId(transaction),
+  getDaySignature(transaction),
+  getMovementInstrumentSignature(transaction),
+  getMovementDirection(transaction),
+  getMccSignature(transaction),
+  normalizeText(getMerchantTitle(transaction)).toUpperCase()
+].join('|')
+
+const getAbsoluteMovementAmount = (transaction: Transaction): number => {
+  const movement = transaction.movements[0]
+  return Math.abs(movement?.invoice?.sum ?? movement?.sum ?? 0)
+}
+
+const hasReliableMerchantIdentity = (transaction: Transaction): boolean =>
+  normalizeText(getMerchantTitle(transaction)) !== '' && getMccSignature(transaction) !== ''
+
+const isPendingPurchase = (transaction: Transaction): boolean =>
+  (transaction as TransactionWithIdentityStage).identityStage === 'pending' &&
+  getMovementDirection(transaction) < 0 &&
+  hasReliableMerchantIdentity(transaction)
+
 const makeMovementId = (fingerprint: string, occurrenceIndex: number): string =>
-  ['zepterbank-by', fingerprint, occurrenceIndex].join('|')
-
-const canPersistStableIdAliases = (): boolean =>
-  typeof ZenMoney !== 'undefined' &&
-  typeof ZenMoney.getData === 'function' &&
-  typeof ZenMoney.setData === 'function' &&
-  typeof ZenMoney.saveData === 'function'
-
-const getStableIdAliases = (): Record<string, string> => {
-  if (!canPersistStableIdAliases()) {
-    return {}
-  }
-
-  const aliases = ZenMoney.getData(STABLE_ID_ALIASES_KEY, {})
-  return aliases != null && typeof aliases === 'object' && !Array.isArray(aliases)
-    ? aliases as Record<string, string>
-    : {}
-}
-
-const setStableIdAliases = (aliases: Record<string, string>): void => {
-  if (!canPersistStableIdAliases()) {
-    return
-  }
-
-  const prunedAliases = Object.fromEntries(Object.entries(aliases).slice(-STABLE_ID_ALIAS_MAX_COUNT))
-  ZenMoney.setData(STABLE_ID_ALIASES_KEY, prunedAliases)
-  ZenMoney.saveData()
-}
-
-const shouldPreferStableIdentity = ({ source, transaction, legacyIdentityTransaction }: SourcedTransaction): boolean => {
-  if ((transaction as TransactionWithIdentityStage).identityStage === 'pending') {
-    return true
-  }
-
-  return source === 'statement' && legacyIdentityTransaction == null
-}
+  md5(['zepterbank-by', fingerprint, occurrenceIndex].join('|')).toString()
 
 const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => {
   const leftId = getMovementId(left)
@@ -129,30 +122,60 @@ const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => 
   return getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
 }
 
+const reconcileUnambiguousPartialSettlements = (entries: SourcedTransaction[]): SourcedTransaction[] => {
+  const pendingHistoryIndexesByKey = new Map<string, number[]>()
+  const unmatchedStatementIndexesByKey = new Map<string, number[]>()
+
+  for (const [index, entry] of entries.entries()) {
+    if (entry.source === 'history' && isPendingPurchase(entry.transaction)) {
+      const key = getPartialSettlementFingerprint(entry.transaction)
+      pendingHistoryIndexesByKey.set(key, [...pendingHistoryIndexesByKey.get(key) ?? [], index])
+    } else if (entry.source === 'statement' && entry.matchedHistory !== true && hasReliableMerchantIdentity(entry.transaction)) {
+      const key = getPartialSettlementFingerprint(entry.transaction)
+      unmatchedStatementIndexesByKey.set(key, [...unmatchedStatementIndexesByKey.get(key) ?? [], index])
+    }
+  }
+
+  const indexesToRemove = new Set<number>()
+
+  for (const [key, pendingHistoryIndexes] of pendingHistoryIndexesByKey) {
+    const unmatchedStatementIndexes = unmatchedStatementIndexesByKey.get(key) ?? []
+
+    if (pendingHistoryIndexes.length !== 1 || unmatchedStatementIndexes.length !== 1) {
+      continue
+    }
+
+    const [pendingHistoryIndex] = pendingHistoryIndexes
+    const [unmatchedStatementIndex] = unmatchedStatementIndexes
+    const pendingHistoryEntry = entries[pendingHistoryIndex]
+    const unmatchedStatementEntry = entries[unmatchedStatementIndex]
+    const pendingAmount = getAbsoluteMovementAmount(pendingHistoryEntry.transaction)
+    const settledAmount = getAbsoluteMovementAmount(unmatchedStatementEntry.transaction)
+
+    if (settledAmount <= 0 || settledAmount >= pendingAmount) {
+      continue
+    }
+
+    entries[pendingHistoryIndex] = {
+      source: 'statement',
+      transaction: unmatchedStatementEntry.transaction,
+      matchedHistory: true
+    }
+    indexesToRemove.add(unmatchedStatementIndex)
+  }
+
+  return entries.filter((_entry, index) => !indexesToRemove.has(index))
+}
+
 const withStableMovementIds = (entries: SourcedTransaction[]): Transaction[] => {
   const stableOccurrenceIndexes = new Map<string, number>()
-  const legacyOccurrenceIndexes = new Map<string, number>()
-  const shouldPersistStableIdAliases = canPersistStableIdAliases()
-  const stableIdAliases = getStableIdAliases()
-  let stableIdAliasesChanged = false
 
-  const transactions = entries.map((entry) => {
+  return entries.map((entry) => {
     const { transaction } = entry
     const stableFingerprint = getStableIdFingerprint(transaction)
     const stableOccurrenceIndex = stableOccurrenceIndexes.get(stableFingerprint) ?? 0
     stableOccurrenceIndexes.set(stableFingerprint, stableOccurrenceIndex + 1)
-    const stableMovementId = makeMovementId(stableFingerprint, stableOccurrenceIndex)
-    const legacyFingerprint = getDuplicateFingerprint(entry.legacyIdentityTransaction ?? transaction)
-    const legacyOccurrenceIndex = legacyOccurrenceIndexes.get(legacyFingerprint) ?? 0
-    legacyOccurrenceIndexes.set(legacyFingerprint, legacyOccurrenceIndex + 1)
-    const legacyMovementId = makeMovementId(legacyFingerprint, legacyOccurrenceIndex)
-    const selectedMovementId = shouldPersistStableIdAliases
-      ? stableIdAliases[stableMovementId] ?? (shouldPreferStableIdentity(entry) ? stableMovementId : legacyMovementId)
-      : stableMovementId
-    if (shouldPersistStableIdAliases && stableIdAliases[stableMovementId] !== selectedMovementId) {
-      stableIdAliases[stableMovementId] = selectedMovementId
-      stableIdAliasesChanged = true
-    }
+    const selectedMovementId = makeMovementId(stableFingerprint, stableOccurrenceIndex)
     const [firstMovement, secondMovement] = transaction.movements
     const firstMovementWithStableId = {
       ...firstMovement,
@@ -167,12 +190,6 @@ const withStableMovementIds = (entries: SourcedTransaction[]): Transaction[] => 
       movements
     }
   })
-
-  if (stableIdAliasesChanged) {
-    setStableIdAliases(stableIdAliases)
-  }
-
-  return transactions
 }
 
 export const mergeTransactions = (historyTransactions: Transaction[], statementTransactions: Transaction[]): Transaction[] => {
@@ -187,11 +204,10 @@ export const mergeTransactions = (historyTransactions: Transaction[], statementT
     )
 
     if (duplicateHistoryIndex !== -1) {
-      const legacyIdentityTransaction = mergedTransactions[duplicateHistoryIndex].transaction
       mergedTransactions[duplicateHistoryIndex] = {
         source: 'statement',
         transaction: statementTransaction,
-        legacyIdentityTransaction
+        matchedHistory: true
       }
       continue
     }
@@ -202,5 +218,5 @@ export const mergeTransactions = (historyTransactions: Transaction[], statementT
     })
   }
 
-  return withStableMovementIds(mergedTransactions)
+  return withStableMovementIds(reconcileUnambiguousPartialSettlements(mergedTransactions))
 }


### PR DESCRIPTION
## Что исправлено

- Идентификаторы исходных и объединённых операций Zepter Bank теперь являются детерминированными MD5-хешами длиной 32 символа без текстовых префиксов.
- Сопоставление выполняется в два этапа: сначала точные совпадения, затем безопасное сопоставление частичного списания.
- Частичное списание объединяется только при единственной однозначной паре с одинаковыми счётом, датой, валютой, направлением, MCC и нормализованным получателем.
- Неоднозначные группы не объединяются автоматически.

## Причина

При возврате железнодорожных билетов исходная ожидающая операция на 57,90 заменялась окончательным списанием комиссии 17,82. Из-за изменения суммы плагин не связывал эти записи и возвращал обе операции.

После исправления в проверенном сценарии остаются только окончательные списания: 30,99, 30,99 и 17,82; устаревшая ожидающая операция 57,90 удаляется.

## Проверка

- 8 наборов тестов, 55 тестов — успешно.
- Полная проверка TypeScript — успешно.
- Полная проверка стиля — успешно.
- Сборка плагина `zepterbank-by` — успешно.
- Санитизированное воспроизведение на актуальных данных — успешно.
- `git diff --check` — успешно.

## Важно

Из-за перехода на новый формат идентификаторов существующие операции Zepter Bank могут один раз определиться как новые. После этой одноразовой миграции идентификаторы остаются стабильными.