### PR TITLE
Add read-only Bitget wallet synchronization

### DIFF
--- a/src/plugins/bitget/README.md
+++ b/src/plugins/bitget/README.md
@@ -1,0 +1,7 @@
+# Bitget
+
+Read-only Bitget wallet balances and external transfers for ZenMoney. The account overview endpoint returns the exchange-native Spot, Funding, Earn, Futures, Margin and Bots sections that are available for the connected account, already valued by Bitget in USDT.
+
+Create a Bitget API key in **API Management**, choose a passphrase, and enable read access only. Leave trading, transfers and withdrawals disabled. The plugin supports the documented Classic account overview; Bitget recommends Unified Trading Account for newly migrated users, which will be handled separately when its read-only wallet coverage is equivalent.
+
+Completed external deposits and withdrawals are loaded in API-compliant date windows, paginated with Bitget order IDs and imported with stable IDs. Individual trades and bot operations are intentionally omitted from the household budget. Bitget Card activity is not imported because Bitget does not currently publish a supported card-history API for third-party clients.

--- a/src/plugins/bitget/ZenmoneyManifest.xml
+++ b/src/plugins/bitget/ZenmoneyManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>bitget</id>
+    <company>0</company>
+    <description>Read-only Bitget wallets and paginated external transfers.</description>
+    <version>0.1</version>
+    <build>2</build>
+    <modular>true</modular>
+    <files><js>index.js</js><preferences>preferences.xml</preferences></files>
+</provider>

--- a/src/plugins/bitget/__tests__/api.test.ts
+++ b/src/plugins/bitget/__tests__/api.test.ts
@@ -1,0 +1,12 @@
+import { login } from '../api'
+
+describe('Bitget credentials', () => {
+  it('keeps the three read-only API credentials', () => {
+    expect(login({
+      apiKey: 'key',
+      apiSecret: 'secret',
+      passphrase: 'passphrase',
+      startDate: '2026-01-01T00:00:00.000Z'
+    })).toEqual({ apiKey: 'key', apiSecret: 'secret', passphrase: 'passphrase' })
+  })
+})

--- a/src/plugins/bitget/__tests__/converters.test.ts
+++ b/src/plugins/bitget/__tests__/converters.test.ts
@@ -1,0 +1,31 @@
+import { AccountType } from '../../../types/zenmoney'
+import { convertExternalStablecoinTransfers, createAccounts, parseSettlementAssets } from '../converters'
+
+describe('Bitget accounts', () => {
+  it('creates one account for each actual exchange wallet', () => {
+    expect(createAccounts('Bitget', [
+      { accountType: 'spot', valueUsdt: 647.84903385 },
+      { accountType: 'bots', valueUsdt: 21.04068974 },
+      { accountType: 'earn', valueUsdt: 100 }
+    ])).toEqual([
+      { id: 'bitget_spot', type: AccountType.investment, title: 'Bitget Spot', instrument: 'USD', balance: 647.84903385, savings: false, syncIds: ['bitget_spot'] },
+      { id: 'bitget_bots', type: AccountType.investment, title: 'Bitget Bots', instrument: 'USD', balance: 21.04068974, savings: true, syncIds: ['bitget_bots'] },
+      { id: 'bitget_earn', type: AccountType.investment, title: 'Bitget Earn', instrument: 'USD', balance: 100, savings: true, syncIds: ['bitget_earn'] }
+    ])
+  })
+
+  it('creates deterministic stablecoin transfer movements', () => {
+    const result = convertExternalStablecoinTransfers('Bitget', [
+      { id: 'in', direction: 'deposit', coin: 'USDT', amount: 10, fee: 0, date: new Date('2026-08-01T00:00:00Z'), network: 'bsc' },
+      { id: 'out', direction: 'withdrawal', coin: 'USDC', amount: 20, fee: 1, date: new Date('2026-08-02T00:00:00Z'), network: null },
+      { id: 'other', direction: 'deposit', coin: 'BTC', amount: 1, fee: 0, date: new Date('2026-08-03T00:00:00Z'), network: null }
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0].movements[0]).toMatchObject({ id: 'bitget_deposit_in', account: { id: 'bitget_spot' }, sum: 10 })
+    expect(result[1].movements[0]).toMatchObject({ id: 'bitget_withdrawal_out', sum: -20, fee: -1 })
+  })
+
+  it('normalizes custom settlement assets', () => {
+    expect([...parseSettlementAssets(' usdt,USDC,usdt ')]).toEqual(['USDT', 'USDC'])
+  })
+})

--- a/src/plugins/bitget/__tests__/fetchApi.test.ts
+++ b/src/plugins/bitget/__tests__/fetchApi.test.ts
@@ -1,0 +1,20 @@
+import { buildRequestPath, parseCapitalTransfers, signRequest } from '../fetchApi'
+
+describe('Bitget API conversion', () => {
+  it('signs the exact sorted request path', () => {
+    const path = buildRequestPath('/api/v2/spot/wallet/deposit-records', { limit: 100, startTime: 10, endTime: 20 })
+    expect(path).toBe('/api/v2/spot/wallet/deposit-records?endTime=20&limit=100&startTime=10')
+    expect(signRequest('secret', '123', path)).toBe('UVsCInGPaO3vxFX/42U42v9VZg1BM/n9Q0CU2wkIXdo=')
+  })
+
+  it('keeps completed records and normalizes a negative withdrawal fee', () => {
+    const result = parseCapitalTransfers([
+      { orderId: 'deposit', status: 'success', coin: 'USDT', size: '10', cTime: '1000', chain: 'bsc' },
+      { orderId: 'pending', status: 'pending', coin: 'USDT', size: '20', cTime: '1000' }
+    ], [
+      { orderId: 'withdrawal', status: 'success', coin: 'USDC', size: '5', fee: '-0.25', cTime: '2000', chain: 'erc20' }
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[1]).toMatchObject({ id: 'withdrawal', direction: 'withdrawal', amount: 5, fee: 0.25 })
+  })
+})

--- a/src/plugins/bitget/api.ts
+++ b/src/plugins/bitget/api.ts
@@ -1,0 +1,9 @@
+import { InvalidPreferencesError } from '../../errors'
+import { Credentials, Preferences } from './models'
+
+export function login (preferences: Preferences): Credentials {
+  if (preferences.apiKey?.trim() === '' || preferences.apiSecret?.trim() === '' || preferences.passphrase?.trim() === '') {
+    throw new InvalidPreferencesError('Bitget: API Key, API Secret and passphrase are required')
+  }
+  return { apiKey: preferences.apiKey, apiSecret: preferences.apiSecret, passphrase: preferences.passphrase }
+}

--- a/src/plugins/bitget/converters.ts
+++ b/src/plugins/bitget/converters.ts
@@ -1,0 +1,49 @@
+import { AccountOrCard, AccountType, Transaction } from '../../types/zenmoney'
+import { CapitalTransfer, WalletBalance } from './models'
+
+export function parseSettlementAssets (value?: string): Set<string> {
+  return new Set((value ?? 'USDT,USDC,USD,USDE,FDUSD,TUSD')
+    .split(',')
+    .map(asset => asset.trim().toUpperCase())
+    .filter(asset => asset !== ''))
+}
+
+function accountSlug (value: string): string {
+  const slug = value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+  return slug === '' ? 'wallet' : slug
+}
+
+export function createAccounts (label: string, wallets: WalletBalance[]): AccountOrCard[] {
+  const titlePrefix = label.trim() === '' ? 'Bitget' : label.trim()
+  const idPrefix = accountSlug(titlePrefix)
+  return wallets.map(wallet => {
+    const walletTitle = wallet.accountType.charAt(0).toUpperCase() + wallet.accountType.slice(1)
+    const id = `${idPrefix}_${accountSlug(wallet.accountType)}`
+    return {
+      id,
+      type: AccountType.investment,
+      title: `${titlePrefix} ${walletTitle}`,
+      instrument: 'USD',
+      balance: Number(wallet.valueUsdt.toFixed(8)),
+      savings: ['bots', 'earn'].includes(wallet.accountType.toLowerCase()),
+      syncIds: [id]
+    }
+  })
+}
+
+export function convertExternalStablecoinTransfers (label: string, transfers: CapitalTransfer[], settlementAssets = new Set(['USDT', 'USDC', 'USD', 'FDUSD'])): Transaction[] {
+  const idPrefix = accountSlug(label.trim() === '' ? 'Bitget' : label.trim())
+  return transfers.filter(transfer => settlementAssets.has(transfer.coin) && !Number.isNaN(transfer.date.getTime())).map(transfer => ({
+    hold: false,
+    date: transfer.date,
+    movements: [{
+      id: `bitget_${transfer.direction}_${transfer.id}`,
+      account: { id: `${idPrefix}_spot` },
+      invoice: null,
+      sum: transfer.direction === 'deposit' ? transfer.amount : -transfer.amount,
+      fee: transfer.direction === 'withdrawal' ? -Math.abs(transfer.fee) : 0
+    }],
+    merchant: null,
+    comment: `Bitget external ${transfer.direction}: ${transfer.coin}${transfer.network == null || transfer.network === '' ? '' : `; network ${transfer.network}`}`
+  }))
+}

--- a/src/plugins/bitget/fetchApi.ts
+++ b/src/plugins/bitget/fetchApi.ts
@@ -1,0 +1,109 @@
+import crypto from 'crypto-js'
+import { fetchJson } from '../../common/network'
+import { InvalidPreferencesError, TemporaryError } from '../../errors'
+import { getArray, getOptString, getString } from '../../types/get'
+import { CapitalTransfer, Credentials, WalletBalance } from './models'
+
+const BASE_URL = 'https://api.bitget.com'
+
+export function buildRequestPath (path: string, query: Record<string, string | number | undefined> = {}): string {
+  const queryString = Object.entries(query)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join('&')
+  return queryString === '' ? path : `${path}?${queryString}`
+}
+
+export function signRequest (secret: string, timestamp: string, requestPath: string): string {
+  return crypto.enc.Base64.stringify(crypto.HmacSHA256(`${timestamp}GET${requestPath}`, secret))
+}
+
+async function signedGet (credentials: Credentials, path: string, query: Record<string, string | number | undefined> = {}): Promise<unknown> {
+  const requestPath = buildRequestPath(path, query)
+  const timestamp = String(Date.now())
+  const response = await fetchJson(`${BASE_URL}${requestPath}`, {
+    method: 'GET',
+    headers: {
+      'ACCESS-KEY': credentials.apiKey,
+      'ACCESS-SIGN': signRequest(credentials.apiSecret, timestamp, requestPath),
+      'ACCESS-TIMESTAMP': timestamp,
+      'ACCESS-PASSPHRASE': credentials.passphrase,
+      locale: 'en-US'
+    },
+    sanitizeRequestLog: {
+      headers: { 'ACCESS-KEY': true, 'ACCESS-SIGN': true, 'ACCESS-PASSPHRASE': true }
+    }
+  })
+  if (response.status === 401 || response.status === 403) {
+    throw new InvalidPreferencesError('Bitget: API key rejected. Recreate a read-only key with Spot and Wallet viewing enabled.')
+  }
+  if (response.status === 418 || response.status === 429) throw new TemporaryError('Bitget: request limit reached, try again later')
+  const code = getOptString(response.body, 'code')
+  if (code != null && code !== '00000') {
+    const message = getOptString(response.body, 'msg') ?? 'unknown API error'
+    if (code === '40006' || code === '40009' || code === '40012') throw new InvalidPreferencesError(`Bitget: ${message} (code=${code})`)
+    throw new TemporaryError(`Bitget: ${message} (code=${code})`)
+  }
+  return response.body
+}
+
+export async function fetchWalletBalances (credentials: Credentials): Promise<WalletBalance[]> {
+  const body = await signedGet(credentials, '/api/v2/account/all-account-balance')
+  return getArray(body, 'data').map(row => ({
+    accountType: getString(row, 'accountType').trim(),
+    valueUsdt: Number(getString(row, 'usdtBalance'))
+  })).filter(wallet => wallet.accountType !== '' && Number.isFinite(wallet.valueUsdt))
+}
+
+const MAX_HISTORY_RANGE_MS = 89 * 24 * 60 * 60 * 1000
+
+async function fetchHistoryPage (credentials: Credentials, path: string, query: Record<string, string | number | undefined>): Promise<unknown[]> {
+  return getArray(await signedGet(credentials, path, { ...query, limit: 100 }), 'data')
+}
+
+async function fetchHistory (credentials: Credentials, path: string, fromDate: Date, toDate: Date): Promise<unknown[]> {
+  const all: unknown[] = []
+  for (let start = fromDate.getTime(); start < toDate.getTime(); start += MAX_HISTORY_RANGE_MS) {
+    const end = Math.min(start + MAX_HISTORY_RANGE_MS, toDate.getTime())
+    let idLessThan: string | undefined
+    for (let page = 0; page < 100; page++) {
+      const rows = await fetchHistoryPage(credentials, path, { startTime: start, endTime: end, idLessThan })
+      all.push(...rows)
+      if (rows.length < 100) break
+      idLessThan = getString(rows[rows.length - 1], 'orderId')
+      if (idLessThan === '') break
+    }
+  }
+  return all
+}
+
+export async function fetchCapitalTransfers (credentials: Credentials, fromDate: Date, toDate: Date): Promise<CapitalTransfer[]> {
+  const [deposits, withdrawals] = await Promise.all([
+    fetchHistory(credentials, '/api/v2/spot/wallet/deposit-records', fromDate, toDate),
+    fetchHistory(credentials, '/api/v2/spot/wallet/withdrawal-records', fromDate, toDate)
+  ])
+  return parseCapitalTransfers(deposits, withdrawals)
+}
+
+export function parseCapitalTransfers (deposits: unknown[], withdrawals: unknown[]): CapitalTransfer[] {
+  const transfers: CapitalTransfer[] = []
+  for (const row of deposits) {
+    if (getString(row, 'status').toLowerCase() !== 'success') continue
+    const id = getString(row, 'orderId')
+    const amount = Number(getString(row, 'size'))
+    if (id === '' || !Number.isFinite(amount) || amount === 0) continue
+    transfers.push({ id, direction: 'deposit', coin: getString(row, 'coin').toUpperCase(), amount, fee: 0, date: new Date(Number(getString(row, 'cTime'))), network: getOptString(row, 'chain') ?? null })
+  }
+  for (const row of withdrawals) {
+    if (getString(row, 'status').toLowerCase() !== 'success') continue
+    const id = getString(row, 'orderId')
+    const amount = Number(getString(row, 'size'))
+    const parsedFee = Math.abs(Number(getOptString(row, 'fee') ?? 0))
+    if (id === '' || !Number.isFinite(amount) || amount === 0) continue
+    transfers.push({ id, direction: 'withdrawal', coin: getString(row, 'coin').toUpperCase(), amount, fee: Number.isFinite(parsedFee) ? parsedFee : 0, date: new Date(Number(getString(row, 'cTime'))), network: getOptString(row, 'chain') ?? null })
+  }
+  const unique = new Map<string, CapitalTransfer>()
+  for (const transfer of transfers) unique.set(`${transfer.direction}:${transfer.id}`, transfer)
+  return [...unique.values()].sort((left, right) => left.date.getTime() - right.date.getTime())
+}

--- a/src/plugins/bitget/index.ts
+++ b/src/plugins/bitget/index.ts
@@ -1,0 +1,11 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { login } from './api'
+import { convertExternalStablecoinTransfers, createAccounts, parseSettlementAssets } from './converters'
+import { fetchCapitalTransfers, fetchWalletBalances } from './fetchApi'
+import { Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  const credentials = login(preferences)
+  const [wallets, transfers] = await Promise.all([fetchWalletBalances(credentials), fetchCapitalTransfers(credentials, fromDate, toDate ?? new Date())])
+  return { accounts: createAccounts(preferences.accountLabel ?? 'Bitget', wallets), transactions: convertExternalStablecoinTransfers(preferences.accountLabel ?? 'Bitget', transfers, parseSettlementAssets(preferences.externalTransferAssets)) }
+}

--- a/src/plugins/bitget/models.ts
+++ b/src/plugins/bitget/models.ts
@@ -1,0 +1,29 @@
+export interface Preferences {
+  apiKey: string
+  apiSecret: string
+  passphrase: string
+  accountLabel?: string
+  startDate: string
+  externalTransferAssets?: string
+}
+
+export interface Credentials {
+  apiKey: string
+  apiSecret: string
+  passphrase: string
+}
+
+export interface WalletBalance {
+  accountType: string
+  valueUsdt: number
+}
+
+export interface CapitalTransfer {
+  id: string
+  direction: 'deposit' | 'withdrawal'
+  coin: string
+  amount: number
+  fee: number
+  date: Date
+  network: string | null
+}

--- a/src/plugins/bitget/preferences.xml
+++ b/src/plugins/bitget/preferences.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference key="apiKey" obligatory="true" title="Read-only API Key" dialogTitle="Read-only API Key" dialogMessage="Create an API key in Bitget API Management. Do not enable trading, transfers or withdrawals." positiveButtonText="OK" negativeButtonText="Cancel" summary="|apiKey|{@s}" />
+    <EditTextPreference key="apiSecret" obligatory="true" inputType="textPassword" title="Read-only API Secret" dialogTitle="Read-only API Secret" dialogMessage="The secret is shown once. Keep it private." positiveButtonText="OK" negativeButtonText="Cancel" summary="||***********" />
+    <EditTextPreference key="passphrase" obligatory="true" inputType="textPassword" title="API passphrase" dialogTitle="API passphrase" dialogMessage="This is the passphrase chosen while creating the Bitget API key, not your Bitget password." positiveButtonText="OK" negativeButtonText="Cancel" summary="||***********" />
+    <EditTextPreference key="accountLabel" obligatory="true" defaultValue="Bitget" title="Account label" dialogTitle="Account label" positiveButtonText="OK" negativeButtonText="Cancel" summary="|accountLabel|{@s}" />
+    <EditTextPreference key="externalTransferAssets" defaultValue="USDT,USDC,USD,USDE,FDUSD,TUSD" title="Settlement assets to import" dialogTitle="Settlement assets to import" dialogMessage="Comma-separated USD-pegged assets for deposit/withdrawal history. Current balance still includes all supported assets." positiveButtonText="OK" negativeButtonText="Cancel" summary="|externalTransferAssets|{@s}" />
+    <EditTextPreference key="startDate" obligatory="true" inputType="date" defaultValue="2026-01-01T00:00:00.000Z" title="Load operations from" dialogTitle="Load operations from" dialogMessage="Imports completed external stablecoin deposits and withdrawals using stable Bitget IDs." positiveButtonText="OK" negativeButtonText="Cancel" summary="|startDate|{@s}" />
+</PreferenceScreen>


### PR DESCRIPTION
## Summary
- add read-only Bitget Spot, Futures, Funding, Earn, Bots, and Margin wallet synchronization
- use Bitget account-overview USDT valuations
- import completed external deposits and withdrawals with stable IDs and paginated date windows
- preserve withdrawal fees and mark Earn/Bots as savings accounts

## Safety
- requires read access only
- does not trade, transfer, or withdraw funds
- redacts API credentials from request logs
- does not import individual trades or bot activity into the household budget
- does not use undocumented Bitget Card endpoints

## Verification
- TypeScript compilation and focused style checks pass in a clean worktree
- 3 test suites / 6 tests pass
- live read-only check returned all six documented wallet sections with current Spot and Bots balances
