### PR TITLE
Add read-only MEXC Spot synchronization

### DIFF
--- a/src/plugins/mexc/README.md
+++ b/src/plugins/mexc/README.md
@@ -1,0 +1,16 @@
+# MEXC
+
+Read-only MEXC Spot balance plugin for ZenMoney.
+
+## API key
+
+Create an API key in MEXC and enable only:
+
+- **Spot → Account → View account information**
+- **Withdrawal → View deposit/withdrawal details**
+
+Do not enable trading, withdrawal or transfer actions. The second permission is read-only despite being grouped under Withdrawal in the MEXC interface.
+
+## Scope
+
+The plugin creates one exchange-native **MEXC Spot** account and values available/locked assets in USDT terms using MEXC market prices. External deposit and withdrawal history is limited by MEXC to the latest 90 days and queried in windows shorter than seven days. A full window of 1,000 records is split automatically to avoid silent truncation. Individual spot trades are intentionally omitted from the household budget.

--- a/src/plugins/mexc/ZenmoneyManifest.xml
+++ b/src/plugins/mexc/ZenmoneyManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>mexc</id>
+    <company>0</company>
+    <description>Read-only MEXC Spot wallet and complete supported external transfer history.</description>
+    <version>0.1</version>
+    <build>2</build>
+    <modular>true</modular>
+    <files><js>index.js</js><preferences>preferences.xml</preferences></files>
+</provider>

--- a/src/plugins/mexc/__tests__/api.test.ts
+++ b/src/plugins/mexc/__tests__/api.test.ts
@@ -1,0 +1,7 @@
+import { login } from '../api'
+
+describe('MEXC credentials', () => {
+  it('keeps only the read-only API credentials', () => {
+    expect(login({ apiKey: 'key', apiSecret: 'secret', startDate: '2026-01-01T00:00:00.000Z' })).toEqual({ apiKey: 'key', apiSecret: 'secret' })
+  })
+})

--- a/src/plugins/mexc/__tests__/converters.test.ts
+++ b/src/plugins/mexc/__tests__/converters.test.ts
@@ -1,0 +1,48 @@
+import { AccountType } from '../../../types/zenmoney'
+import { convertExternalStablecoinTransfers, createSpotAccount, parseSettlementAssets, valueInUsdt } from '../converters'
+
+describe('MEXC balance conversion', () => {
+  const prices = new Map([['BTCUSDT', 60000], ['ETHBTC', 0.05]])
+
+  it('values stablecoins, direct and bridged assets', () => {
+    expect(valueInUsdt('USDT', 10, prices)).toBe(10)
+    expect(valueInUsdt('BTC', 0.1, prices)).toBe(6000)
+    expect(valueInUsdt('ETH', 2, prices)).toBe(6000)
+    expect(valueInUsdt('UNKNOWN', 1, prices)).toBe(0)
+  })
+
+  it('uses a market quote for non-USDT stablecoins when available', () => {
+    expect(valueInUsdt('USDC', 100, new Map([['USDCUSDT', 0.999]]))).toBe(99.9)
+    expect(valueInUsdt('USDC', 100, new Map())).toBe(100)
+  })
+
+  it('creates one stable MEXC Spot account', () => {
+    expect(createSpotAccount('MEXC', [
+      { asset: 'USDT', free: 100, locked: 2 },
+      { asset: 'BTC', free: 0.1, locked: 0 }
+    ], prices)).toEqual({
+      id: 'mexc_spot',
+      type: AccountType.investment,
+      title: 'MEXC Spot',
+      instrument: 'USD',
+      balance: 6102,
+      savings: false,
+      syncIds: ['mexc_spot']
+    })
+  })
+
+  it('imports only stable external transfers with deterministic ids', () => {
+    const result = convertExternalStablecoinTransfers('MEXC', [
+      { id: 'deposit', direction: 'deposit', coin: 'USDT', amount: 10, fee: 0, date: new Date('2026-08-01T00:00:00Z'), network: 'TRC20' },
+      { id: 'withdrawal', direction: 'withdrawal', coin: 'USDC', amount: 20, fee: 1, date: new Date('2026-08-02T00:00:00Z'), network: null },
+      { id: 'btc', direction: 'deposit', coin: 'BTC', amount: 1, fee: 0, date: new Date('2026-08-03T00:00:00Z'), network: null }
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0].movements[0]).toMatchObject({ id: 'mexc_deposit_deposit', sum: 10, fee: 0 })
+    expect(result[1].movements[0]).toMatchObject({ id: 'mexc_withdrawal_withdrawal', sum: -20, fee: -1 })
+  })
+
+  it('normalizes custom settlement assets', () => {
+    expect([...parseSettlementAssets(' usdt,USDC,usdt ')]).toEqual(['USDT', 'USDC'])
+  })
+})

--- a/src/plugins/mexc/__tests__/fetchApi.test.ts
+++ b/src/plugins/mexc/__tests__/fetchApi.test.ts
@@ -1,0 +1,9 @@
+import { buildQueryString, signQuery } from '../fetchApi'
+
+describe('MEXC request signing', () => {
+  it('signs the exact query string sent to MEXC', () => {
+    const query = buildQueryString({ startTime: 10, endTime: 20, limit: 1000, empty: undefined })
+    expect(query).toBe('startTime=10&endTime=20&limit=1000')
+    expect(signQuery('secret', query)).toBe('b1438e4a8006bff3520479c965a58b1399fa69ea5cb5a7f628c1810654053eac')
+  })
+})

--- a/src/plugins/mexc/api.ts
+++ b/src/plugins/mexc/api.ts
@@ -1,0 +1,9 @@
+import { InvalidPreferencesError } from '../../errors'
+import { Credentials, Preferences } from './models'
+
+export function login (preferences: Preferences): Credentials {
+  if (preferences.apiKey?.trim() === '' || preferences.apiSecret?.trim() === '') {
+    throw new InvalidPreferencesError('MEXC: API Key and API Secret are required')
+  }
+  return { apiKey: preferences.apiKey, apiSecret: preferences.apiSecret }
+}

--- a/src/plugins/mexc/converters.ts
+++ b/src/plugins/mexc/converters.ts
@@ -1,0 +1,60 @@
+import { AccountOrCard, AccountType, Transaction } from '../../types/zenmoney'
+import { CapitalTransfer, SpotAsset } from './models'
+
+const STABLECOINS = new Set(['USDT', 'USDC', 'USD', 'FDUSD', 'TUSD'])
+
+export function parseSettlementAssets (value?: string): Set<string> {
+  return new Set((value ?? 'USDT,USDC,USD,USDE,FDUSD,TUSD')
+    .split(',')
+    .map(asset => asset.trim().toUpperCase())
+    .filter(asset => asset !== ''))
+}
+
+export function valueInUsdt (asset: string, amount: number, prices: Map<string, number>): number {
+  const symbol = asset.toUpperCase()
+  if (symbol === 'USDT' || symbol === 'USD') return amount
+  const direct = prices.get(`${symbol}USDT`)
+  if (direct != null) return amount * direct
+  for (const bridge of ['BTC', 'ETH', 'USDC']) {
+    const assetBridge = prices.get(`${symbol}${bridge}`)
+    const bridgeUsdt = prices.get(`${bridge}USDT`)
+    if (assetBridge != null && bridgeUsdt != null) return amount * assetBridge * bridgeUsdt
+  }
+  if (STABLECOINS.has(symbol)) return amount
+  return 0
+}
+
+export function createSpotAccount (label: string, balances: SpotAsset[], prices: Map<string, number>): AccountOrCard {
+  const title = label.trim() === '' ? 'MEXC' : label.trim()
+  const idCandidate = title.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+  const id = `${idCandidate === '' ? 'mexc' : idCandidate}_spot`
+  const balance = balances.reduce((sum, asset) => sum + valueInUsdt(asset.asset, asset.free + asset.locked, prices), 0)
+  return {
+    id,
+    type: AccountType.investment,
+    title: `${title} Spot`,
+    instrument: 'USD',
+    balance: Number(balance.toFixed(8)),
+    savings: false,
+    syncIds: [id]
+  }
+}
+
+export function convertExternalStablecoinTransfers (label: string, transfers: CapitalTransfer[], settlementAssets = STABLECOINS): Transaction[] {
+  const prefix = label.trim() === '' ? 'MEXC' : label.trim()
+  const idCandidate = prefix.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+  const accountId = `${idCandidate === '' ? 'mexc' : idCandidate}_spot`
+  return transfers.filter(transfer => settlementAssets.has(transfer.coin) && !Number.isNaN(transfer.date.getTime())).map(transfer => ({
+    hold: false,
+    date: transfer.date,
+    movements: [{
+      id: `mexc_${transfer.direction}_${transfer.id}`,
+      account: { id: accountId },
+      invoice: null,
+      sum: transfer.direction === 'deposit' ? transfer.amount : -transfer.amount,
+      fee: transfer.direction === 'withdrawal' ? -Math.abs(transfer.fee) : 0
+    }],
+    merchant: null,
+    comment: `MEXC external ${transfer.direction}: ${transfer.coin}${transfer.network == null || transfer.network === '' ? '' : `; network ${transfer.network}`}`
+  }))
+}

--- a/src/plugins/mexc/fetchApi.ts
+++ b/src/plugins/mexc/fetchApi.ts
@@ -1,0 +1,122 @@
+import crypto from 'crypto-js'
+import { fetchJson } from '../../common/network'
+import { InvalidPreferencesError, TemporaryError } from '../../errors'
+import { getArray, getOptNumber, getOptString, getString } from '../../types/get'
+import { CapitalTransfer, Credentials, SpotAsset } from './models'
+
+const BASE_URL = 'https://api.mexc.com'
+const RECV_WINDOW = 20000
+
+export function buildQueryString (query: Record<string, string | number | undefined>): string {
+  return Object.entries(query)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join('&')
+}
+
+export function signQuery (secret: string, query: string): string {
+  return crypto.HmacSHA256(query, secret).toString(crypto.enc.Hex)
+}
+
+async function signedGet (credentials: Credentials, path: string, query: Record<string, string | number | undefined> = {}): Promise<unknown> {
+  const payload = buildQueryString({ ...query, recvWindow: RECV_WINDOW, timestamp: Date.now() })
+  const signature = signQuery(credentials.apiSecret, payload)
+  const response = await fetchJson(`${BASE_URL}${path}?${payload}&signature=${signature}`, {
+    method: 'GET',
+    headers: { 'X-MEXC-APIKEY': credentials.apiKey },
+    sanitizeRequestLog: { headers: { 'X-MEXC-APIKEY': true }, query: { signature: true } }
+  })
+  if (response.status === 401 || response.status === 403) {
+    throw new InvalidPreferencesError('MEXC: API key rejected. Create a read-only key with account viewing enabled.')
+  }
+  if (response.status === 418 || response.status === 429) {
+    throw new TemporaryError('MEXC: request limit reached, try again later')
+  }
+  const code = getOptNumber(response.body, 'code')
+  if (code != null && code !== 0) {
+    const message = getOptString(response.body, 'msg') ?? 'unknown API error'
+    if (code === 700002 || code === 700003 || code === 700005 || code === 700006) {
+      throw new InvalidPreferencesError(`MEXC: ${message}`)
+    }
+    throw new TemporaryError(`MEXC: ${message} (code=${code})`)
+  }
+  return response.body
+}
+
+export async function fetchSpotBalances (credentials: Credentials): Promise<SpotAsset[]> {
+  const body = await signedGet(credentials, '/api/v3/account', { omitZeroBalances: 'true' })
+  return getArray(body, 'balances').map(row => ({
+    asset: getString(row, 'asset').toUpperCase(),
+    free: Number(getString(row, 'free')),
+    locked: Number(getString(row, 'locked'))
+  })).filter(row => Number.isFinite(row.free) && Number.isFinite(row.locked))
+}
+
+export async function fetchPrices (): Promise<Map<string, number>> {
+  const response = await fetchJson(`${BASE_URL}/api/v3/ticker/price`)
+  if (response.status === 418 || response.status === 429) throw new TemporaryError('MEXC: price request limit reached')
+  const rows: unknown[] = Array.isArray(response.body) ? response.body : []
+  const prices = new Map<string, number>()
+  for (const row of rows) {
+    const price = Number(getString(row, 'price'))
+    if (Number.isFinite(price)) prices.set(getString(row, 'symbol').toUpperCase(), price)
+  }
+  return prices
+}
+
+const MAX_HISTORY_MS = 89 * 24 * 60 * 60 * 1000
+// MEXC accepts capital-history windows of at most seven days. The public API
+// does not paginate a wider range for us, so the plugin does it transparently.
+const MAX_CAPITAL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000 - 1
+
+function records (body: unknown): unknown[] {
+  return Array.isArray(body) ? body : getArray(body, 'data')
+}
+
+async function fetchCapitalRows (credentials: Credentials, path: string, startTime: number, endTime: number): Promise<unknown[]> {
+  const rows = records(await signedGet(credentials, path, { startTime, endTime, limit: 1000 }))
+  if (rows.length < 1000 || endTime - startTime <= 1000) return rows
+  const middle = Math.floor((startTime + endTime) / 2)
+  const [left, right] = await Promise.all([
+    fetchCapitalRows(credentials, path, startTime, middle),
+    fetchCapitalRows(credentials, path, middle + 1, endTime)
+  ])
+  return [...left, ...right]
+}
+
+/**
+ * MEXC exposes no more than 90 days of capital history. We ask for all that
+ * the exchange can legally return and never pretend that an older period was
+ * imported. Only terminal statuses are emitted.
+ */
+export async function fetchCapitalTransfers (credentials: Credentials, fromDate: Date, toDate: Date): Promise<CapitalTransfer[]> {
+  const safeFrom = new Date(Math.max(fromDate.getTime(), toDate.getTime() - MAX_HISTORY_MS))
+  const transfers: CapitalTransfer[] = []
+  for (let start = safeFrom.getTime(); start <= toDate.getTime(); start += MAX_CAPITAL_WINDOW_MS + 1) {
+    const end = Math.min(start + MAX_CAPITAL_WINDOW_MS, toDate.getTime())
+    const [deposits, withdrawals] = await Promise.all([
+      fetchCapitalRows(credentials, '/api/v3/capital/deposit/hisrec', start, end),
+      fetchCapitalRows(credentials, '/api/v3/capital/withdraw/history', start, end)
+    ])
+    for (const row of deposits) {
+      const status = getOptNumber(row, 'status')
+      // MEXC documents both SUCCESS (5) and COMPLETED (12) for deposits.
+      if (status !== 5 && status !== 12) continue
+      const amount = Number(getString(row, 'amount'))
+      const id = getString(row, 'txId')
+      if (id === '' || !Number.isFinite(amount) || amount === 0) continue
+      transfers.push({ id, direction: 'deposit', coin: getString(row, 'coin').toUpperCase(), amount, fee: 0, date: new Date(getOptNumber(row, 'insertTime') ?? 0), network: getOptString(row, 'network') ?? null })
+    }
+    for (const row of withdrawals) {
+      // MEXC documents SUCCESS as status 7 for withdrawals.
+      if (getOptNumber(row, 'status') !== 7) continue
+      const amount = Number(getString(row, 'amount'))
+      const id = getString(row, 'id')
+      if (id === '' || !Number.isFinite(amount) || amount === 0) continue
+      transfers.push({ id, direction: 'withdrawal', coin: getString(row, 'coin').toUpperCase(), amount, fee: Number(getOptString(row, 'transactionFee') ?? 0), date: new Date(getOptNumber(row, 'applyTime') ?? 0), network: getOptString(row, 'network') ?? null })
+    }
+  }
+  const unique = new Map<string, CapitalTransfer>()
+  for (const transfer of transfers) unique.set(`${transfer.direction}:${transfer.id}`, transfer)
+  return [...unique.values()].sort((left, right) => left.date.getTime() - right.date.getTime())
+}

--- a/src/plugins/mexc/index.ts
+++ b/src/plugins/mexc/index.ts
@@ -1,0 +1,14 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { login } from './api'
+import { convertExternalStablecoinTransfers, createSpotAccount, parseSettlementAssets } from './converters'
+import { fetchCapitalTransfers, fetchPrices, fetchSpotBalances } from './fetchApi'
+import { Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  const credentials = login(preferences)
+  const [balances, prices, transfers] = await Promise.all([fetchSpotBalances(credentials), fetchPrices(), fetchCapitalTransfers(credentials, fromDate, toDate ?? new Date())])
+  return {
+    accounts: [createSpotAccount(preferences.accountLabel ?? 'MEXC', balances, prices)],
+    transactions: convertExternalStablecoinTransfers(preferences.accountLabel ?? 'MEXC', transfers, parseSettlementAssets(preferences.externalTransferAssets))
+  }
+}

--- a/src/plugins/mexc/models.ts
+++ b/src/plugins/mexc/models.ts
@@ -1,0 +1,28 @@
+export interface Preferences {
+  apiKey: string
+  apiSecret: string
+  accountLabel?: string
+  startDate: string
+  externalTransferAssets?: string
+}
+
+export interface Credentials {
+  apiKey: string
+  apiSecret: string
+}
+
+export interface SpotAsset {
+  asset: string
+  free: number
+  locked: number
+}
+
+export interface CapitalTransfer {
+  id: string
+  direction: 'deposit' | 'withdrawal'
+  coin: string
+  amount: number
+  fee: number
+  date: Date
+  network: string | null
+}

--- a/src/plugins/mexc/preferences.xml
+++ b/src/plugins/mexc/preferences.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference key="apiKey" obligatory="true" title="Read-only API Key" dialogTitle="Read-only API Key" dialogMessage="Enable Spot → Account → View account information and Withdrawal → View deposit/withdrawal details. Do not enable trading, withdrawal or transfer actions." positiveButtonText="OK" negativeButtonText="Cancel" summary="|apiKey|{@s}" />
+    <EditTextPreference key="apiSecret" obligatory="true" inputType="textPassword" title="Read-only API Secret" dialogTitle="Read-only API Secret" dialogMessage="The secret is shown once. Keep it private." positiveButtonText="OK" negativeButtonText="Cancel" summary="||***********" />
+    <EditTextPreference key="accountLabel" obligatory="true" defaultValue="MEXC" title="Account label" dialogTitle="Account label" positiveButtonText="OK" negativeButtonText="Cancel" summary="|accountLabel|{@s}" />
+    <EditTextPreference key="externalTransferAssets" defaultValue="USDT,USDC,USD,USDE,FDUSD,TUSD" title="Settlement assets to import" dialogTitle="Settlement assets to import" dialogMessage="Comma-separated USD-pegged assets for deposit/withdrawal history. Current balance still includes all supported assets." positiveButtonText="OK" negativeButtonText="Cancel" summary="|externalTransferAssets|{@s}" />
+    <EditTextPreference key="startDate" obligatory="true" inputType="date" defaultValue="2026-01-01T00:00:00.000Z" title="Load operations from" dialogTitle="Load operations from" dialogMessage="Imports completed external stablecoin deposits and withdrawals. MEXC itself provides up to 90 days of this history." positiveButtonText="OK" negativeButtonText="Cancel" summary="|startDate|{@s}" />
+</PreferenceScreen>


### PR DESCRIPTION
## Summary
- add read-only MEXC Spot balance synchronization valued in USDT terms
- import completed external deposits and withdrawals with stable IDs
- respect MEXC's 90-day history limit and seven-day request windows
- recursively split full 1,000-record windows to avoid silent truncation
- use market quotes for non-USDT stablecoins when available

## Safety
- requires Spot account viewing and deposit/withdrawal-details viewing only
- does not enable trading, withdrawal, or transfer actions
- redacts API credentials and request signatures from logs
- does not import individual spot trades into the household budget

## Verification
- TypeScript compilation and focused style checks pass in a clean worktree
- 3 test suites / 7 tests pass
- live read-only check returned the current MEXC Spot balance without duplicate transactions
