### PR TITLE
Add read-only BingX wallet synchronization

### DIFF
--- a/src/plugins/bingx/README.md
+++ b/src/plugins/bingx/README.md
@@ -1,0 +1,9 @@
+# BingX
+
+Read-only BingX wallets and transfers for ZenMoney.
+
+Create an API key in BingX API Management with read access only. Do not enable trading, transfers or withdrawals.
+
+The plugin uses BingX's USDT-valued account overview and creates the exchange-native sections available to the user: Fund / Spot, Standard Futures, USDT-M Futures, Coin-M Futures, Copy Trading, Grid Bots, Wealth and C2C. It imports confirmed external deposits and withdrawals with stable IDs.
+
+Confirmed transfers between Fund, Standard Futures and USDT-M Futures are represented as balanced transfers between the user's own ZenMoney accounts. They have no income or spending effect. Individual trades, futures PnL events and Wealth accrual noise are intentionally not copied into the household budget.

--- a/src/plugins/bingx/ZenmoneyManifest.xml
+++ b/src/plugins/bingx/ZenmoneyManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>bingx</id>
+    <company>0</company>
+    <description>Read-only BingX wallets with external and own-account transfers.</description>
+    <version>0.1</version>
+    <build>2</build>
+    <modular>true</modular>
+    <files><js>index.js</js><preferences>preferences.xml</preferences></files>
+</provider>

--- a/src/plugins/bingx/__tests__/api.test.ts
+++ b/src/plugins/bingx/__tests__/api.test.ts
@@ -1,0 +1,7 @@
+import { login } from '../api'
+
+describe('BingX credentials', () => {
+  it('keeps only the read-only API credentials', () => {
+    expect(login({ apiKey: 'key', apiSecret: 'secret', startDate: '2026-01-01T00:00:00.000Z' })).toEqual({ apiKey: 'key', apiSecret: 'secret' })
+  })
+})

--- a/src/plugins/bingx/__tests__/converters.test.ts
+++ b/src/plugins/bingx/__tests__/converters.test.ts
@@ -1,0 +1,48 @@
+import { AccountType } from '../../../types/zenmoney'
+import { convertExternalStablecoinTransfers, convertInternalTransfers, createAccounts, parseSettlementAssets } from '../converters'
+import { historyRows, internalTransferRows } from '../fetchApi'
+
+describe('BingX accounts', () => {
+  it('keeps Fund/Spot and bots separate', () => {
+    expect(createAccounts('BingX', [
+      { wallet: 'Fund / Spot', valueUsdt: 636.19996441, savings: false },
+      { wallet: 'Grid Bots', valueUsdt: 61.76, savings: true }
+    ])).toEqual([
+      { id: 'bingx_fund_spot', type: AccountType.investment, title: 'BingX Fund / Spot', instrument: 'USD', balance: 636.19996441, savings: false, syncIds: ['bingx_fund_spot'] },
+      { id: 'bingx_grid_bots', type: AccountType.investment, title: 'BingX Grid Bots', instrument: 'USD', balance: 61.76, savings: true, syncIds: ['bingx_grid_bots'] }
+    ])
+  })
+
+  it('uses Fund / Spot for external stablecoin transfers', () => {
+    const result = convertExternalStablecoinTransfers('BingX', [
+      { id: 'in', direction: 'deposit', coin: 'USDT', amount: 100, fee: 0, date: new Date('2026-04-17T14:30:56Z'), network: 'BEP20' },
+      { id: 'out', direction: 'withdrawal', coin: 'USDC', amount: 20, fee: 1, date: new Date('2026-08-01T00:00:00Z'), network: null }
+    ])
+    expect(result).toHaveLength(2)
+    expect(result[0].movements[0]).toMatchObject({ id: 'bingx_deposit_in', account: { id: 'bingx_fund_spot' }, sum: 100 })
+    expect(result[1].movements[0]).toMatchObject({ id: 'bingx_withdrawal_out', sum: -20, fee: -1 })
+  })
+
+  it('accepts BingX bare-array capital history responses', () => {
+    expect(historyRows([{ id: 'deposit-1' }])).toEqual([{ id: 'deposit-1' }])
+  })
+
+  it('accepts both internal-transfer response shapes', () => {
+    const rows = [{ tranId: 123 }]
+    expect(internalTransferRows({ rows })).toEqual(rows)
+    expect(internalTransferRows({ data: { rows } })).toEqual(rows)
+  })
+
+  it('creates a balanced own-account transfer', () => {
+    const result = convertInternalTransfers('BingX', [{ id: '123', coin: 'USDT', amount: 50, date: new Date('2026-08-01T00:00:00Z'), fromWallet: 'Fund / Spot', toWallet: 'USDT-M Futures' }])
+    expect(result).toHaveLength(1)
+    expect(result[0].movements).toEqual([
+      { id: 'bingx_internal_123_out', account: { id: 'bingx_fund_spot' }, invoice: null, sum: -50, fee: 0 },
+      { id: 'bingx_internal_123_in', account: { id: 'bingx_usdt_m_futures' }, invoice: null, sum: 50, fee: 0 }
+    ])
+  })
+
+  it('normalizes custom settlement assets', () => {
+    expect([...parseSettlementAssets(' usdt,USDC,usdt ')]).toEqual(['USDT', 'USDC'])
+  })
+})

--- a/src/plugins/bingx/__tests__/fetchApi.test.ts
+++ b/src/plugins/bingx/__tests__/fetchApi.test.ts
@@ -1,0 +1,9 @@
+import { buildQueryString, signQuery } from '../fetchApi'
+
+describe('BingX request signing', () => {
+  it('sorts and signs the exact encoded query string sent to BingX', () => {
+    const query = buildQueryString({ timestamp: 1700000000000, symbol: 'BTC-USDT', recvWindow: 5000, empty: undefined })
+    expect(query).toBe('recvWindow=5000&symbol=BTC-USDT&timestamp=1700000000000')
+    expect(signQuery('secret', query)).toBe('f70971b2211682368f2d05d1ab18d837e4da793c3475e397a9a0451393e487e7')
+  })
+})

--- a/src/plugins/bingx/api.ts
+++ b/src/plugins/bingx/api.ts
@@ -1,0 +1,9 @@
+import { InvalidPreferencesError } from '../../errors'
+import { Credentials, Preferences } from './models'
+
+export function login (preferences: Preferences): Credentials {
+  if (preferences.apiKey?.trim() === '' || preferences.apiSecret?.trim() === '') {
+    throw new InvalidPreferencesError('BingX: API Key and API Secret are required')
+  }
+  return { apiKey: preferences.apiKey, apiSecret: preferences.apiSecret }
+}

--- a/src/plugins/bingx/converters.ts
+++ b/src/plugins/bingx/converters.ts
@@ -1,0 +1,64 @@
+import { AccountOrCard, AccountType, Transaction } from '../../types/zenmoney'
+import { CapitalTransfer, InternalTransfer, WalletBalance } from './models'
+
+export function parseSettlementAssets (value?: string): Set<string> {
+  return new Set((value ?? 'USDT,USDC,USD,USDE,FDUSD,TUSD')
+    .split(',')
+    .map(asset => asset.trim().toUpperCase())
+    .filter(asset => asset !== ''))
+}
+
+function slug (value: string): string {
+  const candidate = value.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '')
+  return candidate === '' ? 'wallet' : candidate
+}
+
+export function createAccounts (label: string, wallets: WalletBalance[]): AccountOrCard[] {
+  const prefix = label.trim() === '' ? 'BingX' : label.trim()
+  const idPrefix = slug(prefix)
+  return wallets.map(wallet => {
+    const id = `${idPrefix}_${slug(wallet.wallet)}`
+    return { id, type: AccountType.investment, title: `${prefix} ${wallet.wallet}`, instrument: 'USD', balance: Number(wallet.valueUsdt.toFixed(8)), savings: wallet.savings, syncIds: [id] }
+  })
+}
+
+export function convertExternalStablecoinTransfers (label: string, transfers: CapitalTransfer[], settlementAssets = new Set(['USDT', 'USDC', 'BUSD', 'FDUSD'])): Transaction[] {
+  const prefix = label.trim() === '' ? 'BingX' : label.trim()
+  const idPrefix = slug(prefix)
+  return transfers.filter(transfer => settlementAssets.has(transfer.coin) && !Number.isNaN(transfer.date.getTime())).map(transfer => ({
+    hold: false,
+    date: transfer.date,
+    movements: [{
+      id: `bingx_${transfer.direction}_${transfer.id}`,
+      account: { id: `${idPrefix}_fund_spot` },
+      invoice: null,
+      sum: transfer.direction === 'deposit' ? transfer.amount : -transfer.amount,
+      fee: transfer.direction === 'withdrawal' ? -Math.abs(transfer.fee) : 0
+    }],
+    merchant: null,
+    comment: `BingX external ${transfer.direction}: ${transfer.coin}${transfer.network == null || transfer.network === '' ? '' : `; network ${transfer.network}`}`
+  }))
+}
+
+export function convertInternalTransfers (label: string, transfers: InternalTransfer[], settlementAssets = new Set(['USDT', 'USDC', 'BUSD', 'FDUSD'])): Transaction[] {
+  const idPrefix = slug(label.trim() === '' ? 'BingX' : label.trim())
+  return transfers.filter(transfer => settlementAssets.has(transfer.coin) && !Number.isNaN(transfer.date.getTime())).map(transfer => ({
+    hold: false,
+    date: transfer.date,
+    movements: [{
+      id: `bingx_internal_${transfer.id}_out`,
+      account: { id: `${idPrefix}_${slug(transfer.fromWallet)}` },
+      invoice: null,
+      sum: -transfer.amount,
+      fee: 0
+    }, {
+      id: `bingx_internal_${transfer.id}_in`,
+      account: { id: `${idPrefix}_${slug(transfer.toWallet)}` },
+      invoice: null,
+      sum: transfer.amount,
+      fee: 0
+    }],
+    merchant: null,
+    comment: `BingX internal transfer: ${transfer.coin}`
+  }))
+}

--- a/src/plugins/bingx/fetchApi.ts
+++ b/src/plugins/bingx/fetchApi.ts
@@ -1,0 +1,182 @@
+import crypto from 'crypto-js'
+import { fetchJson } from '../../common/network'
+import { InvalidPreferencesError, TemporaryError } from '../../errors'
+import { getArray, getOptArray, getOptNumber, getOptString, getString } from '../../types/get'
+import { CapitalTransfer, Credentials, InternalTransfer, WalletBalance } from './models'
+
+const BASE_URL = 'https://open-api.bingx.com'
+
+export function buildQueryString (query: Record<string, string | number | undefined>): string {
+  return Object.entries(query)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join('&')
+}
+
+export function signQuery (secret: string, query: string): string {
+  return crypto.HmacSHA256(query, secret).toString(crypto.enc.Hex)
+}
+
+async function signedGet (credentials: Credentials, path: string, query: Record<string, string | number | undefined> = {}): Promise<unknown> {
+  const payload = buildQueryString({ ...query, recvWindow: 5000, timestamp: Date.now() })
+  const response = await fetchJson(`${BASE_URL}${path}?${payload}&signature=${signQuery(credentials.apiSecret, payload)}`, {
+    method: 'GET',
+    headers: { 'X-BX-APIKEY': credentials.apiKey },
+    sanitizeRequestLog: { headers: { 'X-BX-APIKEY': true }, query: { signature: true } }
+  })
+  if (response.status === 401 || response.status === 403) throw new InvalidPreferencesError('BingX: API key rejected. Recreate a read-only key.')
+  if (response.status === 418 || response.status === 429) throw new TemporaryError('BingX: request limit reached, try again later')
+  const code = getOptNumber(response.body, 'code')
+  if (code != null && code !== 0) {
+    const message = getOptString(response.body, 'msg') ?? getOptString(response.body, 'message') ?? 'unknown API error'
+    if (code === 100001 || code === 100002 || code === 100004) throw new InvalidPreferencesError(`BingX: ${message} (code=${code})`)
+    throw new TemporaryError(`BingX: ${message} (code=${code})`)
+  }
+  return response.body
+}
+
+async function fetchPrices (): Promise<Map<string, number>> {
+  const response = await fetchJson(`${BASE_URL}/openApi/spot/v1/ticker/price`)
+  const prices = new Map<string, number>()
+  for (const row of getArray(response.body, 'data')) {
+    const symbol = getString(row, 'symbol').replace('_', '-').toUpperCase()
+    const direct = getOptString(row, 'price')
+    const nested = getOptString(row, 'trades.0.price')
+    const value = Number(direct ?? nested ?? 0)
+    if (Number.isFinite(value) && value > 0) prices.set(symbol, value)
+  }
+  return prices
+}
+
+function valueInUsdt (asset: string, amount: number, prices: Map<string, number>): number {
+  const coin = asset.toUpperCase()
+  if (coin === 'USDT' || coin === 'USD') return amount
+  const quoted = prices.get(`${coin}-USDT`)
+  if (quoted != null) return amount * quoted
+  return ['USDC', 'BUSD', 'FDUSD', 'USDE'].includes(coin) ? amount : 0
+}
+
+export async function fetchWalletBalances (credentials: Credentials): Promise<WalletBalance[]> {
+  const [spot, overview, prices] = await Promise.all([
+    signedGet(credentials, '/openApi/spot/v1/account/balance'),
+    signedGet(credentials, '/openApi/account/v1/allAccountBalance'),
+    fetchPrices()
+  ])
+  const spotRows = getArray(spot, 'data.balances').length > 0 ? getArray(spot, 'data.balances') : getArray(spot, 'data.balance')
+  const fundSpot = spotRows.reduce<number>((sum, row) => {
+    const amount = Number(getOptString(row, 'free') ?? getOptString(row, 'available') ?? 0) + Number(getOptString(row, 'locked') ?? getOptString(row, 'freeze') ?? 0)
+    return sum + valueInUsdt(getOptString(row, 'asset') ?? getString(row, 'coin'), amount, prices)
+  }, 0)
+  const titleByType: Record<string, string> = { USDTMPerp: 'USDT-M Futures', stdFutures: 'Standard Futures', coinMPerp: 'Coin-M Futures', copyTrading: 'Copy Trading', grid: 'Grid Bots', eran: 'Wealth', c2c: 'C2C' }
+  const additional: WalletBalance[] = getArray(overview, 'data').filter(row => getString(row, 'accountType') !== 'sopt').map(row => ({
+    wallet: titleByType[getString(row, 'accountType')] ?? getString(row, 'accountType'),
+    valueUsdt: Number(getString(row, 'usdtBalance')),
+    savings: ['grid', 'eran', 'copyTrading'].includes(getString(row, 'accountType'))
+  }))
+  return [{ wallet: 'Fund / Spot', valueUsdt: fundSpot, savings: false }, ...additional]
+    .filter(wallet => Number.isFinite(wallet.valueUsdt))
+}
+
+const INTERNAL_TRANSFER_TYPES: Array<{ type: string, fromWallet: string, toWallet: string }> = [
+  { type: 'FUND_SFUTURES', fromWallet: 'Fund / Spot', toWallet: 'Standard Futures' },
+  { type: 'SFUTURES_FUND', fromWallet: 'Standard Futures', toWallet: 'Fund / Spot' },
+  { type: 'FUND_PFUTURES', fromWallet: 'Fund / Spot', toWallet: 'USDT-M Futures' },
+  { type: 'PFUTURES_FUND', fromWallet: 'USDT-M Futures', toWallet: 'Fund / Spot' },
+  { type: 'SFUTURES_PFUTURES', fromWallet: 'Standard Futures', toWallet: 'USDT-M Futures' },
+  { type: 'PFUTURES_SFUTURES', fromWallet: 'USDT-M Futures', toWallet: 'Standard Futures' }
+]
+
+export async function fetchInternalTransfers (credentials: Credentials, fromDate: Date, toDate: Date): Promise<InternalTransfer[]> {
+  const result: InternalTransfer[] = []
+  let nextRequestAt = 0
+  for (const direction of INTERNAL_TRANSFER_TYPES) {
+    for (let current = 1; current <= 1000; current++) {
+      // This endpoint is limited to two requests per second per IP. Querying
+      // its required direction values without pacing can temporarily disable
+      // an otherwise valid read-only key.
+      const waitMs = nextRequestAt - Date.now()
+      if (waitMs > 0) await new Promise(resolve => setTimeout(resolve, waitMs))
+      const body = await signedGet(credentials, '/openApi/api/v3/asset/transfer', { type: direction.type, startTime: fromDate.getTime(), endTime: toDate.getTime(), current, size: 100 })
+      nextRequestAt = Date.now() + 550
+      const rows = internalTransferRows(body)
+      for (const row of rows) {
+        if (getString(row, 'status').toUpperCase() !== 'CONFIRMED') continue
+        const id = String(responseNumber(row, 'tranId'))
+        const amount = Number(getString(row, 'amount'))
+        const date = new Date(responseNumber(row, 'timestamp'))
+        if (id === '0' || !Number.isFinite(amount) || amount <= 0 || Number.isNaN(date.getTime())) continue
+        result.push({ id, coin: getString(row, 'asset').toUpperCase(), amount, date, fromWallet: direction.fromWallet, toWallet: direction.toWallet })
+      }
+      if (rows.length < 100) break
+    }
+  }
+  const unique = new Map<string, InternalTransfer>()
+  for (const transfer of result) unique.set(`${transfer.id}:${transfer.coin}`, transfer)
+  return [...unique.values()].sort((left, right) => left.date.getTime() - right.date.getTime())
+}
+
+export function internalTransferRows (body: unknown): unknown[] {
+  // BingX currently unwraps `data` in the common signed-request adapter for
+  // this endpoint. Keep the documented { data: { rows } } response compatible
+  // as well, so a server-side response-shape change does not break scraping.
+  return getOptArray(body, 'rows') ?? getOptArray(body, 'data.rows') ?? []
+}
+
+export function historyRows (body: unknown): unknown[] {
+  // Unlike most BingX endpoints, capital history currently returns a bare
+  // JSON array instead of { code, data }. Keep both API shapes compatible.
+  if (Array.isArray(body)) return body
+  const data = getOptArray(body, 'data') ?? []
+  const items = getOptArray(body, 'data.items') ?? []
+  const list = getOptArray(body, 'data.list') ?? []
+  return items.length > 0 ? items : list.length > 0 ? list : data
+}
+
+function responseNumber (row: unknown, ...paths: string[]): number {
+  for (const path of paths) {
+    const numeric = getOptNumber(row, path)
+    if (numeric !== undefined) return numeric
+    const text = getOptString(row, path)
+    if (text !== undefined) return Number(text)
+  }
+  return 0
+}
+
+async function fetchHistory (credentials: Credentials, path: string, fromDate: Date, toDate: Date): Promise<unknown[]> {
+  const all: unknown[] = []
+  for (let offset = 0; offset < 100000; offset += 1000) {
+    const rows = historyRows(await signedGet(credentials, path, { startTime: fromDate.getTime(), endTime: toDate.getTime(), offset, limit: 1000 }))
+    all.push(...rows)
+    if (rows.length < 1000) break
+  }
+  return all
+}
+
+export async function fetchCapitalTransfers (credentials: Credentials, fromDate: Date, toDate: Date): Promise<CapitalTransfer[]> {
+  const [deposits, withdrawals] = await Promise.all([
+    fetchHistory(credentials, '/openApi/api/v3/capital/deposit/hisrec', fromDate, toDate),
+    fetchHistory(credentials, '/openApi/api/v3/capital/withdraw/history', fromDate, toDate)
+  ])
+  const transfers: CapitalTransfer[] = []
+  for (const row of deposits) {
+    // The current BingX endpoint returns status 1 for a completed deposit.
+    if (String(getOptNumber(row, 'status') ?? getOptString(row, 'status') ?? '') !== '1') continue
+    const id = getOptString(row, 'id') ?? getOptString(row, 'tranId') ?? getOptString(row, 'txId') ?? ''
+    const amount = responseNumber(row, 'amount', 'quantity')
+    if (id === '' || !Number.isFinite(amount) || amount === 0) continue
+    const time = responseNumber(row, 'time', 'createTime', 'applyTime', 'insertTime', 'timestamp')
+    transfers.push({ id, direction: 'deposit', coin: (getOptString(row, 'coin') ?? getOptString(row, 'asset') ?? '').toUpperCase(), amount, fee: 0, date: new Date(time), network: getOptString(row, 'network') ?? getOptString(row, 'chain') ?? null })
+  }
+  for (const row of withdrawals) {
+    if (String(getOptNumber(row, 'status') ?? getOptString(row, 'status') ?? '') !== '1') continue
+    const id = getOptString(row, 'id') ?? getOptString(row, 'tranId') ?? getOptString(row, 'txId') ?? ''
+    const amount = responseNumber(row, 'amount', 'quantity')
+    if (id === '' || !Number.isFinite(amount) || amount === 0) continue
+    const time = responseNumber(row, 'time', 'createTime', 'applyTime', 'insertTime', 'timestamp')
+    transfers.push({ id, direction: 'withdrawal', coin: (getOptString(row, 'coin') ?? getOptString(row, 'asset') ?? '').toUpperCase(), amount, fee: responseNumber(row, 'transactionFee', 'fee'), date: new Date(time), network: getOptString(row, 'network') ?? getOptString(row, 'chain') ?? null })
+  }
+  const unique = new Map<string, CapitalTransfer>()
+  for (const transfer of transfers) unique.set(`${transfer.direction}:${transfer.id}`, transfer)
+  return [...unique.values()].sort((left, right) => left.date.getTime() - right.date.getTime())
+}

--- a/src/plugins/bingx/index.ts
+++ b/src/plugins/bingx/index.ts
@@ -1,0 +1,13 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { login } from './api'
+import { convertExternalStablecoinTransfers, convertInternalTransfers, createAccounts, parseSettlementAssets } from './converters'
+import { fetchCapitalTransfers, fetchInternalTransfers, fetchWalletBalances } from './fetchApi'
+import { Preferences } from './models'
+
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
+  const credentials = login(preferences)
+  const effectiveToDate = toDate ?? new Date()
+  const [wallets, transfers, internalTransfers] = await Promise.all([fetchWalletBalances(credentials), fetchCapitalTransfers(credentials, fromDate, effectiveToDate), fetchInternalTransfers(credentials, fromDate, effectiveToDate)])
+  const assets = parseSettlementAssets(preferences.externalTransferAssets)
+  return { accounts: createAccounts(preferences.accountLabel ?? 'BingX', wallets), transactions: [...convertExternalStablecoinTransfers(preferences.accountLabel ?? 'BingX', transfers, assets), ...convertInternalTransfers(preferences.accountLabel ?? 'BingX', internalTransfers, assets)].sort((left, right) => left.date.getTime() - right.date.getTime()) }
+}

--- a/src/plugins/bingx/models.ts
+++ b/src/plugins/bingx/models.ts
@@ -1,0 +1,30 @@
+export interface Preferences {
+  apiKey: string
+  apiSecret: string
+  accountLabel?: string
+  startDate: string
+  externalTransferAssets?: string
+}
+
+export interface Credentials { apiKey: string, apiSecret: string }
+
+export interface WalletBalance { wallet: string, valueUsdt: number, savings: boolean }
+
+export interface CapitalTransfer {
+  id: string
+  direction: 'deposit' | 'withdrawal'
+  coin: string
+  amount: number
+  fee: number
+  date: Date
+  network: string | null
+}
+
+export interface InternalTransfer {
+  id: string
+  coin: string
+  amount: number
+  date: Date
+  fromWallet: string
+  toWallet: string
+}

--- a/src/plugins/bingx/preferences.xml
+++ b/src/plugins/bingx/preferences.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference key="apiKey" obligatory="true" title="Read-only API Key" dialogTitle="Read-only API Key" dialogMessage="Create a BingX API key with read access only. Do not enable trading, transfers or withdrawals." positiveButtonText="OK" negativeButtonText="Cancel" summary="|apiKey|{@s}" />
+    <EditTextPreference key="apiSecret" obligatory="true" inputType="textPassword" title="Read-only API Secret" dialogTitle="Read-only API Secret" dialogMessage="The secret is shown once. Keep it private." positiveButtonText="OK" negativeButtonText="Cancel" summary="||***********" />
+    <EditTextPreference key="accountLabel" obligatory="true" defaultValue="BingX" title="Account label" dialogTitle="Account label" positiveButtonText="OK" negativeButtonText="Cancel" summary="|accountLabel|{@s}" />
+    <EditTextPreference key="externalTransferAssets" defaultValue="USDT,USDC,USD,USDE,FDUSD,TUSD" title="Settlement assets to import" dialogTitle="Settlement assets to import" dialogMessage="Comma-separated USD-pegged assets for deposit/withdrawal history. Current balance still includes all supported assets." positiveButtonText="OK" negativeButtonText="Cancel" summary="|externalTransferAssets|{@s}" />
+    <EditTextPreference key="startDate" obligatory="true" inputType="date" defaultValue="2026-01-01T00:00:00.000Z" title="Load operations from" dialogTitle="Load operations from" dialogMessage="Imports confirmed external stablecoin deposits and withdrawals using stable BingX IDs." positiveButtonText="OK" negativeButtonText="Cancel" summary="|startDate|{@s}" />
+</PreferenceScreen>


### PR DESCRIPTION
## Summary
- add read-only BingX wallet balances across Fund/Spot, futures, Copy Trading, Grid Bots, Wealth and C2C
- import confirmed external settlement-asset deposits and withdrawals with stable IDs
- represent confirmed internal account transfers as balanced own-account movements
- add setup documentation and focused credential, signing and conversion tests

## Verification
- TypeScript: passed
- ts-standard: passed
- Jest: 3 suites, 8 tests passed
- live read-only check: 5 accounts and a confirmed external deposit returned successfully

API credentials and local runtime data are excluded from the commit.