### PR TITLE
TON Scan: make Jetton synchronization reliable

### DIFF
--- a/src/plugins/tonscan/README.md
+++ b/src/plugins/tonscan/README.md
@@ -1,0 +1,35 @@
+# TON Scan
+
+Read-only synchronization of public TON wallets through the official TON
+Center API v3. The plugin imports the native TON balance and transfers, plus
+the verified TON USDT Jetton balance and transfers.
+
+## Setup
+
+1. Copy the public address of a regular TON wallet or TON Space wallet.
+2. Enter one or more addresses separated by commas.
+3. Choose the history start date.
+
+No seed phrase, private key or withdrawal permission is required. Never enter
+a recovery phrase into ZenMoney or any third-party integration.
+
+## Telegram Wallet limitation
+
+Telegram may expose two different products:
+
+- TON Space or another self-custody wallet has a public TON address and can be
+  synchronized by this plugin.
+- A custodial Telegram Wallet balance is maintained by the provider. If it
+  does not give the user a dedicated on-chain address and complete on-chain
+  history, a blockchain scanner cannot reconstruct that internal ledger.
+
+## Imported data
+
+- Native TON wallet balance and transfers.
+- Official TON USDT Jetton balance and confirmed transfers.
+- Multiple public wallet addresses in one connection.
+
+Unsupported Jettons are intentionally ignored to keep spam tokens and crypto
+dust out of ZenMoney. Aborted Jetton transfers are ignored. Transaction IDs
+include the transfer-specific TON fields so multiple Jetton movements in one
+blockchain transaction cannot overwrite each other.

--- a/src/plugins/tonscan/ZenmoneyManifest.xml
+++ b/src/plugins/tonscan/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>tonscan</id>
     <version>1.0</version>
-    <build>1</build>
+    <build>2</build>
     <company>16062</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>
@@ -10,5 +10,5 @@
         <js>index.js</js>
         <preferences>preferences.xml</preferences>
     </files>
-    <description>TON wallet and Jettons</description>
+    <description>TON wallets and verified Jetton transfers</description>
 </provider>

--- a/src/plugins/tonscan/__tests__/tonscan-scrape.test.ts
+++ b/src/plugins/tonscan/__tests__/tonscan-scrape.test.ts
@@ -101,7 +101,7 @@ describe('scrape', () => {
         hold: false,
         date: new Date('2024-06-15T04:14:36.000Z'),
         movements: [{
-          id: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyQSg=',
+          id: 'Iu1byKIIiIscIUICwIplNohqzlKJlqypafLX+VeyQSg=:ea62fba94c7d8605159e8906457f50bd08b73909661a95a89a672e81b1a1dd34',
           account: { id: 'EQCnDbQfXrcaamtqWgsaAzxG9WNfZ7JcgRsWFZIE1YRNRHYY' },
           invoice: null,
           sum: -26.79,

--- a/src/plugins/tonscan/api.ts
+++ b/src/plugins/tonscan/api.ts
@@ -1,4 +1,5 @@
 import qs from 'querystring'
+import crypto from 'crypto-js'
 import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
 import get from '../../types/get'
 import { SUPPORTED_JETTONS } from './config'
@@ -11,7 +12,7 @@ export interface Preferences {
 }
 
 export interface RawJettons {
-  jetton_wallets: Array<{ address: string, jetton: string, balance: number }>
+  jetton_wallets: Array<{ address: string, jetton: string, balance: number | string }>
 }
 
 export interface JettonInfo {
@@ -25,7 +26,7 @@ export interface JettonInfo {
 }
 
 export interface RawWallet {
-  balance: number
+  balance: number | string
 }
 
 export interface WalletInfo {
@@ -48,11 +49,15 @@ export interface TonTransaction {
 
 export interface RawJettonTransfer {
   jetton_transfers: Array<{
+    trace_id?: string
     transaction_hash: string
+    transaction_lt?: string
+    query_id?: string
     source: string
     destination: string
-    amount: number
+    amount: number | string
     transaction_now: number
+    transaction_aborted?: boolean
   }>
 }
 
@@ -87,6 +92,10 @@ export class TonscanApi {
     this.baseUrl = options.baseUrl
     this.requestsDelay = options.requestsDelay ?? 1300
     this.maxRps = options.maxRps ?? MAX_RPS
+  }
+
+  public async waitForIdle (): Promise<void> {
+    await Promise.all(this.activeList)
   }
 
   private async fetchApi (
@@ -149,17 +158,19 @@ export class TonscanApi {
     ) as FetchResponse & { body: RawJettons }
 
     const filteredJettons = response.body.jetton_wallets.filter(t => Object.keys(SUPPORTED_JETTONS).includes(t.jetton))
-    const jettonsAddressBook = await this.fetchAddressBook(filteredJettons.map(t => t.address))
+    const jettonsAddressBook = filteredJettons.length > 0
+      ? await this.fetchAddressBook(filteredJettons.map(t => t.address))
+      : {}
 
     return filteredJettons
       .map(t => ({
-        address: jettonsAddressBook[t.address].user_friendly,
+        address: jettonsAddressBook[t.address]?.user_friendly ?? t.address,
         jetton: t.jetton,
         jettonType: SUPPORTED_JETTONS[t.jetton].ticker,
         title: SUPPORTED_JETTONS[t.jetton].title,
         decimals: SUPPORTED_JETTONS[t.jetton].decimals,
         owner: ownerWalletAddress,
-        balance: t.balance
+        balance: Number(t.balance)
       }))
   }
 
@@ -174,7 +185,7 @@ export class TonscanApi {
 
     return {
       address: wallet,
-      balance: response.body.balance
+      balance: Number(response.body.balance)
     }
   }
 
@@ -212,16 +223,16 @@ export class TonscanApi {
 
       transactions.push(...incomeTransactions.map(t => ({
         transactionId: t.in_msg.hash,
-        fromAddress: addressBook[t.in_msg.source].user_friendly,
-        toAddress: addressBook[t.in_msg.destination].user_friendly,
+        fromAddress: addressBook[t.in_msg.source]?.user_friendly ?? t.in_msg.source,
+        toAddress: addressBook[t.in_msg.destination]?.user_friendly ?? t.in_msg.destination,
         quantity: t.in_msg.value,
         timestamp: t.in_msg.created_at
       })))
 
       transactions.push(...outcomeTransactions.map(t => ({
         transactionId: t.hash,
-        fromAddress: addressBook[t.source].user_friendly,
-        toAddress: addressBook[t.destination].user_friendly,
+        fromAddress: addressBook[t.source]?.user_friendly ?? t.source,
+        toAddress: addressBook[t.destination]?.user_friendly ?? t.destination,
         quantity: t.value,
         timestamp: t.created_at
       })))
@@ -238,6 +249,7 @@ export class TonscanApi {
 
   public async fetchJettonsTransfers (jettons: JettonInfo[], fromDate: Date, toDate?: Date): Promise<JettonTransfer[]> {
     const transfers: JettonTransfer[] = []
+    const movementIds = new Set<string>()
 
     // fetch each supported jetton transfers separately to avoid fetching all trasnfers of unsupported jettons
     for (const jetton of jettons) {
@@ -256,14 +268,16 @@ export class TonscanApi {
             sort: 'desc'
           })}`) as FetchResponse & { body: RawJettonTransfer }
 
-        transfers.push(...response.body.jetton_transfers.map(t => ({
-          jettonAddress: jetton.address,
-          transactionId: t.transaction_hash,
-          fromAddress: t.source,
-          toAddress: t.destination,
-          quantity: t.amount,
-          timestamp: t.transaction_now
-        })))
+        transfers.push(...response.body.jetton_transfers
+          .filter(t => t.transaction_aborted !== true)
+          .map(t => ({
+            jettonAddress: jetton.address,
+            transactionId: jettonTransferId(t, movementIds),
+            fromAddress: t.source,
+            toAddress: t.destination,
+            quantity: Number(t.amount),
+            timestamp: t.transaction_now
+          })))
 
         if (limit > response.body.jetton_transfers.length) {
           break
@@ -289,4 +303,31 @@ export class TonscanApi {
 
     return updatedTransfers
   }
+}
+
+function jettonTransferId (transfer: RawJettonTransfer['jetton_transfers'][number], usedIds: Set<string>): string {
+  // A TON transaction may contain multiple Jetton transfers. The transaction
+  // hash alone is therefore not always unique. Preserve the historical ID for
+  // the first movement to avoid duplicating existing ZenMoney imports.
+  if (!usedIds.has(transfer.transaction_hash)) {
+    usedIds.add(transfer.transaction_hash)
+    return transfer.transaction_hash
+  }
+  const discriminator = [
+    transfer.trace_id,
+    transfer.transaction_lt,
+    transfer.query_id,
+    transfer.source,
+    transfer.destination,
+    String(transfer.amount),
+    String(transfer.transaction_now)
+  ]
+    .filter((value): value is string => value != null && value !== '')
+    .join('|')
+  const base = `${transfer.transaction_hash}:${crypto.SHA256(discriminator).toString(crypto.enc.Hex)}`
+  let candidate = base
+  let suffix = 2
+  while (usedIds.has(candidate)) candidate = `${base}:${suffix++}`
+  usedIds.add(candidate)
+  return candidate
 }

--- a/src/plugins/tonscan/index.ts
+++ b/src/plugins/tonscan/index.ts
@@ -12,9 +12,10 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
   })
 
   await Promise.all(
-    preferences.wallets
+    [...new Set(preferences.wallets
       .split(',')
       .map(walletAddress => walletAddress.trim())
+      .filter(walletAddress => walletAddress !== ''))]
       .map(async (ownerWalletAddress) => {
         const [wallet, jettons] = await Promise.all([
           tonscanApi.fetchWallet(ownerWalletAddress),
@@ -43,6 +44,9 @@ export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, t
         transactions.push(...walletTransactions)
         transactions.push(...jettonsTransactions)
       }))
+
+  // Release the rate limiter's final timer before the plugin worker exits.
+  await tonscanApi.waitForIdle()
 
   return {
     accounts,

--- a/src/plugins/tonscan/mocks/index.ts
+++ b/src/plugins/tonscan/mocks/index.ts
@@ -83,6 +83,14 @@ export const jettonsTransfersResponseMock: RawJettonTransfer = {
       destination: '0:5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5',
       amount: 2000, // 0.002 USDT < 0.01, will be filtered out
       transaction_now: 1718424875
+    },
+    {
+      transaction_hash: 'aborted-transfer',
+      source: '0:2036F688708A1D807FE514AC92E5640B50A79A65761573004D02B3A6D61D6C58',
+      destination: '0:5225808CAB7270BB522D5092759C091CAE03EF23325963CAA97EE3C4681E1DC5',
+      amount: '5000000',
+      transaction_now: 1718424877,
+      transaction_aborted: true
     }
   ]
 }

--- a/src/plugins/tonscan/preferences.xml
+++ b/src/plugins/tonscan/preferences.xml
@@ -3,9 +3,9 @@
     <EditTextPreference
         key="wallets"
         obligatory="true"
-        title="Wallets address"
-        dialogTitle="Wallets address"
-        dialogMessage="Адреса ваших кошельков (user-friendly form, через запятую)"
+        title="TON wallet addresses"
+        dialogTitle="TON wallet addresses"
+        dialogMessage="Адреса обычных TON-кошельков или TON Space в user-friendly формате, через запятую. Кастодиальный Telegram Wallet без собственного адреса не поддерживается."
         positiveButtonText="ОК"
         negativeButtonText="Отмена"
         summary="|wallets|{@s}"


### PR DESCRIPTION
## Summary
- keep historical movement IDs compatible while disambiguating multiple Jetton transfers in one TON transaction
- ignore aborted Jetton transfers and handle current string-valued TON Center balances
- tolerate incomplete address-book responses and duplicate/empty wallet preferences
- release rate-limiter timers cleanly between plugin runs
- document safe public-address setup and the custodial Telegram Wallet limitation

## Privacy and safety
- public wallet addresses used by tests predate this change and come from the existing upstream TON Scan fixtures
- duplicate-ID suffixes are hashed; raw address data is not embedded in new movement IDs
- no private key, seed phrase, API key or personal user data is included

## Verification
- TypeScript: passed
- ts-standard: passed
- Jest: 3 suites, 9 tests passed
- live read-only TON Center check: native TON and official TON USDT accounts returned successfully