### PR TITLE
[alfabank-ua] sanitize authentication failures

### DIFF
--- a/src/plugins/alfabank-ua/__tests__/api.sanitization.test.js
+++ b/src/plugins/alfabank-ua/__tests__/api.sanitization.test.js
@@ -1,0 +1,53 @@
+import { getDeviceToken } from '../api'
+import { TemporaryUnavailableError } from '../../../errors'
+
+function makeResponse (body, headers = {}) {
+  const entries = Object.entries(headers)
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    url: 'https://superapp.sensebank.com.ua/mob/device/token',
+    headers: {
+      forEach: callback => entries.forEach(([key, value]) => callback(value, key)),
+      entries: () => entries[Symbol.iterator](),
+      get: key => headers[key.toLowerCase()] || null,
+      has: key => Object.prototype.hasOwnProperty.call(headers, key.toLowerCase()),
+      keys: () => entries.map(([key]) => key)[Symbol.iterator](),
+      values: () => entries.map(([, value]) => value)[Symbol.iterator]()
+    },
+    text: jest.fn().mockResolvedValue(body)
+  }
+}
+
+describe('Sense device token safety', () => {
+  let debugSpy
+  let warnSpy
+
+  beforeEach(() => {
+    global.ZenMoney = { device: { manufacturer: 'Google', model: 'Pixel' } }
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    debugSpy.mockRestore()
+    warnSpy.mockRestore()
+    delete global.fetch
+    delete global.ZenMoney
+  })
+
+  it('masks WAF cookies and HTML bodies before they reach logs', async () => {
+    const wafCookie = 'incap_ses_360_2935954=private-cookie-value'
+    const wafHtml = '<html><body>This page cannot be displayed</body></html>'
+    global.fetch = jest.fn().mockResolvedValue(makeResponse(wafHtml, { 'set-cookie': wafCookie }))
+
+    await expect(getDeviceToken({ device: { fingerPrint: 'private-fingerprint' } }))
+      .rejects.toBeInstanceOf(TemporaryUnavailableError)
+
+    const log = JSON.stringify([...debugSpy.mock.calls, ...warnSpy.mock.calls])
+    expect(log).not.toContain(wafCookie)
+    expect(log).not.toContain(wafHtml)
+    expect(log).not.toContain('private-fingerprint')
+  })
+})

--- a/src/plugins/alfabank-ua/__tests__/converters/transactions/skippedTransaction.test.js
+++ b/src/plugins/alfabank-ua/__tests__/converters/transactions/skippedTransaction.test.js
@@ -104,6 +104,42 @@ describe('convertTransaction', () => {
           ]
       },
       null
+    ],
+    [
+      {
+        allowedOperations: [],
+        id: 'credit-limit-change-1',
+        operationDate: '2026-05-09T12:00:00+03:00',
+        operationName: 'Збільшення кредитного ліміту',
+        description: 'Кредитний ліміт',
+        categoryPFM: false,
+        subjectAmount: 2700000,
+        subjectUnit: 'UAH',
+        filterData: [
+          { key: 'incomeOutlay', value: 'Доход' },
+          { key: 'operationSum', value: '2700000' },
+          { key: 'operationCurrency', value: 'Гривна' }
+        ]
+      },
+      null
+    ],
+    [
+      {
+        allowedOperations: [],
+        id: 'credit-limit-change-2',
+        operationDate: '2026-05-10T12:00:00+03:00',
+        operationName: 'Уменьшение кредитного лимита',
+        description: 'Кредитный лимит',
+        categoryPFM: false,
+        subjectAmount: -500000,
+        subjectUnit: 'UAH',
+        filterData: [
+          { key: 'incomeOutlay', value: 'Расход' },
+          { key: 'operationSum', value: '-500000' },
+          { key: 'operationCurrency', value: 'Гривна' }
+        ]
+      },
+      null
     ]
   ])('converts skipped transaction', (apiTransaction, transaction) => {
     expect(convertTransaction(apiTransaction, { id: '1337' })).toEqual(transaction)

--- a/src/plugins/alfabank-ua/api.js
+++ b/src/plugins/alfabank-ua/api.js
@@ -55,8 +55,17 @@ async function fetchApi (url, options, auth) {
     ...options?.sanitizeRequestLog
   }
   const sanitizeResponseLog = {
-    ...url === '/auth' && { body: { access_token: true, refresh_token: true } },
-    ...options?.sanitizeResponseLog
+    headers: {
+      'set-cookie': true,
+      'Set-Cookie': true,
+      ...options?.sanitizeResponseLog?.headers
+    },
+    body: url === '/device/token'
+      ? true
+      : {
+          ...url === '/auth' && { access_token: true, refresh_token: true },
+          ...options?.sanitizeResponseLog?.body
+        }
   }
   let result
   try {
@@ -135,11 +144,29 @@ async function askPinCode () {
 }
 
 function assertResponseCodeOk (response) {
-  console.assert(response.body.code === 'OK', 'unexpected response', response)
+  if (response?.body?.code !== 'OK') {
+    console.warn('Sense API returned an unexpected response', responseSummary(response))
+    throw new TemporaryUnavailableError('Sense Bank тимчасово відхилив запит. Спробуйте пізніше.')
+  }
 }
 
 function assertResponseAccessToken (response) {
-  console.assert(response.body.access_token, 'unexpected response', response)
+  if (typeof response?.body?.access_token !== 'string' || !response.body.access_token) {
+    console.warn('Sense authentication returned an unexpected response', responseSummary(response))
+    throw new TemporaryUnavailableError('Sense Bank тимчасово не підтвердив авторизацію. Спробуйте пізніше.')
+  }
+}
+
+function responseSummary (response) {
+  const body = response?.body
+  return {
+    status: Number.isInteger(response?.status) ? response.status : null,
+    contentType: response?.headers?.['content-type'] || response?.headers?.get?.('content-type') || null,
+    bodyType: body == null ? String(body) : typeof body,
+    responseCode: typeof body?.code === 'string' ? body.code : null,
+    responseError: typeof body?.error === 'string' ? body.error : null,
+    errorDescription: typeof body?.error_description === 'string' ? body.error_description : null
+  }
 }
 
 function getPhoneNumber (input) {
@@ -151,7 +178,7 @@ function getPhoneNumber (input) {
   return null
 }
 
-async function getDeviceToken (auth) {
+export async function getDeviceToken (auth) {
   const response = await fetchApi('/device/token', {
     method: 'POST',
     body: {

--- a/src/plugins/alfabank-ua/api.js
+++ b/src/plugins/alfabank-ua/api.js
@@ -146,14 +146,14 @@ async function askPinCode () {
 function assertResponseCodeOk (response) {
   if (response?.body?.code !== 'OK') {
     console.warn('Sense API returned an unexpected response', responseSummary(response))
-    throw new TemporaryUnavailableError('Sense Bank тимчасово відхилив запит. Спробуйте пізніше.')
+    throw new TemporaryUnavailableError()
   }
 }
 
 function assertResponseAccessToken (response) {
   if (typeof response?.body?.access_token !== 'string' || !response.body.access_token) {
     console.warn('Sense authentication returned an unexpected response', responseSummary(response))
-    throw new TemporaryUnavailableError('Sense Bank тимчасово не підтвердив авторизацію. Спробуйте пізніше.')
+    throw new TemporaryUnavailableError()
   }
 }
 

--- a/src/plugins/alfabank-ua/converters.js
+++ b/src/plugins/alfabank-ua/converters.js
@@ -266,7 +266,9 @@ function convertUsualTransaction (apiTransaction, account) {
   }
   if ([
     /Погашение процентов/i,
-    /Погашение тела кредита/i
+    /Погашение тела кредита/i,
+    /^(Збільшення|Зменшення) кредитного ліміту$/i,
+    /^(Увеличение|Уменьшение|Изменение) кредитного лимита$/i
   ].some(regexp => regexp.test(apiTransaction.operationName))) {
     return null
   }


### PR DESCRIPTION
## Summary

- mask device-token responses and Set-Cookie headers in network logs
- replace raw authentication assertions with safe retryable errors
- add a regression test proving WAF cookies, HTML bodies and fingerprints never reach logs

This intentionally does not change the existing User-Agent or claim to fix the previously intermittent Imperva response. The published plugin and the unchanged local plugin currently complete authentication successfully.

## Verification

- 17 alfabank-ua test suites passed
- 25 tests passed
- changed files pass ts-standard