### PR TITLE
[bcc.kz] plugin fix

### DIFF
--- a/src/plugins/bcc-kz/__tests__/api/login.test.js
+++ b/src/plugins/bcc-kz/__tests__/api/login.test.js
@@ -30,7 +30,8 @@ describe('bcc-kz login auth flow', () => {
   beforeEach(() => {
     global.ZenMoney = {
       device: { brand: 'Google', model: 'Pixel 7' },
-      readLine: jest.fn().mockResolvedValue('2009')
+      readLine: jest.fn().mockResolvedValue('2009'),
+      setCookie: jest.fn()
     }
     global.fetch = jest.fn()
   })
@@ -42,7 +43,8 @@ describe('bcc-kz login auth flow', () => {
       .mockResolvedValueOnce(makeNetworkResponse({
         access_token: 'bearer-token',
         provider_response: {
-          session_code: 'session-code'
+          session_code: 'session-code',
+          mbsessionid: 'mb-session-id'
         }
       }))
 
@@ -75,6 +77,12 @@ describe('bcc-kz login auth flow', () => {
     expect(connectBody.OS).toContain('OS:Android10')
     expect(auth.accessToken).toBe('bearer-token')
     expect(auth.sessionCode).toBe('session-code')
+    expect(global.ZenMoney.setCookie).toHaveBeenCalledWith(
+      'm.bcc.kz',
+      'mbsessionid',
+      'mb-session-id',
+      { path: '/', secure: true }
+    )
   })
 
   it('maps OTP timeout response to InvalidOtpCodeError', async () => {

--- a/src/plugins/bcc-kz/api.js
+++ b/src/plugins/bcc-kz/api.js
@@ -83,6 +83,15 @@ function extractSessionCode (responseBody, accessToken) {
   return null
 }
 
+function extractMbsessionId (responseBody, accessToken) {
+  const jwtPayload = decodeJwtPayload(accessToken)
+  return responseBody?.provider_response?.mbsessionid ||
+    responseBody?.mbsessionid ||
+    jwtPayload?.provider_response?.mbsessionid ||
+    jwtPayload?.mbsessionid ||
+    null
+}
+
 async function fetchAuthApi (options) {
   return await fetch(AUTH_URL, {
     method: 'POST',
@@ -98,6 +107,16 @@ async function fetchAuthApi (options) {
 
 export async function setLanguageCookie () {
   await ZenMoney.setCookie('m.bcc.kz', 'lang', 'ae')
+}
+
+export async function setMbsessionCookie (auth) {
+  if (!auth?.mbsessionId) {
+    return
+  }
+  await ZenMoney.setCookie('m.bcc.kz', 'mbsessionid', auth.mbsessionId, {
+    path: '/',
+    secure: true
+  })
 }
 
 function validatePreferences (rawPreferences) {
@@ -225,7 +244,8 @@ async function postAuth (auth) {
 
   return {
     accessToken: response.body.access_token,
-    sessionCode: extractSessionCode(response.body, response.body.access_token)
+    sessionCode: extractSessionCode(response.body, response.body.access_token),
+    mbsessionId: extractMbsessionId(response.body, response.body.access_token)
   }
 }
 
@@ -243,6 +263,11 @@ export async function login (rawPreferences, auth) {
   const connectResult = await postAuth(auth)
   auth.accessToken = connectResult.accessToken
   auth.sessionCode = connectResult.sessionCode
+  auth.mbsessionId = connectResult.mbsessionId
+  await setMbsessionCookie(auth)
+  if (auth.mbsessionId && typeof ZenMoney.saveCookies === 'function') {
+    await ZenMoney.saveCookies()
+  }
 }
 
 function createAuthenticatedMainUrl (auth, params) {

--- a/src/plugins/bcc-kz/index.js
+++ b/src/plugins/bcc-kz/index.js
@@ -1,4 +1,5 @@
-import { fetchAccounts, fetchTransactions, generateDevice, login, setLanguageCookie } from './api'
+import { fetchAccounts, fetchTransactions, generateDevice, login, setLanguageCookie, setMbsessionCookie } from './api'
+import { adjustTransactions } from '../../common/transactionGroupHandler'
 import { convertAccounts, convertTransaction } from './converters'
 
 export async function fetchAccountsWithCachedAuthFallback (preferences, auth, deps = { fetchAccounts, login }) {
@@ -25,6 +26,7 @@ export async function scrape ({ preferences, fromDate, toDate }) {
     }
   }
   await setLanguageCookie()
+  await setMbsessionCookie(auth)
 
   const apiAccounts = await fetchAccountsWithCachedAuthFallback(preferences, auth)
   ZenMoney.setData('auth', auth)
@@ -47,6 +49,9 @@ export async function scrape ({ preferences, fromDate, toDate }) {
   }))
   return {
     accounts: accountsData,
-    transactions
+    transactions: adjustTransactions({
+      transactions,
+      accounts: accountsData
+    })
   }
 }


### PR DESCRIPTION
Problem

BCC synchronization failed in two scenarios:

1. Internal transfers caused a scrape error:

   Assertion failed: props are unknown: groupKeys

2. After successful SMS authentication, the next request to ACCOUNTS_INFO failed with:

   ORA-01403: no data found
   MC_USER.PKG_MC_MODEL_SESSION, line 857

   On subsequent synchronization runs, the saved access token was reused, but the BCC session cookie was not restored.

Root cause

Two issues were found in the BCC plugin:

1. Internal transfer groupKeys were not processed

The BCC converter adds groupKeys to internal transfer transactions so outgoing and incoming movements can be matched.

However, bcc-kz returned transactions directly from scrape() without passing them through the common adjustTransactions() handler. As a result, the temporary groupKeys field reached the ZenMoney transaction adapter, which treats it as an unknown property.

2. BCC mbsessionid was not persisted or restored

After CONNECT, BCC returns mbsessionid inside provider_response in the JWT payload. The plugin extracted the access token and session_code, but ignored mbsessionid.

The next ACCOUNTS_INFO request therefore did not have a valid BCC session cookie. BCC returned:

    mbsessionid=Error
    ORA-01403: no data found
    reason: "Превышено время бездействия системы"

The issue also reproduced on subsequent runs because the cookie was not explicitly restored from the saved authentication state.

Changes

api.js:

    Added extractMbsessionId() to extract mbsessionid from the CONNECT response or JWT provider_response.
    Added setMbsessionCookie() to set the BCC mbsessionid cookie.
    postAuth() now returns mbsessionId together with the access token and session code.
    login() stores mbsessionId in plugin data.
    login() sets and persists the mbsessionid cookie after successful authentication.

index.js:

    Restores the saved mbsessionid cookie before using cached authentication.
    Passes transactions through adjustTransactions().
    Internal transfers are merged and the temporary groupKeys field is removed before returning the scrape result.

Tests

    20 BCC test suites passed.
    59 tests passed.

Manual verification

    Logged in with real BCC credentials.
    Completed SMS authentication.
    Successfully loaded accounts and transactions.
    Successfully repeated synchronization without another authentication failure.