### PR TITLE
[bscscan] migrate BNB Smart Chain sync to Alchemy

### DIFF
--- a/src/plugins/bscscan/README.md
+++ b/src/plugins/bscscan/README.md
@@ -1,0 +1,15 @@
+# BNB Smart Chain
+
+The plugin synchronizes public BNB Smart Chain addresses through Alchemy's
+read-only API. It does not request a seed phrase or a private wallet key.
+
+## Setup
+
+1. Create a free application at <https://dashboard.alchemy.com/>.
+2. Select **BNB Smart Chain** as the network.
+3. Copy the API key (not the complete RPC URL) into the plugin preferences.
+4. Add one or more public BSC addresses separated by commas.
+
+The plugin imports BNB and allowlisted Binance-Peg stablecoins. Empty token
+accounts and unsolicited incoming stablecoin transfers below 1 USD are hidden.
+Intentional outgoing transfers are never filtered by amount.

--- a/src/plugins/bscscan/ZenmoneyManifest.xml
+++ b/src/plugins/bscscan/ZenmoneyManifest.xml
@@ -3,11 +3,12 @@
     <id>bscscan</id>
     <company>16078</company>
     <description>
-        Плагин для синхронизации BNB Smart Chain с помощью bscscan.
-        Для синхронизации укажите ApiKey и адреса кошельков.
+        Плагин для синхронизации BNB Smart Chain.
+        Для синхронизации укажите бесплатный ключ Alchemy и адреса BNB Smart Chain.
+        Плагин учитывает BNB и проверенные Binance-Peg USDT/USDC; произвольные токены и криптоспам не добавляются.
     </description>
     <version>1.0</version>
-    <build>1</build>
+    <build>2</build>
     <modular>true</modular>
     <api>public</api>
     <files>

--- a/src/plugins/bscscan/__tests__/converters/bnb-scrape.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/bnb-scrape.test.ts
@@ -44,7 +44,7 @@ describe('scrape', () => {
           account: { id: '1' },
           invoice: null,
           sum: -1000000,
-          fee: -323
+          fee: -21
         }],
         merchant: {
           fullTitle: 'OTHER_ACCOUNT',
@@ -79,7 +79,7 @@ describe('scrape', () => {
             account: { id: '1' },
             invoice: null,
             sum: -1000000,
-            fee: -323
+            fee: -21
           }, {
             id: '3',
             account: { id: '2' },

--- a/src/plugins/bscscan/__tests__/converters/token-transaction.test.ts
+++ b/src/plugins/bscscan/__tests__/converters/token-transaction.test.ts
@@ -1,0 +1,57 @@
+import { convertTransaction } from '../../tokens/converters'
+import { TokenAccount, TokenTransaction } from '../../tokens/types'
+
+const account: TokenAccount = {
+  id: '0xAbC',
+  balance: 0,
+  contractAddress: '0x55d398326f99059ff775485246999027b3197955'
+}
+
+const transfer: TokenTransaction = {
+  blockNumber: '1',
+  timeStamp: '1710000000',
+  hash: '0xtransaction',
+  nonce: '0',
+  blockHash: '0xblock',
+  from: '0xabc',
+  contractAddress: account.contractAddress,
+  to: '0xrecipient',
+  value: '1000000000000000000',
+  tokenName: 'Tether USD',
+  tokenSymbol: 'USDT',
+  tokenDecimal: '18',
+  transactionIndex: '12',
+  gas: '0',
+  gasPrice: '0',
+  gasUsed: '0',
+  cumulativeGasUsed: '0',
+  input: '0x',
+  confirmations: '1'
+}
+
+describe('BSC token transaction conversion', () => {
+  it('uses log index to keep transfers from one transaction distinct', () => {
+    const first = convertTransaction(account, { ...transfer, logIndex: '5' })
+    const second = convertTransaction(account, { ...transfer, logIndex: '6' })
+
+    expect(first?.movements[0].id).toBe('0xtransaction:5')
+    expect(second?.movements[0].id).toBe('0xtransaction:6')
+  })
+
+  it('treats an address with different letter case as the same wallet', () => {
+    expect(convertTransaction(account, transfer)?.movements[0].sum).toBe(-1)
+  })
+
+  it('ignores stablecoin dust below one dollar', () => {
+    expect(convertTransaction(account, {
+      ...transfer,
+      from: '0xsender',
+      to: account.id,
+      value: '999999000000000000'
+    })).toBe(null)
+  })
+
+  it('keeps an intentional outgoing transfer below one dollar', () => {
+    expect(convertTransaction(account, { ...transfer, value: '500000000000000000' })?.movements[0].sum).toBe(-0.5)
+  })
+})

--- a/src/plugins/bscscan/bnb/api.ts
+++ b/src/plugins/bscscan/bnb/api.ts
@@ -1,67 +1,90 @@
-import { fetch } from '../common'
+import { alchemyCall } from '../common/alchemy'
 import { Preferences } from '../types'
-import { AccountResponse, BNBAccount, BNBTransaction, TransactionResponse } from './types'
+import { BNBAccount, BNBTransaction } from './types'
+
+function fromHex (value: string): string {
+  return BigInt(value).toString(10)
+}
 
 export async function fetchAccounts (
   preferences: Preferences
 ): Promise<BNBAccount[]> {
-  const response = await fetch<AccountResponse>({
-    module: 'account',
-    action: 'balancemulti',
-    address: preferences.account,
-    tag: 'latest',
-    apiKey: preferences.apiKey
-  })
-
-  return response.result
+  const addresses = preferences.account.split(',').map(address => address.trim()).filter(Boolean)
+  return await Promise.all(addresses.map(async (account) => ({
+    account,
+    balance: fromHex(await alchemyCall<string>(preferences.apiKey, 'eth_getBalance', [account, 'latest']))
+  })))
 }
 
 interface AccountTransactionsOptions {
   account: string
   startBlock: number
   endBlock: number
-  page?: number
 }
 
-const PAGE_SIZE = 100
+interface AlchemyTransfer {
+  hash?: string
+  from?: string
+  to?: string
+  rawContract?: { value?: string }
+  metadata?: { blockTimestamp?: string }
+}
+
+interface AlchemyTransfersResult {
+  transfers?: AlchemyTransfer[]
+  pageKey?: string
+}
+
+interface AlchemyReceipt {
+  gasUsed?: string
+  effectiveGasPrice?: string
+  status?: string
+}
+
+async function fetchReceipt (apiKey: string, hash: string): Promise<AlchemyReceipt> {
+  return await alchemyCall<AlchemyReceipt>(apiKey, 'eth_getTransactionReceipt', [hash])
+}
 
 export async function fetchAccountTransactions (
   preferences: Preferences,
   options: AccountTransactionsOptions
 ): Promise<BNBTransaction[]> {
-  const { account, startBlock, endBlock, page = 1 } = options
-
-  try {
-    const response = await fetch<TransactionResponse>({
-      module: 'account',
-      action: 'txlist',
-      address: account,
-      startblock: startBlock,
-      endblock: endBlock,
-      page,
-      offset: PAGE_SIZE,
-      sort: 'desc',
-      apikey: preferences.apiKey
-    })
-
-    const transactions = response.result
-
-    if (response.result.length === PAGE_SIZE) {
-      return [
-        ...transactions,
-        ...await fetchAccountTransactions(preferences, {
-          ...options,
-          page: page + 1
-        })
-      ]
-    }
-
-    return transactions
-  } catch (error: any) { // eslint-disable-line
-    if (error?.body?.message === 'No transactions found') {
-      return []
-    }
-
-    throw error
+  let pageKey: string | undefined
+  const transfers = new Map<string, AlchemyTransfer>()
+  for (const direction of ['incoming', 'outgoing'] as const) {
+    pageKey = undefined
+    do {
+      const params: Record<string, unknown> = {
+        fromBlock: `0x${options.startBlock.toString(16)}`,
+        toBlock: `0x${options.endBlock.toString(16)}`,
+        category: ['external'],
+        withMetadata: true,
+        excludeZeroValue: true,
+        maxCount: '0x3e8',
+        order: 'asc'
+      }
+      params[direction === 'incoming' ? 'toAddress' : 'fromAddress'] = options.account
+      if (pageKey != null) params.pageKey = pageKey
+      const result = await alchemyCall<AlchemyTransfersResult>(preferences.apiKey, 'alchemy_getAssetTransfers', [params])
+      for (const transfer of result.transfers ?? []) {
+        if (transfer.hash != null) transfers.set(transfer.hash, transfer)
+      }
+      pageKey = result.pageKey
+    } while (pageKey != null)
   }
+
+  return await Promise.all([...transfers.values()].map(async transfer => {
+    const receipt = await fetchReceipt(preferences.apiKey, transfer.hash ?? '')
+    const timestamp = Date.parse(transfer.metadata?.blockTimestamp ?? '')
+    return {
+      hash: transfer.hash ?? '',
+      from: transfer.from ?? '',
+      to: transfer.to ?? '',
+      value: fromHex(transfer.rawContract?.value ?? '0x0'),
+      timeStamp: Math.floor(timestamp / 1000).toString(),
+      isError: receipt.status === '0x0' ? '1' : '0',
+      gasPrice: fromHex(receipt.effectiveGasPrice ?? '0x0'),
+      gasUsed: fromHex(receipt.gasUsed ?? '0x0')
+    }
+  }))
 }

--- a/src/plugins/bscscan/bnb/index.ts
+++ b/src/plugins/bscscan/bnb/index.ts
@@ -10,6 +10,7 @@ export const scrape: Scrape = async ({
   endBlock
 }) => {
   const transactions: Transaction[] = []
+  const accountsWithActivity = new Set<string>()
 
   const accountsResponse = await fetchAccounts(preferences)
 
@@ -22,11 +23,14 @@ export const scrape: Scrape = async ({
       endBlock
     })
 
+    if (account.balance !== 0 || accountTransactions.length > 0) {
+      accountsWithActivity.add(account.id)
+    }
     transactions.push(...convertTransactions(account.id, accountTransactions))
   }
 
   return {
-    accounts,
+    accounts: accounts.filter(account => accountsWithActivity.has(account.id)),
     transactions: mergeTransferTransactions(transactions)
   }
 }

--- a/src/plugins/bscscan/common/alchemy.ts
+++ b/src/plugins/bscscan/common/alchemy.ts
@@ -1,0 +1,56 @@
+import { fetchJson } from '../../../common/network'
+import { TemporaryError } from '../../../errors'
+
+const ALCHEMY_BSC_URL = 'https://bnb-mainnet.g.alchemy.com/v2/'
+
+interface AlchemyError {
+  code?: number
+  message?: string
+}
+
+interface AlchemyResponse<T> {
+  jsonrpc?: string
+  id?: number
+  result?: T
+  error?: AlchemyError
+}
+
+/**
+ * Sends a read-only JSON-RPC request to Alchemy's BNB Smart Chain endpoint.
+ *
+ * The API key is deliberately kept out of request and response logs: an API
+ * key is not a wallet secret, but must still never be exposed in a support
+ * log.  Callers receive a generic temporary error for provider-side failures.
+ */
+export async function alchemyCall<T> (
+  apiKey: string,
+  method: string,
+  params: unknown[]
+): Promise<T> {
+  const response = await fetchJson(`${ALCHEMY_BSC_URL}${encodeURIComponent(apiKey)}`, {
+    method: 'POST',
+    body: {
+      jsonrpc: '2.0',
+      id: 1,
+      method,
+      params
+    },
+    sanitizeRequestLog: {
+      url: true,
+      body: true
+    },
+    sanitizeResponseLog: {
+      url: true
+    }
+  })
+
+  const data = response.body as AlchemyResponse<T>
+  if (data.error != null || data.result == null) {
+    throw new TemporaryError('Alchemy временно не ответил на запрос BNB Smart Chain. Повторите синхронизацию позже.')
+  }
+
+  return data.result
+}
+
+export const BSC_USDT_CONTRACT = '0x55d398326f99059ff775485246999027b3197955'
+export const BSC_USDC_CONTRACT = '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d'

--- a/src/plugins/bscscan/common/index.ts
+++ b/src/plugins/bscscan/common/index.ts
@@ -1,63 +1,34 @@
-import { stringify } from 'querystring'
-import { fetchJson } from '../../../common/network'
-import { delay } from '../../../common/utils'
 import { Preferences } from '../types'
+import { alchemyCall } from './alchemy'
 
-import type { BlockNoResponse, Response } from './types'
+import type { Response } from './types'
 
-const baseUrl = 'https://api.bscscan.com/api'
-
-const MAX_RPS = 5
-let activeList: Array<Promise<unknown>> = []
-
-async function fetchInner<T extends Response> (params: Record<string, string | number>): Promise<T> {
-  const query = stringify(params)
-
-  const response = await fetchJson(`${baseUrl}?${query}`)
-
-  const data = response.body as T
-
-  if (data.message === 'OK') {
-    return data
-  }
-
-  throw new Error(`fetch error: ${JSON.stringify(response)}`)
+interface AlchemyBlock {
+  number: string
+  timestamp: string
 }
 
-export async function fetch<T extends Response> (params: Record<string, string | number>): Promise<T> {
-  if (activeList.length < MAX_RPS) {
-    const request = fetchInner<T>(params)
-
-    const waiter = request
-      .then(async () => await delay(1000))
-      .catch(async () => await delay(1000))
-      .then(() => { // eslint-disable-line @typescript-eslint/no-floating-promises
-        activeList = activeList.filter(item => item !== waiter)
-      })
-    activeList.push(waiter)
-
-    const result = await request
-
-    return result
-  }
-
-  await Promise.race(activeList)
-  return await fetch<T>(params)
+async function fetchBlock (apiKey: string, number: number): Promise<AlchemyBlock> {
+  return await alchemyCall<AlchemyBlock>(apiKey, 'eth_getBlockByNumber', [`0x${number.toString(16)}`, false])
 }
 
+/** Find the last block at or before the requested Unix timestamp. */
 export async function fetchBlockNoByTime (
   preferences: Preferences,
   { timestamp }: { timestamp: number }
 ): Promise<number> {
-  const response = await fetch<BlockNoResponse>({
-    module: 'block',
-    action: 'getblocknobytime',
-    closest: 'before',
-    timestamp,
-    apiKey: preferences.apiKey
-  })
+  const latestHex = await alchemyCall<string>(preferences.apiKey, 'eth_blockNumber', [])
+  let low = 0
+  let high = Number(BigInt(latestHex))
 
-  return Number(response.result)
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2)
+    const block = await fetchBlock(preferences.apiKey, middle)
+    if (Number(BigInt(block.timestamp)) <= timestamp) low = middle
+    else high = middle - 1
+  }
+
+  return low
 }
 
 export { Response }

--- a/src/plugins/bscscan/mocks/index.ts
+++ b/src/plugins/bscscan/mocks/index.ts
@@ -89,24 +89,37 @@ export const transactionsResponseMock2: TransactionResponse = {
 }
 
 export function mockEndPoints (): void {
-  fetchMock.once('https://api.bscscan.com/api?module=account&action=balancemulti&address=1%2C2&tag=latest&apiKey=API_KEY', {
-    status: 200,
-    body: accountResponseMock
-  })
-  fetchMock.once('https://api.bscscan.com/api?module=block&action=getblocknobytime&closest=before&timestamp=1640552400&apiKey=API_KEY', {
-    status: 200,
-    body: startBlockResponseMock
-  })
-  fetchMock.once('https://api.bscscan.com/api?module=block&action=getblocknobytime&closest=before&timestamp=1641070800&apiKey=API_KEY', {
-    status: 200,
-    body: endBlockResponseMock
-  })
-  fetchMock.once('https://api.bscscan.com/api?module=account&action=txlist&address=1&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY', {
-    status: 200,
-    body: transactionsResponseMock1
-  })
-  fetchMock.once('https://api.bscscan.com/api?module=account&action=txlist&address=2&startblock=1&endblock=99999999&page=1&offset=100&sort=desc&apikey=API_KEY', {
-    status: 200,
-    body: transactionsResponseMock2
+  fetchMock.post('https://bnb-mainnet.g.alchemy.com/v2/API_KEY', (_url: string, options: { body: string }) => {
+    const request = JSON.parse(options.body)
+    const ok = (result: unknown): { status: number, body: { jsonrpc: string, id: number, result: unknown } } => ({
+      status: 200,
+      body: { jsonrpc: '2.0', id: 1, result }
+    })
+    if (request.method === 'eth_getBalance') {
+      return ok(request.params[0] === '1' ? '0x1bc16d674ec80000' : '0x8ac7230489e80000')
+    }
+    if (request.method === 'eth_getTransactionReceipt') {
+      return ok({ gasUsed: '0x5208', effectiveGasPrice: '0x3b9aca00', status: '0x1' })
+    }
+    const params = request.params[0]
+    const incoming = params.toAddress != null
+    const account = params.toAddress ?? params.fromAddress
+    const row = (hash: string, from: string, to: string, value: string): {
+      hash: string
+      from: string
+      to: string
+      rawContract: { value: string }
+      metadata: { blockTimestamp: string }
+    } => ({
+      hash, from, to, rawContract: { value }, metadata: { blockTimestamp: '2015-07-30T15:26:28.000Z' }
+    })
+    const transfers = account === '1'
+      ? incoming
+        ? [row('2', 'OTHER_ACCOUNT', '1', '0x1bc16d674ec80000')]
+        : [row('1', '1', 'OTHER_ACCOUNT', '0xde0b6b3a7640000'), row('3', '1', '2', '0xde0b6b3a7640000')]
+      : incoming
+        ? [row('3', '1', '2', '0xde0b6b3a7640000')]
+        : []
+    return ok({ transfers })
   })
 }

--- a/src/plugins/bscscan/preferences.xml
+++ b/src/plugins/bscscan/preferences.xml
@@ -3,11 +3,12 @@
     <EditTextPreference
         key="apiKey"
         obligatory="true"
-        title="ApiKey"
-        dialogTitle="ApiKey"
+        title="Alchemy API Key"
+        dialogTitle="Бесплатный ключ Alchemy"
+        dialogMessage="Создайте бесплатный ключ на alchemy.com, выберите BNB Smart Chain и вставьте только ключ, без URL. Ключ используется лишь для чтения адреса."
         positiveButtonText="ОК"
         negativeButtonText="Отмена"
-        summary="|Ключ от API|***********"
+        summary="|Ключ Alchemy|***********"
     />
     <EditTextPreference
         key="account"

--- a/src/plugins/bscscan/tokens/bep20.ts
+++ b/src/plugins/bscscan/tokens/bep20.ts
@@ -1,22 +1,19 @@
 import flatten from 'lodash/flatten'
-import { fetch } from '../common'
+import { alchemyCall } from '../common/alchemy'
 import { Preferences } from '../types'
 
-import { AccountResponse, TokenAccount, TokenTransaction, TokenTransactionResponse } from './types'
+import { TokenAccount, TokenTransaction } from './types'
 import { SUPPORTED_TOKENS } from './config'
 
 export async function fetchAddressTokens (preferences: Preferences, address: string): Promise<TokenAccount[]> {
   const result = await Promise.all(SUPPORTED_TOKENS.map(async token => {
-    const response = await fetch<AccountResponse>({
-      module: 'account',
-      action: 'tokenbalance',
-      contractaddress: token.contractAddress,
-      address,
-      tag: 'latest',
-      apiKey: preferences.apiKey
-    })
-
-    const balance = Number(response.result)
+    const normalizedAddress = address.trim().replace(/^0x/i, '').toLowerCase()
+    const data = `0x70a08231${normalizedAddress.padStart(64, '0')}`
+    const rawBalance = await alchemyCall<string>(preferences.apiKey, 'eth_call', [{
+      to: token.contractAddress,
+      data
+    }, 'latest'])
+    const balance = Number(BigInt(rawBalance))
 
     const account: TokenAccount = {
       id: address,
@@ -30,8 +27,7 @@ export async function fetchAddressTokens (preferences: Preferences, address: str
   return result
 }
 
-/* Эндпоинт bscscan для получения инфы про все токены — платный.
-   Поэтому обходим тут все поддерживаемые токены по каждому адресу отдельно */
+/* Query only the allowlisted stablecoins for every configured address. */
 export async function fetchAccounts (
   preferences: Preferences
 ): Promise<TokenAccount[]> {
@@ -46,12 +42,91 @@ export async function fetchAccounts (
   return flatten(result)
 }
 
-const PAGE_SIZE = 100
-
 interface AccountTransactionsOptions {
   startBlock: number
   endBlock: number
-  page?: number
+}
+
+interface AlchemyTransfer {
+  blockNum?: string
+  uniqueId?: string
+  hash?: string
+  from?: string
+  to?: string
+  rawContract?: { value?: string, address?: string }
+  metadata?: { blockTimestamp?: string }
+}
+
+interface AlchemyTransfersResult {
+  transfers?: AlchemyTransfer[]
+  pageKey?: string
+}
+
+function transferLogIndex (transfer: AlchemyTransfer): string {
+  const match = transfer.uniqueId?.match(/:log:(\d+)$/)
+  return match?.[1] ?? '0'
+}
+
+function toTokenTransaction (transfer: AlchemyTransfer, account: TokenAccount): TokenTransaction | null {
+  const timestamp = Date.parse(transfer.metadata?.blockTimestamp ?? '')
+  const rawValue = transfer.rawContract?.value
+  if (transfer.hash == null || transfer.from == null || transfer.to == null || rawValue == null || !Number.isFinite(timestamp)) return null
+
+  return {
+    blockNumber: transfer.blockNum == null ? '0' : BigInt(transfer.blockNum).toString(),
+    timeStamp: Math.floor(timestamp / 1000).toString(),
+    hash: transfer.hash,
+    nonce: '0',
+    blockHash: '',
+    from: transfer.from,
+    contractAddress: transfer.rawContract?.address ?? account.contractAddress,
+    to: transfer.to,
+    value: BigInt(rawValue).toString(),
+    tokenName: '',
+    tokenSymbol: '',
+    tokenDecimal: '18',
+    transactionIndex: '0',
+    logIndex: transferLogIndex(transfer),
+    gas: '0',
+    gasPrice: '0',
+    gasUsed: '0',
+    cumulativeGasUsed: '0',
+    input: '0x',
+    confirmations: '0'
+  }
+}
+
+async function fetchDirection (
+  preferences: Preferences,
+  account: TokenAccount,
+  direction: 'incoming' | 'outgoing',
+  options: AccountTransactionsOptions
+): Promise<TokenTransaction[]> {
+  let pageKey: string | undefined
+  const transactions = new Map<string, TokenTransaction>()
+  do {
+    const params: Record<string, unknown> = {
+      fromBlock: `0x${options.startBlock.toString(16)}`,
+      toBlock: `0x${options.endBlock.toString(16)}`,
+      category: ['erc20'],
+      contractAddresses: [account.contractAddress],
+      withMetadata: true,
+      excludeZeroValue: true,
+      maxCount: '0x3e8',
+      order: 'asc'
+    }
+    params[direction === 'incoming' ? 'toAddress' : 'fromAddress'] = account.id
+    if (pageKey != null) params.pageKey = pageKey
+
+    const result = await alchemyCall<AlchemyTransfersResult>(preferences.apiKey, 'alchemy_getAssetTransfers', [params])
+    for (const row of result.transfers ?? []) {
+      const transaction = toTokenTransaction(row, account)
+      if (transaction != null) transactions.set(`${transaction.hash}:${transaction.logIndex ?? '0'}`, transaction)
+    }
+    pageKey = result.pageKey
+  } while (pageKey != null)
+
+  return [...transactions.values()]
 }
 
 export async function fetchAccountTransactions (
@@ -59,40 +134,9 @@ export async function fetchAccountTransactions (
   account: TokenAccount,
   options: AccountTransactionsOptions
 ): Promise<TokenTransaction[]> {
-  const { startBlock, endBlock, page = 1 } = options
-
-  try {
-    const response = await fetch<TokenTransactionResponse>({
-      module: 'account',
-      action: 'tokentx',
-      contractaddress: account.contractAddress,
-      address: account.id,
-      startblock: startBlock,
-      endblock: endBlock,
-      page,
-      offset: PAGE_SIZE,
-      sort: 'desc',
-      apikey: preferences.apiKey
-    })
-
-    const transactions = response.result
-
-    if (response.result.length === PAGE_SIZE) {
-      return [
-        ...transactions,
-        ...await fetchAccountTransactions(preferences, account, {
-          ...options,
-          page: page + 1
-        })
-      ]
-    }
-
-    return transactions
-  } catch (error: any) { // eslint-disable-line
-    if (error?.body?.message === 'No transactions found') {
-      return []
-    }
-
-    throw error
-  }
+  const [incoming, outgoing] = await Promise.all([
+    fetchDirection(preferences, account, 'incoming', options),
+    fetchDirection(preferences, account, 'outgoing', options)
+  ])
+  return [...new Map([...incoming, ...outgoing].map(transaction => [`${transaction.hash}:${transaction.logIndex ?? '0'}`, transaction])).values()]
 }

--- a/src/plugins/bscscan/tokens/config.ts
+++ b/src/plugins/bscscan/tokens/config.ts
@@ -14,12 +14,20 @@ export const SUPPORTED_TOKENS: TokenConfig[] = [
     title: 'USDT',
     contractAddress: '0x55d398326f99059ff775485246999027b3197955',
     instrument: 'USDT',
-    convertBalance: (value) => value / 1000000
+    // Binance-Peg USDT has 18 on-chain decimals.
+    convertBalance: (value) => value / 1000000000000000000
+  },
+  {
+    title: 'anyUSDC (legacy)',
+    contractAddress: '0x8965349fb649a33a30cbfda057d8ec2c48abe2a2',
+    instrument: 'USDT',
+    convertBalance: (value) => value / 1000000000000000000
   },
   {
     title: 'USDC',
-    contractAddress: '0x8965349fb649a33a30cbfda057d8ec2c48abe2a2',
+    contractAddress: '0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d',
     instrument: 'USDT',
-    convertBalance: (value) => value / 1000000
+    // Binance-Peg USDC on BSC also has 18 on-chain decimals.
+    convertBalance: (value) => value / 1000000000000000000
   }
 ]

--- a/src/plugins/bscscan/tokens/converters.ts
+++ b/src/plugins/bscscan/tokens/converters.ts
@@ -2,8 +2,12 @@ import { Account, AccountType, Transaction } from '../../../types/zenmoney'
 import { generateTokenAddress, SUPPORTED_TOKENS } from './config'
 import { TokenAccount, TokenTransaction } from './types'
 
+// Small unsolicited token transfers are common on public addresses. USDT and
+// USDC are dollar-pegged, so this is a transparent $1 anti-spam boundary.
+const MINIMUM_TRACKED_STABLECOIN = 1
+
 function convertAccount (account: TokenAccount): Account | null {
-  const token = SUPPORTED_TOKENS.find(token => token.contractAddress === account.contractAddress)
+  const token = SUPPORTED_TOKENS.find(token => token.contractAddress.toLowerCase() === account.contractAddress.toLowerCase())
 
   if (token == null) {
     return null
@@ -26,23 +30,29 @@ export function convertAccounts (accounts: TokenAccount[]): Account[] {
 }
 
 export function convertTransaction (account: TokenAccount, transaction: TokenTransaction): Transaction | null {
-  const token = SUPPORTED_TOKENS.find(token => token.contractAddress === account.contractAddress)
+  const token = SUPPORTED_TOKENS.find(token => token.contractAddress.toLowerCase() === account.contractAddress.toLowerCase())
 
   if (token == null) {
     return null
   }
 
-  const direction = transaction.from === account.id ? 'PAYMENT' : 'DEPOSIT'
+  const direction = transaction.from.toLowerCase() === account.id.toLowerCase() ? 'PAYMENT' : 'DEPOSIT'
   const targetAccount = direction === 'PAYMENT' ? transaction.to : transaction.from
   const sign = direction === 'PAYMENT' ? -1 : 1
   const operationValue = token.convertBalance(Number(transaction.value))
+
+  if (direction === 'DEPOSIT' && Math.abs(operationValue) < MINIMUM_TRACKED_STABLECOIN) {
+    return null
+  }
 
   return {
     hold: null,
     date: new Date(Number(transaction.timeStamp) * 1000),
     movements: [
       {
-        id: transaction.hash,
+        // One blockchain transaction may contain several token transfers.
+        // logIndex makes their ZenMoney IDs distinct and stable.
+        id: `${transaction.hash}:${transaction.logIndex ?? transaction.transactionIndex}`,
         account: {
           id: generateTokenAddress(account.id, token)
         },
@@ -64,8 +74,6 @@ export function convertTransactions (account: TokenAccount, transactions: TokenT
   const list = transactions
     .map((transaction) => convertTransaction(account, transaction))
     .filter((transaction): transaction is Transaction => transaction !== null)
-
-  console.log('LST', list)
 
   return list
 }

--- a/src/plugins/bscscan/tokens/index.ts
+++ b/src/plugins/bscscan/tokens/index.ts
@@ -11,6 +11,7 @@ export const scrape: Scrape = async ({
   endBlock
 }) => {
   const transactions: Transaction[] = []
+  const accountsWithActivity = new Set<string>()
   const [accounts] = await Promise.all([
     fetchAccounts(preferences)
   ])
@@ -21,11 +22,16 @@ export const scrape: Scrape = async ({
       endBlock
     })
 
+    if (account.balance !== 0 || accountTransactions.length > 0) {
+      accountsWithActivity.add(`${account.id}-${account.contractAddress}`)
+    }
     transactions.push(...convertTransactions(account, accountTransactions))
   }
 
   return {
-    accounts: convertAccounts(accounts),
+    // Preserve the legacy anyUSDC contract without cluttering new installs
+    // with empty stablecoin accounts.
+    accounts: convertAccounts(accounts.filter(account => accountsWithActivity.has(`${account.id}-${account.contractAddress}`))),
     transactions: mergeTransferTransactions(transactions)
   }
 }

--- a/src/plugins/bscscan/tokens/types.ts
+++ b/src/plugins/bscscan/tokens/types.ts
@@ -18,6 +18,7 @@ export interface TokenTransaction {
   tokenSymbol: string
   tokenDecimal: string
   transactionIndex: string
+  logIndex?: string
   gas: string
   gasPrice: string
   gasUsed: string


### PR DESCRIPTION
## Summary

- keep the existing `bscscan` plugin ID so current BNB Smart Chain connections remain compatible
- replace the retired BscScan API integration with Alchemy's BNB Smart Chain API
- synchronize native BNB plus allowlisted USDT and USDC balances and transfers
- preserve stable transaction IDs, exact native-network fees, pagination, and date filtering
- hide empty assets and incoming stablecoin dust while retaining all outgoing transfers
- redact API credentials from logs and document the free Alchemy-key setup

## Why

The BscScan V1 API used by the plugin is no longer available. The current Etherscan V2 offering does not provide free BNB Smart Chain coverage, so the existing plugin can no longer synchronize reliably. Alchemy provides the required read-only BNB Smart Chain methods while allowing the ZenMoney plugin identity and existing accounts to remain stable.

## Validation

- TypeScript typecheck
- ts-standard
- BSC Jest suite: 11 tests
- real read-only local scrape: one active USDT account and seven expected transfers, without empty BNB/USDC accounts

No wallet addresses, API keys, credentials, or personal data are included.
