### PR TITLE
[belarusbank] add mobile banking plugin

### DIFF
--- a/src/common/pdfUtils.js
+++ b/src/common/pdfUtils.js
@@ -1,9 +1,7 @@
-import pdfjs from 'pdfjs-dist'
+import 'pdfjs-dist/build/pdf.worker.entry'
 import pdf from 'pdf-extraction/lib/pdf-extraction'
 import { fetchJson } from './network'
 import { isDebug } from './utils'
-
-pdfjs.GlobalWorkerOptions.workerSrc = 'unexisting'
 
 const PDF_PARSER_URL = ''
 

--- a/src/plugins/belarusbank/ZenmoneyManifest.xml
+++ b/src/plugins/belarusbank/ZenmoneyManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>belarusbank</id>
+    <company>15381</company>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+    <codeRequired>false</codeRequired>
+</provider>

--- a/src/plugins/belarusbank/__tests__/api.test.ts
+++ b/src/plugins/belarusbank/__tests__/api.test.ts
@@ -1,0 +1,970 @@
+import { convertAccount, convertCard } from '../converters'
+import { UserInteractionError } from '../../../errors'
+import type { AuthState } from '../models'
+
+// Test records are synthetic and must not be copied from real bank data.
+const mockFetchApi = jest.fn()
+const mockParsePdf = jest.fn()
+
+jest.mock('../fetchApi', () => ({
+  fetchApi: mockFetchApi
+}))
+jest.mock('../../../common/pdfUtils', () => ({
+  parsePdf: mockParsePdf
+}))
+
+const { authenticate, getCardTransactions, getGeneralPaymentHistory, getPaymentHistory, getProducts, getStatementTransactions, isCardLinkedToAccount } = jest.requireActual<typeof import('../api')>('../api')
+const auth: AuthState = {
+  login: 'test-login',
+  sessionToken: 'session-token',
+  refreshToken: 'refresh-token',
+  tokenType: 'Bearer'
+}
+
+describe('Belarusbank API', () => {
+  beforeEach(() => {
+    mockFetchApi.mockReset()
+    mockParsePdf.mockReset()
+  })
+
+  it('does not start an interactive SMS login during a background sync', async () => {
+    const pluginData: Record<string, unknown> = {}
+    Object.defineProperty(globalThis, 'ZenMoney', {
+      configurable: true,
+      value: {
+        getData: jest.fn((key: string, defaultValue: unknown) => pluginData[key] ?? defaultValue),
+        setData: jest.fn((key: string, value: unknown) => { pluginData[key] = value }),
+        saveData: jest.fn()
+      } as unknown as typeof ZenMoney
+    })
+    mockFetchApi.mockResolvedValue({ status: 401, body: {} })
+
+    await expect(authenticate({ login: 'test-login', password: 'test-password' }, true)).rejects.toBeInstanceOf(UserInteractionError)
+    expect(mockFetchApi).toHaveBeenCalledTimes(2)
+    expect(mockFetchApi).toHaveBeenNthCalledWith(1, 'users/auth/login', expect.objectContaining({ retry: false }))
+    expect(mockFetchApi).toHaveBeenNthCalledWith(2, 'users/auth/login/preparation', expect.objectContaining({
+      query: { loginMode: 'PIN' },
+      retry: false
+    }))
+  })
+
+  it('tries direct cold-start login before SMS when plugin data is empty', async () => {
+    const pluginData: Record<string, unknown> = {}
+    Object.defineProperty(globalThis, 'ZenMoney', {
+      configurable: true,
+      value: {
+        getData: jest.fn((key: string, defaultValue: unknown) => pluginData[key] ?? defaultValue),
+        setData: jest.fn((key: string, value: unknown) => { pluginData[key] = value }),
+        saveData: jest.fn()
+      } as unknown as typeof ZenMoney
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        sessionToken: 'new-session-token',
+        refreshToken: 'new-refresh-token',
+        tokenType: 'Bearer'
+      }
+    })
+
+    await expect(authenticate({ login: 'test-login', password: 'test-password' }, true)).resolves.toMatchObject({
+      sessionToken: 'new-session-token',
+      refreshToken: 'new-refresh-token'
+    })
+    expect(mockFetchApi).toHaveBeenCalledTimes(1)
+    expect(mockFetchApi).toHaveBeenCalledWith('users/auth/login', expect.objectContaining({
+      method: 'POST',
+      body: expect.objectContaining({
+        login: 'test-login',
+        password: 'test-password'
+      }),
+      retry: false
+    }))
+  })
+
+  it('re-authenticates with stored credentials without SMS after refresh expires', async () => {
+    const setData = jest.fn()
+    const saveData = jest.fn()
+    Object.defineProperty(globalThis, 'ZenMoney', {
+      configurable: true,
+      value: {
+        getData: jest.fn((key: string) => key === 'belarusbankAuth' ? auth : 'device-uid'),
+        setData,
+        saveData
+      } as unknown as typeof ZenMoney
+    })
+    mockFetchApi
+      .mockResolvedValueOnce({ status: 401, body: {} })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: {
+          sessionToken: 'new-session-token',
+          refreshToken: 'new-refresh-token',
+          tokenType: 'Bearer'
+        }
+      })
+
+    await expect(authenticate({ login: 'test-login', password: 'test-password' }, true)).resolves.toMatchObject({
+      sessionToken: 'new-session-token',
+      refreshToken: 'new-refresh-token'
+    })
+    expect(mockFetchApi).toHaveBeenNthCalledWith(2, 'users/auth/login', {
+      method: 'POST',
+      body: expect.objectContaining({
+        login: 'test-login',
+        password: 'test-password'
+      }),
+      retry: false
+    })
+    expect(setData).toHaveBeenCalledWith('belarusbankAuth', expect.objectContaining({
+      sessionToken: 'new-session-token',
+      refreshToken: 'new-refresh-token'
+    }))
+    expect(saveData).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the official PIN login mode without sending the local PIN to the bank', async () => {
+    const setData = jest.fn()
+    Object.defineProperty(globalThis, 'ZenMoney', {
+      configurable: true,
+      value: {
+        getData: jest.fn((key: string) => key === 'belarusbankAuth' ? auth : 'device-uid'),
+        setData,
+        saveData: jest.fn()
+      } as unknown as typeof ZenMoney
+    })
+    mockFetchApi
+      .mockResolvedValueOnce({ status: 401, body: {} })
+      .mockResolvedValueOnce({ status: 401, body: {} })
+      .mockResolvedValueOnce({ status: 200, body: { requestId: 'trusted-request-id' } })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: {
+          sessionToken: 'new-session-token',
+          refreshToken: 'new-refresh-token',
+          tokenType: 'Bearer'
+        }
+      })
+
+    await expect(authenticate({ login: 'test-login', password: 'test-password' }, true)).resolves.toMatchObject({
+      sessionToken: 'new-session-token',
+      refreshToken: 'new-refresh-token'
+    })
+    expect(mockFetchApi).toHaveBeenNthCalledWith(3, 'users/auth/login/preparation', {
+      method: 'POST',
+      query: { loginMode: 'PIN' },
+      body: expect.objectContaining({
+        login: 'test-login',
+        password: 'test-password'
+      }),
+      retry: false
+    })
+    expect(mockFetchApi).toHaveBeenNthCalledWith(4, 'users/auth/login/trusted-request-id', {
+      method: 'POST',
+      body: { requestId: 'trusted-request-id' },
+      retry: false
+    })
+  })
+
+  it('rotates and persists a stored refresh session without SMS', async () => {
+    const setData = jest.fn()
+    const saveData = jest.fn()
+    Object.defineProperty(globalThis, 'ZenMoney', {
+      configurable: true,
+      value: {
+        getData: jest.fn(() => auth),
+        setData,
+        saveData
+      } as unknown as typeof ZenMoney
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        sessionToken: 'rotated-session-token',
+        refreshToken: 'rotated-refresh-token',
+        tokenType: 'Bearer'
+      }
+    })
+
+    await expect(authenticate({ login: 'test-login', password: 'test-password' }, true)).resolves.toEqual({
+      login: 'test-login',
+      sessionToken: 'rotated-session-token',
+      refreshToken: 'rotated-refresh-token',
+      tokenType: 'Bearer'
+    })
+    expect(mockFetchApi).toHaveBeenCalledWith('users/auth/refresh-token', {
+      method: 'POST',
+      body: 'refresh-token',
+      rawStringBody: true,
+      retry: false
+    })
+    expect(setData).toHaveBeenCalledWith('belarusbankAuth', {
+      login: 'test-login',
+      sessionToken: 'rotated-session-token',
+      refreshToken: 'rotated-refresh-token',
+      tokenType: 'Bearer'
+    })
+    expect(saveData).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads all visible product types and enriches deposit and credit details', async () => {
+    mockFetchApi.mockImplementation(async (path: string) => {
+      switch (path) {
+        case 'cards': return { status: 200, body: { cards: [] } }
+        case 'accounts': return { status: 200, body: { accounts: [] } }
+        case 'deposits': return {
+          status: 200,
+          body: {
+            accounts: [{
+              productId: 'deposit-1',
+              contractCurrencyIso: 'BYN',
+              contractCurrentRest: '1000'
+            }]
+          }
+        }
+        case 'credits': return {
+          status: 200,
+          body: {
+            credits: [{
+              productId: 'credit-1',
+              contractCurrencyIso: 'BYN'
+            }]
+          }
+        }
+        case 'deposits/deposit-1': return {
+          status: 200,
+          body: {
+            productId: 'deposit-1',
+            contractCurrencyIso: 'BYN',
+            contractCurrentRest: '1000',
+            contractOpenDate: '2026-01-01',
+            contractEndDate: '2027-01-01',
+            percRate: '10'
+          }
+        }
+        case 'credits/credit-1': return {
+          status: 200,
+          body: {
+            productId: 'credit-1',
+            contractCurrencyIso: 'BYN',
+            contractOpenDate: '2026-01-01',
+            returnDate: '2027-01-01',
+            contractFirstSum: '500',
+            restCredit: '300'
+          }
+        }
+        default: throw new Error(`Unexpected path: ${path}`)
+      }
+    })
+
+    const products = await getProducts(auth)
+
+    expect(products.map(({ id }) => id)).toEqual(['deposit-1', 'credit-1'])
+    expect(products[0]).toMatchObject({
+      balance: 1000,
+      percent: 10,
+      _meta: { productKind: 'deposit' }
+    })
+    expect(mockFetchApi).toHaveBeenCalledWith('deposits', {
+      query: { ibState: 'VISIBLE', refresh: true },
+      sessionToken: 'session-token',
+      tokenType: 'Bearer'
+    })
+    expect(mockFetchApi).toHaveBeenCalledWith('deposits/deposit-1', {
+      sessionToken: 'session-token',
+      tokenType: 'Bearer'
+    })
+  })
+
+  it('links current accounts to cards and omits standalone current-account products', async () => {
+    mockFetchApi.mockImplementation(async (path: string, options?: { query?: { contractNumber?: string } }) => {
+      switch (path) {
+        case 'cards': {
+          const card = {
+            productId: 'card-1',
+            cardAccountNumber: ' CONTRACT-1 ',
+            ibanNum: 'BY00 LINKED',
+            currencyIso: 'BYN'
+          }
+          return {
+            status: 200,
+            body: {
+              cards: options?.query?.contractNumber === 'contract-2' ? [] : [card]
+            }
+          }
+        }
+        case 'accounts': return {
+          status: 200,
+          body: {
+            accounts: [{
+              productId: 'account-1',
+              contractNumber: 'contract-1',
+              ibanNum: 'BY00LINKED',
+              contractCurrencyIso: 'BYN',
+              contractCurrentRest: '456.78'
+            }, {
+              productId: 'account-unlinked',
+              contractNumber: 'contract-2',
+              ibanNum: 'BY00UNLINKED',
+              contractCurrencyIso: 'BYN'
+            }]
+          }
+        }
+        case 'deposits': return { status: 200, body: { accounts: [] } }
+        case 'credits': return { status: 200, body: { credits: [] } }
+        default: throw new Error(`Unexpected path: ${path}`)
+      }
+    })
+
+    const products = await getProducts(auth)
+
+    expect(products.map(({ id }) => id)).toEqual(['card-1'])
+    expect(products[0].syncIds).toEqual(expect.arrayContaining(['card-1', 'account-1', 'BY00 LINKED', 'BY00LINKED', 'CONTRACT-1', 'contract-1']))
+    expect(products[0].balance).toBe(456.78)
+    expect(isCardLinkedToAccount({ productId: 'card-1', contractNumber: ' CONTRACT-1 ' }, {
+      productId: 'account-1',
+      contractNumber: 'contract-1'
+    })).toBe(true)
+  })
+
+  it('loads card operations by product id with date-only filters', async () => {
+    const account = convertCard({
+      productId: 'product-1',
+      productCardId: 'physical-card-1',
+      currencyIso: 'BYN'
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        dataTable: [{
+          id: 1,
+          authorizationDate: '2026-08-20T10:30:00+03:00',
+          operationDirection: 'debit',
+          amount: '5',
+          currency: 'BYN'
+        }],
+        total: 1
+      }
+    })
+
+    const transactions = await getCardTransactions(
+      auth,
+      account,
+      new Date('2026-08-01T12:00:00Z'),
+      new Date('2026-08-29T12:00:00Z')
+    )
+
+    expect(transactions[0].movements[0].sum).toBe(-5)
+    expect(mockFetchApi).toHaveBeenNthCalledWith(1, 'cards/transactions/product-1', {
+      method: 'POST',
+      query: { page: 1, size: 100 },
+      body: {
+        dateStart: '2026-08-01',
+        dateEnd: '2026-08-29'
+      },
+      sessionToken: 'session-token',
+      tokenType: 'Bearer'
+    })
+    expect(mockFetchApi).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not request card operations when service right 17 is denied', async () => {
+    const account = convertCard({
+      productId: 'product-1',
+      currencyIso: 'BYN',
+      serviceRights: '111111111111111110'
+    })
+
+    await expect(getCardTransactions(
+      auth,
+      account,
+      new Date('2026-08-01T00:00:00Z'),
+      new Date('2026-08-29T00:00:00Z')
+    )).resolves.toEqual([])
+    expect(mockFetchApi).not.toHaveBeenCalled()
+  })
+
+  it('isolates bank code 1094 to one day and keeps transactions from available days', async () => {
+    const account = convertCard({ productId: 'product-1', currencyIso: 'BYN' })
+    mockFetchApi.mockImplementation(async (_path: string, options: { body?: { dateStart?: string, dateEnd?: string } }) => {
+      if (options.body?.dateEnd === '2026-08-29') {
+        return {
+          status: 400,
+          body: {
+            errorInfo: {
+              code: 1094,
+              errorDescription: 'Невозможно сформировать список операций'
+            }
+          }
+        }
+      }
+
+      return {
+        status: 200,
+        body: {
+          dataTable: [{
+            id: 1,
+            authorizationDate: '2026-08-28T12:00:00+03:00',
+            operationDirection: 'debit',
+            amount: '10.00',
+            currency: '933'
+          }],
+          total: 1
+        }
+      }
+    })
+
+    await expect(getCardTransactions(
+      auth,
+      account,
+      new Date('2026-08-28T00:00:00Z'),
+      new Date('2026-08-29T00:00:00Z')
+    )).resolves.toEqual([
+      expect.objectContaining({
+        movements: [expect.objectContaining({ sum: -10 })]
+      })
+    ])
+    expect(mockFetchApi).toHaveBeenCalledTimes(2)
+    expect(mockFetchApi.mock.calls.map(([, options]) => options.body)).toEqual([
+      { dateStart: '2026-08-28', dateEnd: '2026-08-29' },
+      { dateStart: '2026-08-28', dateEnd: '2026-08-28' }
+    ])
+  })
+
+  it('loads the official card-account statement as binary and parses its text layer', async () => {
+    const account = convertCard({ productId: 'product-1', currencyIso: 'RUB' })
+    const binary = new ArrayBuffer(8)
+    mockFetchApi.mockResolvedValue({ status: 200, body: binary })
+    mockParsePdf.mockResolvedValue({
+      text: [
+        '04.02.2026',
+        '08:15:30',
+        '04.02.2026456,77 RUB+456,77456,78',
+        'Зачисление процентов'
+      ].join('\n')
+    })
+
+    const transactions = await getStatementTransactions(
+      auth,
+      account,
+      new Date('2025-01-01T00:00:00Z'),
+      new Date('2026-08-29T00:00:00Z')
+    )
+
+    expect(transactions).toMatchObject([{
+      hold: false,
+      comment: 'Зачисление процентов',
+      movements: [{ sum: 456.77, account: { id: 'product-1' } }]
+    }])
+    expect(mockFetchApi).toHaveBeenCalledWith('cards/documents/product-1/statement', expect.objectContaining({
+      query: { startDate: '2025-01-01', endDate: '2026-08-29' },
+      binaryResponse: true
+    }))
+    expect(mockParsePdf).toHaveBeenCalledWith(expect.objectContaining({ arrayBuffer: expect.any(Function) }))
+  })
+
+  it('loads six months of product payment history in one date span', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const account = convertAccount({
+      productId: 'account-1',
+      contractCurrencyIso: 'BYN'
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        dataTable: [{
+          id: 1,
+          paymentName: 'Оплата услуги',
+          amount: '5',
+          currency: 'BYN',
+          time: '2026-03-20T10:30:00+03:00'
+        }],
+        total: 1
+      }
+    })
+
+    try {
+      const transactions = await getPaymentHistory(
+        auth,
+        account,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(transactions).toHaveLength(1)
+      expect(transactions[0]).toMatchObject({
+        comment: 'Оплата услуги',
+        movements: [{ sum: -5, account: { id: 'account-1' } }]
+      })
+      expect(mockFetchApi).toHaveBeenCalledWith('payments/history', {
+        method: 'POST',
+        query: { page: 1, size: 300 },
+        body: {
+          dateRangeStartDt: '2026-02-28',
+          dateRangeEndDt: '2026-08-29',
+          productId: 'account-1',
+          productType: 'ACCOUNT',
+          refresh: true
+        },
+        sessionToken: 'session-token',
+        tokenType: 'Bearer'
+      })
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('loads general card history once and maps rows by card number', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const bynCard = convertCard({ productId: 'byn-card', cardPAN: '**** 1111', currencyIso: 'BYN' })
+    const rubCard = convertCard({ productId: 'rub-card', cardPAN: '**** 2222', currencyIso: 'RUB' })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        dataTable: [{
+          id: 1,
+          paymentName: 'BYN payment',
+          amount: '5',
+          currency: 'BYN',
+          time: '2026-02-10T10:30:00+03:00',
+          cardNumber: '**** 1111'
+        }, {
+          id: 2,
+          paymentName: 'RUB payment',
+          amount: '7',
+          currency: 'RUB',
+          time: '2026-02-11T10:30:00+03:00',
+          cardNumber: '**** 2222'
+        }],
+        total: 2
+      }
+    })
+
+    try {
+      const transactions = await getGeneralPaymentHistory(
+        auth,
+        [bynCard, rubCard],
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(transactions.map((transaction) => transaction.movements[0])).toEqual(expect.arrayContaining([
+        expect.objectContaining({ account: { id: 'byn-card' }, sum: -5 }),
+        expect.objectContaining({ account: { id: 'rub-card' }, sum: -7 })
+      ]))
+      expect(mockFetchApi).toHaveBeenCalledTimes(1)
+      expect(mockFetchApi).toHaveBeenCalledWith('payments/history', expect.objectContaining({
+        body: {
+          dateRangeStartDt: '2026-02-28',
+          dateRangeEndDt: '2026-08-29',
+          productType: 'CARD',
+          refresh: true
+        }
+      }))
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('merges payment-history fragments by card, currency and rrn', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const card = convertCard({ productId: 'card-1', cardPAN: '**** 3333', currencyIso: 'BYN' })
+    const fragment = (id: string, amount: string, rrn: string): Record<string, unknown> => ({
+      id,
+      paymentName: 'Тестовая составная операция',
+      amount,
+      feeAmount: '0.00',
+      currency: 'BYN',
+      time: '2026-02-01T10:20:30Z',
+      timeBpc: '2026-02-01T10:20:30Z',
+      cardNumber: '**** 3333',
+      rrn,
+      approvalId: 'synthetic-approval',
+      channelTypeId: 2,
+      paymentId: 'synthetic-payment',
+      paymentIdLeaf: 'synthetic-payment-leaf',
+      statusType: 'success'
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        dataTable: [
+          fragment('zero', '0.00', 'synthetic-composite-rrn'),
+          fragment('part-1', '1.25', 'synthetic-composite-rrn'),
+          fragment('part-2', '0.15', 'synthetic-composite-rrn'),
+          fragment('part-3', '1.25', 'synthetic-composite-rrn'),
+          fragment('part-4', '0.15', 'synthetic-composite-rrn'),
+          fragment('other-rrn', '5.00', 'different-rrn')
+        ],
+        total: 6
+      }
+    })
+
+    try {
+      const transactions = await getGeneralPaymentHistory(
+        auth,
+        [card],
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(transactions).toHaveLength(2)
+      expect(transactions.map((transaction) => transaction.movements[0].sum)).toEqual([-2.8, -5])
+      expect(transactions[0].movements[0].id).toEqual(expect.stringMatching(/^[a-f0-9]{32}$/))
+      expect(transactions[0].movements[0].id).not.toBe(transactions[1].movements[0].id)
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('does not merge nearby subset sums or equal payments with different rrns', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const card = convertCard({ productId: 'card-1', cardPAN: '**** 3333', currencyIso: 'BYN' })
+    const payment = (id: string, amount: string, rrn: string, time: string): Record<string, unknown> => ({
+      id,
+      paymentName: 'Отдельная операция',
+      amount,
+      feeAmount: '0.00',
+      currency: 'BYN',
+      time,
+      timeBpc: time,
+      cardNumber: '**** 3333',
+      rrn,
+      approvalId: `approval-${rrn}`,
+      channelTypeId: 2,
+      paymentId: 'synthetic-payment',
+      paymentIdLeaf: 'synthetic-payment-leaf',
+      statusType: 'success'
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: {
+        dataTable: [
+          payment('subset-1', '12.00', 'rrn-1', '2026-01-10T10:16:14Z'),
+          payment('subset-2', '88.00', 'rrn-2', '2026-01-10T10:17:09Z'),
+          payment('subset-result', '100.00', 'rrn-3', '2026-01-10T10:18:19Z'),
+          payment('equal-1', '250.00', 'rrn-4', '2026-01-11T12:00:00Z'),
+          payment('equal-2', '250.00', 'rrn-5', '2026-01-11T12:00:27Z'),
+          payment('equal-3', '250.00', 'rrn-6', '2026-01-11T12:00:54Z')
+        ],
+        total: 6
+      }
+    })
+
+    try {
+      const transactions = await getGeneralPaymentHistory(
+        auth,
+        [card],
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(transactions).toHaveLength(6)
+      expect(transactions.map((transaction) => transaction.movements[0].sum)).toEqual([
+        -12,
+        -88,
+        -100,
+        -250,
+        -250,
+        -250
+      ])
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('retries an empty refreshed payment history from the bank cache', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const card = convertCard({ productId: 'card-1', cardPAN: '**** 1111', currencyIso: 'BYN' })
+    mockFetchApi
+      .mockResolvedValueOnce({
+        status: 200,
+        body: { dataTable: [], total: 0 }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: {
+          dataTable: [{
+            id: 1,
+            paymentName: 'Cached payment',
+            amount: '5',
+            currency: 'BYN',
+            time: '2026-02-10T10:30:00+03:00',
+            cardNumber: '**** 1111'
+          }],
+          total: 1
+        }
+      })
+
+    try {
+      const transactions = await getGeneralPaymentHistory(
+        auth,
+        [card],
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(transactions).toHaveLength(1)
+      expect(transactions[0]).toMatchObject({
+        comment: 'Cached payment',
+        movements: [{ sum: -5, account: { id: 'card-1' } }]
+      })
+      expect(mockFetchApi).toHaveBeenNthCalledWith(1, 'payments/history', expect.objectContaining({
+        query: { page: 1, size: 300 },
+        body: expect.objectContaining({ refresh: true })
+      }))
+      expect(mockFetchApi).toHaveBeenNthCalledWith(2, 'payments/history', expect.objectContaining({
+        query: { page: 1, size: 300 },
+        body: expect.objectContaining({ refresh: false })
+      }))
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('paginates card payment history with the card product filter', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const account = convertCard({
+      productId: 'card-1',
+      currencyIso: 'BYN'
+    })
+    mockFetchApi
+      .mockResolvedValueOnce({
+        status: 200,
+        body: {
+          dataTable: [{
+            id: 1,
+            paymentName: 'Платёж 1',
+            amount: '5',
+            currency: 'BYN',
+            time: '2026-03-20T10:30:00+03:00'
+          }],
+          total: 301
+        }
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        body: {
+          dataTable: [{
+            id: 2,
+            paymentName: 'Платёж 2',
+            amount: '7',
+            currency: 'BYN',
+            time: '2026-03-21T10:30:00+03:00'
+          }],
+          total: 301
+        }
+      })
+
+    try {
+      const transactions = await getPaymentHistory(
+        auth,
+        account,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(transactions).toHaveLength(2)
+      expect(mockFetchApi).toHaveBeenNthCalledWith(1, 'payments/history', expect.objectContaining({
+        query: { page: 1, size: 300 },
+        body: expect.objectContaining({
+          productId: 'card-1',
+          productType: 'CARD',
+          refresh: true
+        })
+      }))
+      expect(mockFetchApi).toHaveBeenNthCalledWith(2, 'payments/history', expect.objectContaining({
+        query: { page: 2, size: 300 },
+        body: expect.objectContaining({
+          productId: 'card-1',
+          productType: 'CARD',
+          refresh: false
+        })
+      }))
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('starts with the full range and falls back to periods accepted by the bank', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-03-02T12:00:00Z').getTime())
+    const account = convertCard({
+      productId: 'product-1',
+      currencyIso: 'BYN'
+    })
+    mockFetchApi.mockImplementation(async (_path: string, options: { body?: { dateStart?: string, dateEnd?: string } }) => {
+      const dateStart = new Date(`${options.body?.dateStart ?? ''}T00:00:00Z`)
+      const dateEnd = new Date(`${options.body?.dateEnd ?? ''}T00:00:00Z`)
+      const inclusiveDays = Math.round((dateEnd.getTime() - dateStart.getTime()) / (24 * 60 * 60 * 1000)) + 1
+
+      if (inclusiveDays > 15) {
+        return {
+          status: 400,
+          body: { errorInfo: { code: 1094, errorDescription: 'Диапазон не поддерживается' } }
+        }
+      }
+
+      return {
+        status: 200,
+        body: { dataTable: [], total: 0 }
+      }
+    })
+
+    try {
+      await getCardTransactions(
+        auth,
+        account,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-03-02T00:00:00Z')
+      )
+
+      expect(mockFetchApi).toHaveBeenCalledTimes(7)
+      expect(mockFetchApi.mock.calls.map((call) => call[1]?.body)).toEqual([
+        { dateStart: '2026-01-01', dateEnd: '2026-03-02' },
+        { dateStart: '2026-01-01', dateEnd: '2026-03-01' },
+        { dateStart: '2026-01-01', dateEnd: '2026-01-15' },
+        { dateStart: '2026-01-16', dateEnd: '2026-01-30' },
+        { dateStart: '2026-01-31', dateEnd: '2026-02-14' },
+        { dateStart: '2026-02-15', dateEnd: '2026-03-01' },
+        { dateStart: '2026-03-02', dateEnd: '2026-03-02' }
+      ])
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('loads the remaining day when a 16-day range is rejected', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const account = convertCard({ productId: 'product-1', currencyIso: 'BYN' })
+    mockFetchApi.mockImplementation(async (_path: string, options: { body?: { dateStart?: string, dateEnd?: string } }) => {
+      const dateStart = new Date(`${options.body?.dateStart ?? ''}T00:00:00Z`)
+      const dateEnd = new Date(`${options.body?.dateEnd ?? ''}T00:00:00Z`)
+      const inclusiveDays = Math.round((dateEnd.getTime() - dateStart.getTime()) / (24 * 60 * 60 * 1000)) + 1
+
+      return inclusiveDays > 15
+        ? { status: 400, body: { errorInfo: { code: 1094 } } }
+        : { status: 200, body: { dataTable: [], total: 0 } }
+    })
+
+    try {
+      await getCardTransactions(
+        auth,
+        account,
+        new Date('2026-08-14T00:00:00Z'),
+        new Date('2026-08-29T00:00:00Z')
+      )
+
+      expect(mockFetchApi.mock.calls.map((call) => call[1]?.body)).toEqual([
+        { dateStart: '2026-08-14', dateEnd: '2026-08-29' },
+        { dateStart: '2026-08-14', dateEnd: '2026-08-28' },
+        { dateStart: '2026-08-29', dateEnd: '2026-08-29' }
+      ])
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('continues after an unavailable date inside a supported period', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const account = convertCard({ productId: 'product-1', currencyIso: 'BYN' })
+    mockFetchApi.mockImplementation(async (_path: string, options: { body?: { dateStart?: string, dateEnd?: string } }) => {
+      const dateStart = options.body?.dateStart ?? ''
+      const dateEnd = options.body?.dateEnd ?? ''
+      const includesUnavailableDate = dateStart <= '2026-08-08' && dateEnd >= '2026-08-08'
+
+      return includesUnavailableDate
+        ? { status: 400, body: { errorInfo: { code: 1094 } } }
+        : { status: 200, body: { dataTable: [], total: 0 } }
+    })
+
+    try {
+      await getCardTransactions(
+        auth,
+        account,
+        new Date('2026-08-01T00:00:00Z'),
+        new Date('2026-08-15T00:00:00Z')
+      )
+
+      expect(mockFetchApi.mock.calls.map((call) => call[1]?.body)).toEqual(expect.arrayContaining([
+        { dateStart: '2026-08-01', dateEnd: '2026-08-07' },
+        { dateStart: '2026-08-09', dateEnd: '2026-08-15' }
+      ]))
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('stops chunk fallback after a whole period remains unavailable', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-03-02T12:00:00Z').getTime())
+    const errorLog = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const warningLog = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const account = convertCard({ productId: 'product-1', currencyIso: 'BYN' })
+    mockFetchApi.mockResolvedValue({ status: 400, body: { errorInfo: { code: 1094 } } })
+
+    try {
+      await expect(getCardTransactions(
+        auth,
+        account,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-02-01T00:00:00Z')
+      )).resolves.toEqual([])
+
+      expect(mockFetchApi).toHaveBeenCalledTimes(17)
+      expect(mockFetchApi).toHaveBeenLastCalledWith('cards/transactions/product-1', expect.objectContaining({
+        body: { dateStart: '2026-01-01', dateEnd: '2026-01-01' }
+      }))
+    } finally {
+      errorLog.mockRestore()
+      warningLog.mockRestore()
+      now.mockRestore()
+    }
+  })
+
+  it('includes the oldest supported date when the requested end is at midnight', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const account = convertCard({ productId: 'product-1', currencyIso: 'BYN' })
+    mockFetchApi.mockResolvedValue({ status: 200, body: { dataTable: [], total: 0 } })
+
+    try {
+      await getCardTransactions(
+        auth,
+        account,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-02-28T00:00:00Z')
+      )
+
+      expect(mockFetchApi).toHaveBeenCalledWith('cards/transactions/product-1', expect.objectContaining({
+        body: { dateStart: '2026-02-28', dateEnd: '2026-02-28' }
+      }))
+    } finally {
+      now.mockRestore()
+    }
+  })
+
+  it('limits card operations to the six calendar months offered by the bank', async () => {
+    const now = jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-08-29T12:00:00Z').getTime())
+    const account = convertCard({
+      productId: 'product-1',
+      currencyIso: 'BYN'
+    })
+    mockFetchApi.mockResolvedValue({
+      status: 200,
+      body: { dataTable: [], total: 0 }
+    })
+
+    try {
+      await getCardTransactions(
+        auth,
+        account,
+        new Date('2026-01-01T00:00:00Z'),
+        new Date('2026-08-29T12:00:00Z')
+      )
+
+      expect(mockFetchApi.mock.calls.map((call) => call[1]?.body)).toEqual([
+        { dateStart: '2026-02-28', dateEnd: '2026-08-29' }
+      ])
+    } finally {
+      now.mockRestore()
+    }
+  })
+})

--- a/src/plugins/belarusbank/__tests__/converters.test.ts
+++ b/src/plugins/belarusbank/__tests__/converters.test.ts
@@ -1,0 +1,319 @@
+import { AccountType } from '../../../types/zenmoney'
+import { convertAccount, convertCard, convertCardTransaction, convertCredit, convertDeposit, convertPaymentHistoryTransaction } from '../converters'
+
+// Test records are synthetic and must not be copied from real bank data.
+describe('Belarusbank converters', () => {
+  it('converts a card with string balance and numeric active status', () => {
+    const account = convertCard({
+      productId: 10,
+      productCardId: 20,
+      name: 'Моя карта',
+      cardPAN: '**** 1234',
+      currencyIso: '933',
+      amount: '101.25',
+      status: 0
+    })
+
+    expect(account).toMatchObject({
+      id: '10',
+      type: AccountType.ccard,
+      title: 'Моя карта *1234',
+      instrument: 'BYN',
+      syncIds: ['10', '20', '1234'],
+      balance: 101.25,
+      available: 101.25,
+      archived: false,
+      _meta: {
+        productId: '10',
+        transactionCardId: '10',
+        statementProductId: '10',
+        productKind: 'card'
+      }
+    })
+  })
+
+  it('converts a current account and uses the product kind as a title fallback', () => {
+    const account = convertAccount({
+      productId: 'account-1',
+      contractKindName: 'Текущий счёт',
+      ibanNum: 'BY00AKBB00000000000000000000',
+      contractCurrencyIso: 'BYN',
+      contractCurrentRest: '55,70',
+      isArchived: false
+    })
+
+    expect(account).toMatchObject({
+      id: 'account-1',
+      type: AccountType.checking,
+      title: 'Текущий счёт',
+      instrument: 'BYN',
+      balance: 55.7,
+      archived: false
+    })
+  })
+
+  it('converts detailed deposit data including dates and interest', () => {
+    const account = convertDeposit({
+      productId: 'deposit-1',
+      name: 'Безотзывный вклад',
+      contractNumber: 'D-1',
+      contractCurrencyIso: '933',
+      contractCurrentRest: '1000.50',
+      contractOpenDate: '2026-01-15',
+      contractEndDate: '2027-01-15',
+      percRate: '12.5',
+      isArchived: false
+    })
+
+    expect(account).toMatchObject({
+      id: 'deposit-1',
+      type: AccountType.deposit,
+      title: 'Безотзывный вклад',
+      instrument: 'BYN',
+      balance: 1000.5,
+      startBalance: 1000.5,
+      percent: 12.5,
+      capitalization: false,
+      payoffInterval: null,
+      payoffStep: 0,
+      archived: false
+    })
+    if (account.type !== AccountType.deposit) throw new Error('Expected deposit account')
+    expect(account.startDate).toEqual(new Date('2026-01-15'))
+  })
+
+  it('maps deposit capitalization only when the bank description states it explicitly', () => {
+    const account = convertDeposit({
+      productId: 'deposit-2',
+      name: 'Вклад с ежемесячной капитализацией',
+      contractCurrencyIso: 'BYN',
+      contractCurrentRest: '1000',
+      contractOpenDate: '2026-01-15',
+      contractEndDate: '2027-01-15'
+    })
+
+    expect(account).toMatchObject({
+      capitalization: true,
+      payoffInterval: 'month',
+      payoffStep: 1
+    })
+  })
+
+  it('converts a credit to a negative outstanding balance', () => {
+    const account = convertCredit({
+      productId: 'credit-1',
+      name: 'Кредит',
+      contractCurrencyIso: 'BYN',
+      contractFirstSum: '5000',
+      restCredit: '1200.10',
+      restPerc: '10.20',
+      restOverdue: '3.40',
+      percRate: '11.9',
+      contractOpenDate: '2025-01-01',
+      returnDate: '2027-01-01',
+      status: 0
+    })
+
+    expect(account).toMatchObject({
+      type: AccountType.loan,
+      balance: -1213.7,
+      startBalance: 5000,
+      percent: 11.9,
+      archived: false
+    })
+  })
+
+  it('uses the credit direction and account-currency amount from a card operation', () => {
+    const account = convertCard({
+      productId: 'card-1',
+      productCardId: 'card-product-1',
+      currencyIso: 'BYN',
+      amount: 100
+    })
+    const transaction = convertCardTransaction({
+      id: 777,
+      authorizationDate: '2026-08-20T10:30:00+03:00',
+      operationDirection: 'credit',
+      amount: '10.00',
+      currency: 'USD',
+      amountInAccountCurrency: '3150.00',
+      accountCurrency: 'BYN',
+      transactionDescription: 'Покупка',
+      merchantName: 'МАГАЗИН',
+      merchantCountry: 'BY',
+      merchantCity: 'MINSK',
+      mcc: '5411'
+    }, account)
+
+    expect(transaction).toEqual({
+      hold: null,
+      date: new Date('2026-08-20T10:30:00+03:00'),
+      comment: 'Покупка',
+      movements: [{
+        id: expect.stringMatching(/^[a-f0-9]{32}$/),
+        account: { id: 'card-1' },
+        fee: 0,
+        invoice: {
+          sum: 10,
+          instrument: 'USD'
+        },
+        sum: 31.5
+      }],
+      merchant: {
+        country: 'BY',
+        city: 'MINSK',
+        title: 'МАГАЗИН',
+        mcc: 5411,
+        location: null
+      }
+    })
+  })
+
+  it('converts a RUB P2P credit to the linked BYN account amount in minor units', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: '933', amount: '67.89' })
+    const transaction = convertCardTransaction({
+      id: 1001,
+      accountCurrency: '933',
+      accountNumber: 'test-account',
+      amount: '123.45',
+      amountInAccountCurrency: '6789.00',
+      authorizationDate: '2026-02-03T12:34:56',
+      currency: '643',
+      mcc: '6012',
+      merchantCity: 'MINSK',
+      merchantCountry: 'BLR',
+      merchantName: 'PERSON TO PERSON',
+      operationDirection: 'credit',
+      rrn: 'test-transfer-reference',
+      terminalAddress: 'PERSON TO PERSON BLR TEST CITY',
+      transactionDescription: 'P2P Credit part',
+      transactionType: '785'
+    }, account)
+
+    expect(transaction.date).toEqual(new Date('2026-02-03T09:34:56.000Z'))
+    expect(transaction).toMatchObject({
+      groupKeys: ['belarusbank:p2p:2026-02-03T09:34:56.000Z:RUB:123.45'],
+      movements: [{
+        account: { id: 'card-1' },
+        sum: 67.89,
+        invoice: {
+          sum: 123.45,
+          instrument: 'RUB'
+        }
+      }]
+    })
+
+    const counterpart = convertCardTransaction({
+      id: 1002,
+      accountCurrency: '643',
+      amount: '123.45',
+      amountInAccountCurrency: '12345.00',
+      authorizationDate: '2026-02-03T12:34:56',
+      currency: '643',
+      operationDirection: 'debit',
+      rrn: 'different-transfer-reference',
+      transactionDescription: 'P2P Debit part',
+      transactionType: '781'
+    }, convertCard({ productId: 'card-2', currencyIso: '643', amount: '0' }))
+
+    expect(counterpart.groupKeys).toEqual(transaction.groupKeys)
+  })
+
+  it('keeps major-unit decimals, applies a negative debit sign and ignores a changing bank row id', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'RUB', amount: '456.78' })
+    const first = convertCardTransaction({
+      id: 2001,
+      authorizationDate: '2026-02-04T08:15:30+03:00',
+      operationDirection: 'DEBIT',
+      amount: '456.78',
+      currency: 'RUB',
+      amountInAccountCurrency: '45678.00',
+      accountCurrency: 'RUB',
+      transactionDescription: 'Первое описание',
+      rrn: 'stable-rrn'
+    }, account)
+    const refreshed = convertCardTransaction({
+      id: 2002,
+      authorizationDate: '2026-02-04T08:15:30+03:00',
+      operationDirection: 'DEBIT',
+      amount: '456.78',
+      currency: 'RUB',
+      amountInAccountCurrency: '45678.00',
+      accountCurrency: 'RUB',
+      transactionDescription: 'Уточнённое описание',
+      rrn: 'stable-rrn'
+    }, account)
+
+    expect(account.balance).toBe(456.78)
+    expect(first.movements[0].sum).toBe(-456.78)
+    expect(first.movements[0].id).toBe(refreshed.movements[0].id)
+  })
+
+  it('merges linked current-account identities into the card', () => {
+    const account = convertCard({
+      productId: 'card-1',
+      productCardId: 'physical-card-1',
+      cardPAN: '**** 1234',
+      cardAccountNumber: 'contract-1',
+      ibanNum: 'BY00CARD',
+      currencyIso: 'BYN',
+      amount: '0'
+    }, {
+      productId: 'account-1',
+      contractNumber: 'contract-1',
+      ibanNum: 'BY00CARD',
+      contractCurrencyIso: 'BYN',
+      contractCurrentRest: '456.78'
+    })
+
+    expect(account.syncIds).toEqual([
+      'card-1',
+      'physical-card-1',
+      'BY00CARD',
+      'contract-1',
+      'account-1',
+      '1234'
+    ])
+    expect(account).toMatchObject({ balance: 0, available: 0 })
+  })
+
+  it('rejects a card operation without a valid authorization date', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'BYN' })
+
+    expect(() => convertCardTransaction({
+      id: 1,
+      authorizationDate: 'not-a-date',
+      operationDirection: 'debit',
+      amount: 1
+    }, account)).toThrow('authorizationDate')
+  })
+
+  it('ignores zero-amount rows from the app payment history', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'BYN' })
+
+    expect(convertPaymentHistoryTransaction({
+      id: 'zero-payment',
+      amount: 0,
+      currency: 'BYN',
+      time: '2026-02-01T10:20:30Z',
+      paymentName: 'Тестовая нулевая операция'
+    }, account)).toBeNull()
+  })
+
+  it('includes the payment-history fee in the account movement total', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'BYN' })
+
+    expect(convertPaymentHistoryTransaction({
+      id: 'bank-transfer',
+      amount: '20.00',
+      feeAmount: '0.50',
+      currency: 'BYN',
+      time: '2026-02-05T09:10:20Z',
+      timeBpc: '2026-02-05T09:10:21Z',
+      paymentName: 'Тестовый банковский перевод'
+    }, account)).toMatchObject({
+      date: new Date('2026-02-05T12:10:21+03:00'),
+      movements: [{ account: { id: 'card-1' }, sum: -20.5 }]
+    })
+  })
+})

--- a/src/plugins/belarusbank/__tests__/fetchApi.test.ts
+++ b/src/plugins/belarusbank/__tests__/fetchApi.test.ts
@@ -1,0 +1,50 @@
+import { TemporaryUnavailableError } from '../../../errors'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../common/network', () => ({
+  fetchJson: mockFetchJson
+}))
+
+const { fetchApi } = jest.requireActual<typeof import('../fetchApi')>('../fetchApi')
+
+describe('Belarusbank fetch API', () => {
+  beforeEach(() => {
+    mockFetchJson.mockReset()
+  })
+
+  it('sends the refresh token as a raw string and disables request logging', async () => {
+    mockFetchJson.mockResolvedValue({ status: 200, body: '{}' })
+
+    await fetchApi('users/auth/refresh-token', {
+      method: 'POST',
+      body: 'refresh-token',
+      rawStringBody: true,
+      retry: false
+    })
+
+    const options = mockFetchJson.mock.calls[0][1]
+    expect(options.stringify('refresh-token')).toBe('refresh-token')
+    expect(options.log).toBe(false)
+  })
+
+  it('does not retry an explicitly non-retryable request', async () => {
+    mockFetchJson.mockResolvedValue({ status: 500, body: '{}' })
+
+    await expect(fetchApi('users/auth/login/preparation', {
+      method: 'POST',
+      body: {},
+      retry: false
+    })).resolves.toMatchObject({ status: 500 })
+    expect(mockFetchJson).toHaveBeenCalledTimes(1)
+  })
+
+  it('turns an exhausted retryable network error into temporary unavailability', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    mockFetchJson.mockRejectedValue(new Error('[NER] connection reset'))
+
+    await expect(fetchApi('cards')).rejects.toBeInstanceOf(TemporaryUnavailableError)
+    expect(mockFetchJson).toHaveBeenCalledTimes(3)
+    consoleError.mockRestore()
+  })
+})

--- a/src/plugins/belarusbank/__tests__/index.test.ts
+++ b/src/plugins/belarusbank/__tests__/index.test.ts
@@ -1,0 +1,579 @@
+import { BankMessageError } from '../../../errors'
+import { AccountType } from '../../../types/zenmoney'
+import type { AuthState, ProductAccount } from '../models'
+
+// Test records are synthetic and must not be copied from real bank data.
+const mockAuthenticate = jest.fn()
+const mockGetProducts = jest.fn()
+const mockGetCardTransactions = jest.fn()
+const mockGetGeneralPaymentHistory = jest.fn()
+const mockGetStatementTransactions = jest.fn()
+let pluginData: Map<string, unknown>
+
+jest.mock('../api', () => ({
+  authenticate: mockAuthenticate,
+  getProducts: mockGetProducts,
+  getCardTransactions: mockGetCardTransactions,
+  getGeneralPaymentHistory: mockGetGeneralPaymentHistory,
+  getStatementTransactions: mockGetStatementTransactions
+}))
+
+const { scrape } = jest.requireActual<typeof import('../index')>('../index')
+
+describe('Belarusbank scrape', () => {
+  beforeEach(() => {
+    mockAuthenticate.mockReset()
+    mockGetProducts.mockReset()
+    mockGetCardTransactions.mockReset()
+    mockGetGeneralPaymentHistory.mockReset().mockResolvedValue([])
+    mockGetStatementTransactions.mockReset().mockResolvedValue([])
+    pluginData = new Map<string, unknown>()
+    Object.defineProperty(globalThis, 'ZenMoney', {
+      configurable: true,
+      value: {
+        isAccountSkipped: jest.fn(() => false),
+        getData: jest.fn((key: string, defaultValue: unknown) => pluginData.get(key) ?? defaultValue),
+        setData: jest.fn((key: string, value: unknown) => pluginData.set(key, value)),
+        saveData: jest.fn()
+      } as unknown as typeof ZenMoney
+    })
+  })
+
+  it('loads the full statement first and supplements it with general payment history', async () => {
+    const auth: AuthState = {
+      login: 'test-login',
+      sessionToken: 'session-token',
+      refreshToken: 'refresh-token',
+      tokenType: 'Bearer'
+    }
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    mockAuthenticate.mockResolvedValue(auth)
+    mockGetProducts.mockResolvedValue([card])
+    mockGetCardTransactions.mockResolvedValue([])
+
+    await expect(scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2025-01-01T00:00:00Z'),
+      toDate: new Date('2026-08-29T00:00:00Z'),
+      isFirstRun: true,
+      isInBackground: false
+    })).resolves.toEqual({
+      accounts: [card],
+      transactions: []
+    })
+    expect(mockGetStatementTransactions).toHaveBeenCalledWith(
+      auth,
+      card,
+      new Date('2025-01-01T00:00:00Z'),
+      new Date('2026-08-29T00:00:00Z')
+    )
+    expect(mockGetGeneralPaymentHistory).toHaveBeenCalledWith(
+      auth,
+      [card],
+      new Date('2025-01-01T00:00:00Z'),
+      new Date('2026-08-29T00:00:00Z')
+    )
+    expect(mockGetStatementTransactions.mock.invocationCallOrder[0]).toBeLessThan(mockGetGeneralPaymentHistory.mock.invocationCallOrder[0])
+    expect(mockGetCardTransactions).not.toHaveBeenCalled()
+    expect(ZenMoney.setData).not.toHaveBeenCalled()
+  })
+
+  it('removes the legacy transaction-id state without creating a replacement', async () => {
+    pluginData.set('belarusbankTransactionIds', {
+      statementIds: ['old-statement-id'],
+      historyIds: ['old-history-id']
+    })
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([])
+
+    await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-08-01T00:00:00Z'),
+      toDate: new Date('2026-08-31T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(ZenMoney.setData).toHaveBeenCalledTimes(1)
+    expect(ZenMoney.setData).toHaveBeenCalledWith('belarusbankTransactionIds', undefined)
+    expect(ZenMoney.saveData).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds general payment history without duplicating matching statement operations', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    const paymentHistoryDate = new Date('2026-02-05T09:10:21Z')
+    const statementDate = new Date('2026-02-05T12:10:21+03:00')
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+    mockGetGeneralPaymentHistory.mockResolvedValue([{
+      hold: false,
+      date: paymentHistoryDate,
+      comment: 'Payment history duplicate',
+      merchant: null,
+      movements: [{ id: 'payment-duplicate', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }, {
+      hold: false,
+      date: new Date('2026-02-02T11:00:00+03:00'),
+      comment: 'Payment history only',
+      merchant: null,
+      movements: [{ id: 'payment-only', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -7 }]
+    }])
+    mockGetStatementTransactions.mockResolvedValue([{
+      hold: null,
+      date: statementDate,
+      comment: 'Statement operation',
+      merchant: null,
+      movements: [{ id: 'card-operation', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }])
+
+    const result = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-02-01T00:00:00Z'),
+      toDate: new Date('2026-08-29T00:00:00Z'),
+      isFirstRun: true,
+      isInBackground: false
+    })
+
+    expect(result.transactions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        comment: 'Statement operation',
+        movements: [expect.objectContaining({ id: expect.stringMatching(/^[a-f0-9]{32}$/), sum: -20.5 })]
+      }),
+      expect.objectContaining({ comment: 'Payment history only' })
+    ]))
+    expect(result.transactions).toHaveLength(2)
+    expect(mockGetCardTransactions).not.toHaveBeenCalled()
+  })
+
+  it('generates the same id when app history arrives before the statement', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    const date = new Date('2026-02-01T10:20:30Z')
+    const history = [{
+      hold: false,
+      date,
+      comment: 'Тестовая составная операция',
+      merchant: null,
+      movements: [{ id: 'rrn-composite', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -2.8 }]
+    }, {
+      hold: false,
+      date,
+      comment: 'Другая операция',
+      merchant: null,
+      movements: [{ id: 'unrelated', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -7 }]
+    }]
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+    mockGetGeneralPaymentHistory.mockResolvedValue(history)
+    mockGetStatementTransactions.mockResolvedValueOnce([])
+
+    const firstResult = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-08-01T00:00:00Z'),
+      toDate: new Date('2026-08-04T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+    const composite = firstResult.transactions.find((transaction) => transaction.comment === 'Тестовая составная операция')
+    expect(firstResult.transactions).toHaveLength(2)
+    expect(composite).toMatchObject({
+      movements: [{ sum: -2.8 }]
+    })
+    const compositeId = composite?.movements[0].id
+    expect(compositeId).toEqual(expect.stringMatching(/^[a-f0-9]{32}$/))
+    expect(compositeId).not.toBe('rrn-composite')
+
+    mockGetStatementTransactions.mockResolvedValueOnce([{
+      hold: false,
+      date,
+      comment: 'USLUGI BANKA БЕЛАРУСЬ',
+      merchant: null,
+      movements: [{ id: 'statement-id', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -2.8 }]
+    }])
+    const secondResult = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-08-01T00:00:00Z'),
+      toDate: new Date('2026-08-04T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(secondResult.transactions).toHaveLength(2)
+    expect(secondResult.transactions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        comment: 'USLUGI BANKA БЕЛАРУСЬ',
+        movements: [expect.objectContaining({ id: compositeId, sum: -2.8 })]
+      }),
+      expect.objectContaining({ comment: 'Другая операция' })
+    ]))
+
+    mockGetGeneralPaymentHistory.mockResolvedValueOnce([])
+    mockGetStatementTransactions.mockResolvedValueOnce([{
+      hold: false,
+      date,
+      comment: 'USLUGI BANKA БЕЛАРУСЬ',
+      merchant: null,
+      movements: [{ id: 'statement-id', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -2.8 }]
+    }])
+    const thirdResult = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-08-01T00:00:00Z'),
+      toDate: new Date('2026-08-04T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(thirdResult.transactions).toHaveLength(1)
+    expect(thirdResult.transactions[0].movements[0].id).toBe(compositeId)
+  })
+
+  it('generates the same id when the statement arrives before app history', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    const date = new Date('2026-02-05T09:10:21Z')
+    const statement = {
+      hold: false,
+      date,
+      comment: 'Выписка',
+      merchant: null,
+      movements: [{ id: 'statement-first', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }
+    const history = {
+      hold: false,
+      date,
+      comment: 'История приложения',
+      merchant: null,
+      movements: [{ id: 'history-later', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+    mockGetStatementTransactions.mockResolvedValue([statement])
+    mockGetGeneralPaymentHistory
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([history])
+
+    const scrapeArgs = {
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-02-01T00:00:00Z'),
+      toDate: new Date('2026-02-06T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    }
+    const firstResult = await scrape(scrapeArgs)
+    const secondResult = await scrape(scrapeArgs)
+    const stableId = firstResult.transactions[0].movements[0].id
+
+    expect(stableId).toEqual(expect.stringMatching(/^[a-f0-9]{32}$/))
+    expect(stableId).not.toBe('statement-first')
+    expect(secondResult.transactions).toHaveLength(1)
+    expect(secondResult.transactions[0]).toMatchObject({
+      comment: 'Выписка',
+      movements: [{ id: stableId, sum: -20.5 }]
+    })
+
+    mockGetStatementTransactions.mockResolvedValueOnce([])
+    mockGetGeneralPaymentHistory.mockResolvedValueOnce([{
+      hold: false,
+      date,
+      comment: 'История приложения',
+      merchant: null,
+      movements: [{ id: 'history-later', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }])
+    const thirdResult = await scrape(scrapeArgs)
+
+    expect(thirdResult.transactions).toHaveLength(1)
+    expect(thirdResult.transactions[0]).toMatchObject({
+      comment: 'История приложения',
+      movements: [{ id: stableId, sum: -20.5 }]
+    })
+  })
+
+  it('does not merge equal amounts whose operation times differ', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+    mockGetStatementTransactions.mockResolvedValue([{
+      hold: false,
+      date: new Date('2026-02-05T09:10:21Z'),
+      comment: 'Выписка',
+      merchant: null,
+      movements: [{ id: 'statement', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }])
+    mockGetGeneralPaymentHistory.mockResolvedValue([{
+      hold: false,
+      date: new Date('2026-02-05T09:10:22Z'),
+      comment: 'Другая операция',
+      merchant: null,
+      movements: [{ id: 'history', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+    }])
+
+    const result = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-02-01T00:00:00Z'),
+      toDate: new Date('2026-02-06T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(result.transactions).toHaveLength(2)
+  })
+
+  it('keeps source-specific ids when same-second statement operations are ambiguous', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    const date = new Date('2026-02-05T09:10:21Z')
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+    mockGetStatementTransactions.mockResolvedValue([
+      {
+        hold: false,
+        date,
+        comment: 'Первая операция',
+        merchant: null,
+        movements: [{ id: 'statement-1', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+      },
+      {
+        hold: false,
+        date,
+        comment: 'Вторая операция',
+        merchant: null,
+        movements: [{ id: 'statement-2', account: { id: 'card-1' }, fee: 0, invoice: null, sum: -20.5 }]
+      }
+    ])
+
+    const result = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-02-01T00:00:00Z'),
+      toDate: new Date('2026-02-06T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(result.transactions).toHaveLength(2)
+    expect(result.transactions.map((transaction) => transaction.movements[0].id)).toEqual([
+      'statement-1',
+      'statement-2'
+    ])
+  })
+
+  it('does not hide bank errors while loading the primary statement', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+    mockGetStatementTransactions.mockRejectedValue(new BankMessageError('Unauthorized'))
+
+    await expect(scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-08-01T00:00:00Z'),
+      toDate: new Date('2026-08-29T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })).rejects.toMatchObject({ bankMessage: 'Unauthorized' })
+    expect(mockGetCardTransactions).not.toHaveBeenCalled()
+  })
+
+  it('loads the entire requested period through the official statement endpoint', async () => {
+    const card: ProductAccount = {
+      id: 'card-1',
+      type: AccountType.ccard,
+      title: 'Card',
+      instrument: 'BYN',
+      balance: 1,
+      syncIds: ['card-1'],
+      _meta: {
+        productId: 'card-1',
+        transactionCardId: 'card-1',
+        statementProductId: 'card-1',
+        productKind: 'card'
+      }
+    }
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([card])
+
+    await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-01-01T00:00:00Z'),
+      toDate: new Date('2026-08-29T00:00:00Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(mockGetStatementTransactions).toHaveBeenCalledWith(
+      {},
+      card,
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-08-29T00:00:00Z')
+    )
+    expect(mockGetCardTransactions).not.toHaveBeenCalled()
+  })
+
+  it('merges the debit and credit parts of an own-card currency transfer', async () => {
+    const bynCard: ProductAccount = {
+      id: 'byn-card',
+      type: AccountType.ccard,
+      title: 'BYN Card',
+      instrument: 'BYN',
+      balance: 67.89,
+      syncIds: ['byn-card'],
+      _meta: {
+        productId: 'byn-card',
+        transactionCardId: 'byn-card',
+        statementProductId: 'byn-card',
+        productKind: 'card'
+      }
+    }
+    const rubCard: ProductAccount = {
+      id: 'rub-card',
+      type: AccountType.ccard,
+      title: 'RUB Card',
+      instrument: 'RUB',
+      balance: 0,
+      syncIds: ['rub-card'],
+      _meta: {
+        productId: 'rub-card',
+        transactionCardId: 'rub-card',
+        statementProductId: 'rub-card',
+        productKind: 'card'
+      }
+    }
+    const date = new Date('2026-02-03T12:34:56+03:00')
+    const groupKeys = ['belarusbank:p2p:2026-02-03T09:34:56.000Z:RUB:123.45']
+    mockAuthenticate.mockResolvedValue({})
+    mockGetProducts.mockResolvedValue([bynCard, rubCard])
+    mockGetStatementTransactions.mockImplementation(async (_auth, account: ProductAccount) => account.id === 'byn-card'
+      ? [{
+          hold: null,
+          date,
+          groupKeys,
+          comment: 'P2P Credit part',
+          merchant: null,
+          movements: [{
+            id: 'income',
+            account: { id: 'byn-card' },
+            fee: 0,
+            invoice: { sum: 123.45, instrument: 'RUB' },
+            sum: 67.89
+          }]
+        }]
+      : [{
+          hold: null,
+          date,
+          groupKeys,
+          comment: 'P2P Debit part',
+          merchant: null,
+          movements: [{
+            id: 'outcome',
+            account: { id: 'rub-card' },
+            fee: 0,
+            invoice: null,
+            sum: -123.45
+          }]
+        }])
+
+    const result = await scrape({
+      preferences: { login: 'test-login', password: 'test-password' },
+      fromDate: new Date('2026-02-03T00:00:00Z'),
+      toDate: new Date('2026-02-03T23:59:59Z'),
+      isFirstRun: false,
+      isInBackground: true
+    })
+
+    expect(result.transactions).toEqual([expect.objectContaining({
+      date,
+      comment: 'P2P Debit part',
+      movements: [
+        expect.objectContaining({ account: { id: 'rub-card' }, invoice: null, sum: -123.45 }),
+        expect.objectContaining({ account: { id: 'byn-card' }, invoice: null, sum: 67.89 })
+      ]
+    })])
+    expect(mockGetCardTransactions).not.toHaveBeenCalled()
+  })
+})

--- a/src/plugins/belarusbank/__tests__/statement.test.ts
+++ b/src/plugins/belarusbank/__tests__/statement.test.ts
@@ -1,0 +1,74 @@
+import { convertCard } from '../converters'
+import { parseStatementTransactions } from '../statement'
+
+// Test records are synthetic and must not be copied from real bank data.
+describe('Belarusbank statement parser', () => {
+  it('parses major-unit amounts, signs and a row split by a page header', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'BYN' })
+    const text = [
+      '10.01.2025',
+      '10:10:56',
+      '10.01.2025250,00 BYN+250,00250,00Дополнительный взнос',
+      '10.01.2025',
+      '11:09:25',
+      '11.01.2025250,00 BYN250,000,00',
+      'Оплата товаров и услуг',
+      '05.02.2026 06.02.2026321,00 RUB+11,110,00Перевод средств держателю карты',
+      'Дата и',
+      'время',
+      'совершения',
+      'операции',
+      'Номер карты',
+      '07:28:13',
+      'PERSON TO PERSON',
+      '0000***1111',
+      '08.02.2026',
+      '21:51:12',
+      '08.02.20260,00 BYN0,000,00Капитализация',
+      'Реквизиты банка:'
+    ].join('\n')
+
+    const transactions = parseStatementTransactions(text, account)
+
+    expect(transactions).toHaveLength(3)
+    expect(transactions.map((transaction) => transaction.movements[0].sum)).toEqual([250, -250, 11.11])
+    expect(transactions[2]).toMatchObject({
+      hold: false,
+      date: new Date('2026-02-05T07:28:13+03:00'),
+      groupKeys: ['belarusbank:p2p:2026-02-05T04:28:13.000Z:RUB:321.00'],
+      comment: 'Перевод средств держателю карты PERSON TO PERSON',
+      movements: [{
+        account: { id: 'card-1' },
+        sum: 11.11,
+        invoice: { sum: 321, instrument: 'RUB' }
+      }]
+    })
+    expect(transactions.every((transaction) => transaction.movements[0].id?.match(/^[a-f0-9]{32}$/) != null)).toBe(true)
+  })
+
+  it('does not scale a decimal amount by one hundred', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'RUB' })
+    const transactions = parseStatementTransactions([
+      '04.02.2026',
+      '08:15:30',
+      '04.02.2026 456,77 RUB +456,77 456,78',
+      'Зачисление процентов'
+    ].join('\n'), account)
+
+    expect(transactions[0].movements[0].sum).toBe(456.77)
+  })
+
+  it('keeps identical rows distinct by their occurrence in the statement', () => {
+    const account = convertCard({ productId: 'card-1', currencyIso: 'BYN' })
+    const row = [
+      '04.02.2026',
+      '08:15:30',
+      '04.02.2026 1,00 BYN 1,00 455,78',
+      'Одинаковая операция'
+    ]
+    const transactions = parseStatementTransactions([...row, ...row].join('\n'), account)
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].movements[0].id).not.toBe(transactions[1].movements[0].id)
+  })
+})

--- a/src/plugins/belarusbank/api.ts
+++ b/src/plugins/belarusbank/api.ts
@@ -1,0 +1,760 @@
+import { BankMessageError, InvalidLoginOrPasswordError, InvalidOtpCodeError, TemporaryUnavailableError, UserInteractionError } from '../../errors'
+import { parsePdf } from '../../common/pdfUtils'
+import { convertCard, convertCardTransaction, convertCredit, convertDeposit, convertPaymentHistoryTransaction } from './converters'
+import { fetchApi, type ApiResponse } from './fetchApi'
+import { asNonEmptyString, getLastCardDigits, toNumber } from './helpers'
+import { APP_VERSION, AUTH_DATA_KEY, DEVICE_UID_DATA_KEY, type AuthState, type PreferenceInput, type ProductAccount } from './models'
+import { parseStatementTransactions } from './statement'
+import type { AccountsResponse, BankAccount, Card, CardTransactionsResponse, CardsResponse, Credit, CreditsResponse, ErrorInfo, ErrorResponse, LoginPreparationResponse, LoginRequest, LoginResponse, PaymentHistoryItem, PaymentHistoryResponse } from './types/fetch'
+
+const PAGE_SIZE = 100
+const PAYMENT_HISTORY_PAGE_SIZE = 300
+const MAX_TRANSACTION_PAGES = 100
+const MAX_TRANSACTION_PERIOD_DAYS = 15
+const MAX_TRANSACTION_LOOKBACK_MONTHS = 6
+const DAY_MS = 24 * 60 * 60 * 1000
+const MINSK_TIMEZONE_OFFSET_MS = 3 * 60 * 60 * 1000
+const formatApiDate = (date: Date): string => new Date(date.getTime() + MINSK_TIMEZONE_OFFSET_MS).toISOString().slice(0, 10)
+
+const normalizeProductIdentifier = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null
+  const normalized = value.replace(/\s/g, '').toUpperCase()
+  return normalized.length > 0 ? normalized : null
+}
+
+/** Returns whether a card belongs to a current account returned by Belarusbank. */
+export const isCardLinkedToAccount = (card: Card, account: BankAccount): boolean => {
+  const accountContractNumber = normalizeProductIdentifier(account.contractNumber)
+  const accountIban = normalizeProductIdentifier(account.ibanNum)
+  const cardContractNumbers = [card.cardAccountNumber, card.contractNumber]
+    .map(normalizeProductIdentifier)
+    .filter((value): value is string => value != null)
+  const cardIban = normalizeProductIdentifier(card.ibanNum)
+
+  if (accountContractNumber != null && cardContractNumbers.length > 0) {
+    return cardContractNumbers.includes(accountContractNumber)
+  }
+
+  return accountIban != null && cardIban === accountIban
+}
+
+const findLinkedAccount = (
+  card: Card,
+  accounts: BankAccount[],
+  authoritativeLinks: Map<string, BankAccount[]>
+): BankAccount | undefined => {
+  const authoritativeMatches = authoritativeLinks.get(String(card.productId))
+  if (authoritativeMatches != null) return authoritativeMatches.length === 1 ? authoritativeMatches[0] : undefined
+
+  const matches = accounts.filter((account) => isCardLinkedToAccount(card, account))
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+const loadAuthoritativeCardAccountLinks = async (
+  auth: AuthState,
+  accounts: BankAccount[]
+): Promise<Map<string, BankAccount[]>> => {
+  const result = new Map<string, BankAccount[]>()
+
+  await Promise.all(accounts.map(async (account) => {
+    if (normalizeProductIdentifier(account.contractNumber) == null) return
+
+    const response = await fetchApi<CardsResponse>('cards', {
+      query: { contractNumber: account.contractNumber as string },
+      ...authOptions(auth)
+    })
+    if (!(response.status >= 200 && response.status < 300)) {
+      console.warn(`[BELARUSBANK:CARD_ACCOUNT_LINK] HTTP ${response.status}`)
+      return
+    }
+
+    for (const card of response.body.cards ?? []) {
+      const productId = String(card.productId)
+      const candidates = result.get(productId) ?? []
+      if (!candidates.some((candidate) => String(candidate.productId) === String(account.productId))) {
+        candidates.push(account)
+        result.set(productId, candidates)
+      }
+    }
+  }))
+
+  return result
+}
+
+export const getCardTransactionStartDate = (): Date => {
+  const minskDate = new Date(Date.now() + MINSK_TIMEZONE_OFFSET_MS)
+  const dayOfMonth = minskDate.getUTCDate()
+  minskDate.setUTCDate(1)
+  minskDate.setUTCMonth(minskDate.getUTCMonth() - MAX_TRANSACTION_LOOKBACK_MONTHS)
+  const lastDayOfTargetMonth = new Date(Date.UTC(
+    minskDate.getUTCFullYear(),
+    minskDate.getUTCMonth() + 1,
+    0
+  )).getUTCDate()
+  minskDate.setUTCDate(Math.min(dayOfMonth, lastDayOfTargetMonth))
+  minskDate.setUTCHours(0, 0, 0, 0)
+  return new Date(minskDate.getTime() - MINSK_TIMEZONE_OFFSET_MS)
+}
+
+const getPaymentHistoryStartDate = (): Date => getCardTransactionStartDate()
+
+const getTransactionPeriods = (fromDate: Date, toDate: Date): Array<{ fromDate: Date, toDate: Date }> => {
+  const periods: Array<{ fromDate: Date, toDate: Date }> = []
+  const today = new Date(Date.now())
+  const earliestSupportedDate = getCardTransactionStartDate()
+  const supportedToDate = new Date(Math.min(toDate.getTime(), today.getTime()))
+  let periodStart = new Date(Math.max(fromDate.getTime(), earliestSupportedDate.getTime()))
+
+  while (periodStart.getTime() <= supportedToDate.getTime()) {
+    const periodEnd = new Date(Math.min(
+      periodStart.getTime() + (MAX_TRANSACTION_PERIOD_DAYS - 1) * DAY_MS,
+      supportedToDate.getTime()
+    ))
+    periods.push({ fromDate: periodStart, toDate: periodEnd })
+    periodStart = new Date(periodEnd.getTime() + DAY_MS)
+  }
+
+  return periods
+}
+
+const getErrorInfo = (body: ErrorResponse | null | undefined): ErrorInfo | null =>
+  body?.errorInfo ?? body?.error?.errorInfo ?? null
+
+const getErrorMessage = (body: ErrorResponse | null | undefined, fallback: string): string => {
+  const errorInfo = getErrorInfo(body)
+  return errorInfo?.errorDescription ?? errorInfo?.errorText ?? fallback
+}
+
+export class CardTransactionsUnavailableError extends BankMessageError {}
+
+const assertSuccess = <T extends ErrorResponse>(response: ApiResponse<T>, context: string): T => {
+  if (response.status >= 200 && response.status < 300) return response.body
+
+  console.error(`[BELARUSBANK:${context}] HTTP ${response.status}`, getErrorInfo(response.body))
+  if (response.status >= 500) throw new TemporaryUnavailableError()
+  if (context === 'CARD_TRANSACTIONS' && String(getErrorInfo(response.body)?.code ?? '') === '1094') {
+    throw new CardTransactionsUnavailableError(getErrorMessage(response.body, 'Операции по карте временно недоступны'))
+  }
+
+  throw new BankMessageError(getErrorMessage(response.body, `Ошибка Беларусбанка (HTTP ${response.status})`))
+}
+
+const makeDeviceUid = (): string => {
+  const bytes = Array.from({ length: 16 }, () => Math.floor(Math.random() * 256))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = bytes.map((value) => `0${value.toString(16)}`.slice(-2)).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
+
+const getDeviceUid = (): string => {
+  const stored = ZenMoney.getData(DEVICE_UID_DATA_KEY, null)
+  if (typeof stored === 'string' && stored.length > 0) return stored
+
+  const deviceUid = makeDeviceUid()
+  ZenMoney.setData(DEVICE_UID_DATA_KEY, deviceUid)
+  ZenMoney.saveData()
+  return deviceUid
+}
+
+const normalizePhone = (login: string): string | null => {
+  const phone = login.replace(/[\s()-]/g, '')
+  return /^\+?375\d{9}$/.test(phone) ? (phone.startsWith('+') ? phone : `+${phone}`) : null
+}
+
+const makeLoginRequest = (preferences: PreferenceInput): LoginRequest => {
+  const login = preferences.login.trim()
+  const phone = normalizePhone(login)
+
+  return {
+    appVersion: APP_VERSION,
+    deviceModel: 'ZenMoney',
+    deviceUid: getDeviceUid(),
+    ...(phone == null ? { login } : { mobilePhone: phone }),
+    osType: 'Android',
+    osVersion: '16',
+    password: preferences.password,
+    token: ''
+  }
+}
+
+const saveAuth = (login: string, response: LoginResponse, previous?: AuthState): AuthState => {
+  const sessionToken = response.sessionToken ?? response.token ?? previous?.sessionToken
+  const refreshToken = response.refreshToken ?? previous?.refreshToken
+  const tokenType = response.tokenType ?? previous?.tokenType ?? 'Bearer'
+
+  if (sessionToken == null || refreshToken == null) {
+    throw new Error('Belarusbank auth response does not contain required tokens')
+  }
+
+  const auth: AuthState = { login, sessionToken, refreshToken, tokenType }
+  ZenMoney.setData(AUTH_DATA_KEY, auth)
+  ZenMoney.saveData()
+  return auth
+}
+
+const loadAuth = (): AuthState | null => {
+  const value = ZenMoney.getData(AUTH_DATA_KEY, null) as Partial<AuthState> | null
+  if (
+    value == null ||
+    typeof value.login !== 'string' ||
+    typeof value.sessionToken !== 'string' ||
+    typeof value.refreshToken !== 'string' ||
+    typeof value.tokenType !== 'string'
+  ) return null
+
+  return value as AuthState
+}
+
+const tryRefresh = async (login: string, auth: AuthState): Promise<AuthState | null> => {
+  const response = await fetchApi<LoginResponse>('users/auth/refresh-token', {
+    method: 'POST',
+    body: auth.refreshToken,
+    rawStringBody: true,
+    retry: false
+  })
+
+  if (response.status >= 200 && response.status < 300) return saveAuth(login, response.body, auth)
+  if ([400, 401, 403].includes(response.status)) return null
+  if (response.status >= 500) throw new TemporaryUnavailableError()
+
+  throw new BankMessageError(getErrorMessage(response.body, `Ошибка обновления сессии Беларусбанка (HTTP ${response.status})`))
+}
+
+const tryDirectLogin = async (preferences: PreferenceInput): Promise<AuthState | null> => {
+  const response = await fetchApi<LoginResponse>('users/auth/login', {
+    method: 'POST',
+    body: makeLoginRequest(preferences),
+    retry: false
+  })
+
+  if (response.status >= 200 && response.status < 300) return saveAuth(preferences.login.trim(), response.body)
+  if ([400, 401, 403].includes(response.status)) return null
+  if (response.status >= 500) throw new TemporaryUnavailableError()
+
+  throw new BankMessageError(getErrorMessage(response.body, `Ошибка доверенного входа Беларусбанка (HTTP ${response.status})`))
+}
+
+const tryTrustedLogin = async (preferences: PreferenceInput): Promise<AuthState | null> => {
+  const preparation = await fetchApi<LoginPreparationResponse>('users/auth/login/preparation', {
+    method: 'POST',
+    query: { loginMode: 'PIN' },
+    body: makeLoginRequest(preferences),
+    retry: false
+  })
+
+  if (!(preparation.status >= 200 && preparation.status < 300)) {
+    if ([400, 401, 403].includes(preparation.status)) return null
+    if (preparation.status >= 500) throw new TemporaryUnavailableError()
+    throw new BankMessageError(getErrorMessage(preparation.body, `Ошибка доверенного входа Беларусбанка (HTTP ${preparation.status})`))
+  }
+
+  if (typeof preparation.body.requestId !== 'string' || preparation.body.requestId.length === 0) return null
+
+  const confirmation = await fetchApi<LoginResponse>(`users/auth/login/${encodeURIComponent(preparation.body.requestId)}`, {
+    method: 'POST',
+    body: { requestId: preparation.body.requestId },
+    retry: false
+  })
+
+  if (confirmation.status >= 200 && confirmation.status < 300) return saveAuth(preferences.login.trim(), confirmation.body)
+  if ([400, 401, 403].includes(confirmation.status)) return null
+  if (confirmation.status >= 500) throw new TemporaryUnavailableError()
+
+  throw new BankMessageError(getErrorMessage(confirmation.body, `Ошибка подтверждения доверенного входа Беларусбанка (HTTP ${confirmation.status})`))
+}
+
+const loginWithSms = async (preferences: PreferenceInput, isInBackground: boolean): Promise<AuthState> => {
+  if (isInBackground) throw new UserInteractionError()
+
+  const preparation = await fetchApi<LoginPreparationResponse>('users/auth/login/preparation', {
+    method: 'POST',
+    body: makeLoginRequest(preferences),
+    retry: false
+  })
+
+  if (!(preparation.status >= 200 && preparation.status < 300)) {
+    const errorInfo = getErrorInfo(preparation.body)
+    const code = String(errorInfo?.code ?? '')
+    const message = getErrorMessage(preparation.body, 'Не удалось войти в Беларусбанк')
+
+    if (code === '1011' || /логин|парол|зарегистр|login|password/i.test(message)) {
+      throw new InvalidLoginOrPasswordError(message)
+    }
+
+    if (preparation.status >= 500) throw new TemporaryUnavailableError()
+    throw new BankMessageError(message)
+  }
+
+  if (typeof preparation.body.requestId !== 'string' || preparation.body.requestId.length === 0) {
+    throw new Error('Belarusbank login preparation response does not contain requestId')
+  }
+
+  let codeWord: string | undefined
+  if (preparation.body.needCodeWord === true) {
+    const answer = await ZenMoney.readLine('Введите кодовое слово для входа в Беларусбанк', {
+      inputType: 'text',
+      time: 120000
+    })
+    codeWord = answer?.trim()
+    if (codeWord == null || codeWord.length === 0) throw new InvalidOtpCodeError('Кодовое слово не введено')
+  }
+
+  const code = await ZenMoney.readLine('Введите 6-значный код из SMS от Беларусбанка', {
+    inputType: 'number',
+    time: 120000
+  })
+  const normalizedCode = code?.trim()
+  if (normalizedCode == null || normalizedCode.length === 0) throw new InvalidOtpCodeError('Код из SMS не введён')
+
+  const confirmationPayload = {
+    requestId: preparation.body.requestId,
+    code: normalizedCode,
+    ...(codeWord == null ? {} : { codeWord })
+  }
+  const confirmation = await fetchApi<LoginResponse>(`users/auth/login/${encodeURIComponent(preparation.body.requestId)}`, {
+    method: 'POST',
+    query: {
+      code: normalizedCode,
+      codeWord
+    },
+    body: confirmationPayload,
+    retry: false
+  })
+
+  if (!(confirmation.status >= 200 && confirmation.status < 300)) {
+    const message = getErrorMessage(confirmation.body, 'Неверный код подтверждения Беларусбанка')
+    if (confirmation.status === 400 || confirmation.status === 401) throw new InvalidOtpCodeError(message)
+    if (confirmation.status >= 500) throw new TemporaryUnavailableError()
+    throw new BankMessageError(message)
+  }
+
+  return saveAuth(preferences.login.trim(), confirmation.body)
+}
+
+export const authenticate = async (preferences: PreferenceInput, isInBackground: boolean): Promise<AuthState> => {
+  const normalizedLogin = preferences.login.trim()
+  const stored = loadAuth()
+
+  if (stored?.login === normalizedLogin) {
+    const refreshed = await tryRefresh(normalizedLogin, stored)
+    if (refreshed != null) return refreshed
+  }
+
+  const direct = await tryDirectLogin(preferences)
+  if (direct != null) return direct
+
+  const trusted = await tryTrustedLogin(preferences)
+  if (trusted != null) return trusted
+
+  return await loginWithSms(preferences, isInBackground)
+}
+
+interface SessionInput {
+  sessionToken: string
+  tokenType: string
+}
+
+const authOptions = (auth: AuthState): SessionInput => ({
+  sessionToken: auth.sessionToken,
+  tokenType: auth.tokenType
+})
+
+const enrichDeposit = async (auth: AuthState, deposit: BankAccount): Promise<BankAccount> => {
+  if (
+    deposit.contractOpenDate != null &&
+    (deposit.contractEndDate != null || deposit.contractCloseDate != null || deposit.returnDate != null) &&
+    deposit.percRate != null
+  ) return deposit
+
+  const response = await fetchApi<BankAccount>(`deposits/${encodeURIComponent(String(deposit.productId))}`, authOptions(auth))
+  return { ...deposit, ...assertSuccess(response, 'DEPOSIT_DETAILS') }
+}
+
+const enrichCredit = async (auth: AuthState, credit: Credit): Promise<Credit> => {
+  if (credit.contractOpenDate != null && credit.returnDate != null && credit.restCredit != null) return credit
+
+  const response = await fetchApi<Credit>(`credits/${encodeURIComponent(String(credit.productId))}`, authOptions(auth))
+  return { ...credit, ...assertSuccess(response, 'CREDIT_DETAILS') }
+}
+
+export const getProducts = async (auth: AuthState): Promise<ProductAccount[]> => {
+  const session = authOptions(auth)
+  const [cardsResponse, accountsResponse, depositsResponse, creditsResponse] = await Promise.all([
+    fetchApi<CardsResponse>('cards', { query: { ibState: 'VISIBLE', refresh: true }, ...session }),
+    fetchApi<AccountsResponse>('accounts', { query: { ibState: 'VISIBLE', refresh: true }, ...session }),
+    fetchApi<AccountsResponse>('deposits', { query: { ibState: 'VISIBLE', refresh: true }, ...session }),
+    fetchApi<CreditsResponse>('credits', { query: { ibState: 'VISIBLE', refresh: true }, ...session })
+  ])
+
+  const cards = assertSuccess(cardsResponse, 'CARDS').cards ?? []
+  const accounts = assertSuccess(accountsResponse, 'ACCOUNTS').accounts ?? []
+  const authoritativeLinks = await loadAuthoritativeCardAccountLinks(auth, accounts)
+  const deposits = await Promise.all((assertSuccess(depositsResponse, 'DEPOSITS').accounts ?? []).map(async (deposit) => await enrichDeposit(auth, deposit)))
+  const credits = await Promise.all((assertSuccess(creditsResponse, 'CREDITS').credits ?? []).map(async (credit) => await enrichCredit(auth, credit)))
+
+  return [
+    ...cards.map((card) => convertCard(card, findLinkedAccount(card, accounts, authoritativeLinks))),
+    ...deposits.map(convertDeposit),
+    ...credits.map(convertCredit)
+  ]
+}
+
+/** Loads and parses the official posted-operation statement for a linked card account. */
+export const getStatementTransactions = async (
+  auth: AuthState,
+  account: ProductAccount,
+  fromDate: Date,
+  toDate: Date
+): Promise<ReturnType<typeof parseStatementTransactions>> => {
+  if (account._meta.statementProductId == null || account._meta.productKind !== 'card' || account._meta.cardStatementAllowed === false) return []
+  if (fromDate.getTime() > toDate.getTime()) return []
+
+  const response = await fetchApi<ArrayBuffer>(`cards/documents/${encodeURIComponent(account._meta.statementProductId)}/statement`, {
+    query: {
+      startDate: formatApiDate(fromDate),
+      endDate: formatApiDate(toDate)
+    },
+    binaryResponse: true,
+    accept: 'application/pdf, application/octet-stream, */*',
+    ...authOptions(auth)
+  })
+  if (!(response.status >= 200 && response.status < 300)) {
+    console.error(`[BELARUSBANK:STATEMENT] HTTP ${response.status}`)
+    if (response.status >= 500) throw new TemporaryUnavailableError()
+    throw new BankMessageError(`Не удалось получить выписку Беларусбанка (HTTP ${response.status})`)
+  }
+  if (!(response.body instanceof ArrayBuffer)) throw new Error('Belarusbank statement response is not binary')
+
+  const { text } = await parsePdf({ arrayBuffer: async () => response.body })
+  return parseStatementTransactions(text, account)
+}
+
+type ConvertedCardTransaction = ReturnType<typeof convertCardTransaction>
+
+interface AvailableCardTransactionPeriod {
+  transactions: ConvertedCardTransaction[]
+  fullyUnavailable: boolean
+}
+
+const loadCardTransactionPeriod = async (
+  auth: AuthState,
+  account: ProductAccount,
+  fromDate: Date,
+  toDate: Date
+): Promise<ConvertedCardTransaction[]> => {
+  const transactions: ConvertedCardTransaction[] = []
+  let page = 1
+  let total = Number.POSITIVE_INFINITY
+
+  while ((page - 1) * PAGE_SIZE < total && page <= MAX_TRANSACTION_PAGES) {
+    const response = await fetchApi<CardTransactionsResponse>(`cards/transactions/${encodeURIComponent(account._meta.transactionCardId ?? '')}`, {
+      method: 'POST',
+      query: { page, size: PAGE_SIZE },
+      body: {
+        dateStart: formatApiDate(fromDate),
+        dateEnd: formatApiDate(toDate)
+      },
+      ...authOptions(auth)
+    })
+    const body = assertSuccess(response, 'CARD_TRANSACTIONS')
+    const pageTransactions = body.dataTable ?? []
+    total = body.total ?? pageTransactions.length
+    transactions.push(...pageTransactions.map((transaction) => convertCardTransaction(transaction, account)))
+
+    if (pageTransactions.length === 0 || pageTransactions.length < PAGE_SIZE) break
+    page += 1
+  }
+
+  return transactions
+}
+
+const loadAvailableCardTransactionPeriod = async (
+  auth: AuthState,
+  account: ProductAccount,
+  fromDate: Date,
+  toDate: Date,
+  initialRequestFailed = false
+): Promise<AvailableCardTransactionPeriod> => {
+  const transactions: ConvertedCardTransaction[] = []
+  let segmentStartDate = fromDate
+  let skipInitialRequest = initialRequestFailed
+
+  while (segmentStartDate.getTime() <= toDate.getTime()) {
+    if (!skipInitialRequest) {
+      try {
+        transactions.push(...await loadCardTransactionPeriod(auth, account, segmentStartDate, toDate))
+        return { transactions, fullyUnavailable: false }
+      } catch (error) {
+        if (!(error instanceof CardTransactionsUnavailableError)) throw error
+      }
+    }
+    skipInitialRequest = false
+
+    let loadedPrefixEndDate: Date | null = null
+    for (let fallbackEndDate = new Date(toDate.getTime() - DAY_MS); fallbackEndDate.getTime() >= segmentStartDate.getTime(); fallbackEndDate = new Date(fallbackEndDate.getTime() - DAY_MS)) {
+      try {
+        transactions.push(...await loadCardTransactionPeriod(auth, account, segmentStartDate, fallbackEndDate))
+        loadedPrefixEndDate = fallbackEndDate
+        break
+      } catch (fallbackError) {
+        if (!(fallbackError instanceof CardTransactionsUnavailableError)) throw fallbackError
+      }
+    }
+
+    if (loadedPrefixEndDate == null) {
+      console.warn(`[BELARUSBANK:CARD_TRANSACTIONS] Period starting ${formatApiDate(segmentStartDate)} is unavailable; later periods will be retried`)
+      return { transactions, fullyUnavailable: true }
+    }
+
+    const unavailableDate = new Date(loadedPrefixEndDate.getTime() + DAY_MS)
+    console.warn(`[BELARUSBANK:CARD_TRANSACTIONS] Date ${formatApiDate(unavailableDate)} is unavailable; it will be retried`)
+    segmentStartDate = new Date(unavailableDate.getTime() + DAY_MS)
+  }
+
+  return { transactions, fullyUnavailable: false }
+}
+
+export const getCardTransactions = async (
+  auth: AuthState,
+  account: ProductAccount,
+  fromDate: Date,
+  toDate: Date
+): Promise<Array<ReturnType<typeof convertCardTransaction>>> => {
+  if (account._meta.transactionCardId == null || account._meta.cardTransactionsAllowed === false) return []
+
+  const transactions: ConvertedCardTransaction[] = []
+  const periods = getTransactionPeriods(fromDate, toDate)
+  if (periods.length === 0) return []
+
+  const supportedFromDate = periods[0].fromDate
+  const supportedToDate = periods[periods.length - 1].toDate
+
+  try {
+    transactions.push(...await loadCardTransactionPeriod(auth, account, supportedFromDate, supportedToDate))
+  } catch (error) {
+    if (!(error instanceof CardTransactionsUnavailableError)) throw error
+
+    if (periods.length === 1) {
+      const fallback = await loadAvailableCardTransactionPeriod(auth, account, supportedFromDate, supportedToDate, true)
+      transactions.push(...fallback.transactions)
+    } else {
+      const shortenedToDate = new Date(supportedToDate.getTime() - DAY_MS)
+      try {
+        transactions.push(...await loadCardTransactionPeriod(auth, account, supportedFromDate, shortenedToDate))
+        console.warn(`[BELARUSBANK:CARD_TRANSACTIONS] Loaded through ${formatApiDate(shortenedToDate)}; newer dates will be retried`)
+        const tail = await loadAvailableCardTransactionPeriod(auth, account, supportedToDate, supportedToDate)
+        transactions.push(...tail.transactions)
+      } catch (shortenedError) {
+        if (!(shortenedError instanceof CardTransactionsUnavailableError)) throw shortenedError
+
+        console.warn(`[BELARUSBANK:CARD_TRANSACTIONS] Full range is unavailable; retrying in ${MAX_TRANSACTION_PERIOD_DAYS}-day periods`)
+        for (const period of periods) {
+          const fallback = await loadAvailableCardTransactionPeriod(auth, account, period.fromDate, period.toDate)
+          transactions.push(...fallback.transactions)
+          if (fallback.fullyUnavailable) break
+        }
+      }
+    }
+  }
+
+  const unique = new Map<string, ReturnType<typeof convertCardTransaction>>()
+  for (const transaction of transactions) {
+    const id = transaction.movements[0].id
+    if (id != null) unique.set(id, transaction)
+  }
+
+  return Array.from(unique.values())
+}
+
+export const getPaymentHistory = async (
+  auth: AuthState,
+  account: ProductAccount,
+  fromDate: Date,
+  toDate: Date
+): Promise<Array<NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>>> => {
+  const productType = account._meta.productKind === 'card'
+    ? 'CARD'
+    : account._meta.productKind === 'account'
+      ? 'ACCOUNT'
+      : null
+  if (productType == null) return []
+
+  const payments = mergePaymentHistoryItemsByRrn(
+    await loadPaymentHistoryItems(auth, fromDate, toDate, {
+      productId: account._meta.productId,
+      productType
+    }),
+    () => account.id
+  )
+
+  const transactions: Array<NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>> = []
+  for (const payment of payments) {
+    const transaction = convertPaymentHistoryTransaction(payment, account)
+    if (transaction != null) transactions.push(transaction)
+  }
+
+  return uniquePaymentHistoryTransactions(transactions)
+}
+
+interface PaymentHistoryFilter {
+  productId?: string
+  productType: 'CARD' | 'ACCOUNT'
+}
+
+const loadPaymentHistoryItems = async (
+  auth: AuthState,
+  fromDate: Date,
+  toDate: Date,
+  filter: PaymentHistoryFilter
+): Promise<PaymentHistoryItem[]> => {
+  const supportedFromDate = new Date(Math.max(fromDate.getTime(), getPaymentHistoryStartDate().getTime()))
+  const supportedToDate = new Date(Math.min(toDate.getTime(), Date.now()))
+  if (supportedFromDate.getTime() > supportedToDate.getTime()) return []
+
+  const payments: PaymentHistoryItem[] = []
+  let page = 1
+  let total = Number.POSITIVE_INFINITY
+
+  while ((page - 1) * PAYMENT_HISTORY_PAGE_SIZE < total && page <= MAX_TRANSACTION_PAGES) {
+    const loadPage = async (refresh: boolean): Promise<PaymentHistoryResponse> => assertSuccess(
+      await fetchApi<PaymentHistoryResponse>('payments/history', {
+        method: 'POST',
+        query: { page, size: PAYMENT_HISTORY_PAGE_SIZE },
+        body: {
+          dateRangeStartDt: formatApiDate(supportedFromDate),
+          dateRangeEndDt: formatApiDate(supportedToDate),
+          ...filter,
+          refresh
+        },
+        ...authOptions(auth)
+      }),
+      'PAYMENT_HISTORY'
+    )
+
+    let body = await loadPage(page === 1)
+    let pagePayments = body.dataTable ?? []
+    if (page === 1 && pagePayments.length === 0 && (body.total ?? 0) === 0) {
+      body = await loadPage(false)
+      pagePayments = body.dataTable ?? []
+    }
+    total = body.total ?? pagePayments.length
+    payments.push(...pagePayments)
+
+    if (pagePayments.length === 0 || page * PAYMENT_HISTORY_PAGE_SIZE >= total) break
+    page += 1
+  }
+
+  return payments
+}
+
+const uniquePaymentHistoryTransactions = (
+  transactions: Array<NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>>
+): Array<NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>> => {
+  const unique = new Map<string, NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>>()
+  for (const transaction of transactions) {
+    const id = transaction.movements[0].id
+    if (id != null) unique.set(id, transaction)
+  }
+  return Array.from(unique.values())
+}
+
+const mergePaymentHistoryItemsByRrn = (
+  payments: PaymentHistoryItem[],
+  getAccountId: (payment: PaymentHistoryItem) => string | null
+): PaymentHistoryItem[] => {
+  const uniqueRows = Array.from(new Map(payments.map((payment) => [String(payment.id), payment])).values())
+  const groups = new Map<string, { firstIndex: number, rows: PaymentHistoryItem[] }>()
+  const output: Array<{ index: number, payment: PaymentHistoryItem }> = []
+
+  uniqueRows.forEach((payment, index) => {
+    const rrn = asNonEmptyString(payment.rrn)
+    const approvalId = asNonEmptyString(payment.approvalId)
+    const eventTime = asNonEmptyString(payment.timeBpc) ?? asNonEmptyString(payment.time)
+    const channelTypeId = asNonEmptyString(payment.channelTypeId)
+    const paymentId = asNonEmptyString(payment.paymentId)
+    const paymentIdLeaf = asNonEmptyString(payment.paymentIdLeaf)
+    const statusType = asNonEmptyString(payment.statusType)?.toLowerCase() ?? null
+    const accountId = getAccountId(payment)
+    if (
+      rrn == null ||
+      approvalId == null ||
+      eventTime == null ||
+      channelTypeId == null ||
+      paymentId == null ||
+      paymentIdLeaf == null ||
+      statusType !== 'success' ||
+      accountId == null
+    ) {
+      output.push({ index, payment })
+      return
+    }
+
+    const key = JSON.stringify({
+      accountId,
+      rrn,
+      currency: asNonEmptyString(payment.currency),
+      approvalId,
+      eventTime,
+      channelTypeId,
+      paymentId,
+      paymentIdLeaf,
+      statusType
+    })
+    const group = groups.get(key) ?? { firstIndex: index, rows: [] }
+    group.rows.push(payment)
+    groups.set(key, group)
+  })
+
+  for (const [key, group] of groups) {
+    const first = group.rows[0]
+    const amount = Math.round(group.rows.reduce((sum, payment) => sum + Math.abs(toNumber(payment.amount, 0)), 0) * 100) / 100
+    const feeAmount = Math.round(group.rows.reduce((sum, payment) => sum + Math.abs(toNumber(payment.feeAmount, 0)), 0) * 100) / 100
+    output.push({
+      index: group.firstIndex,
+      payment: {
+        ...first,
+        id: `rrn:${key}`,
+        amount,
+        feeAmount
+      }
+    })
+  }
+
+  return output
+    .sort((left, right) => left.index - right.index)
+    .map(({ payment }) => payment)
+}
+
+const findPaymentHistoryAccount = (payment: PaymentHistoryItem, accounts: ProductAccount[]): ProductAccount | null => {
+  const lastDigits = getLastCardDigits(payment.cardNumber)
+  const cardAccount = normalizeProductIdentifier(payment.cardAccount)
+  const matches = accounts.filter((account) =>
+    (lastDigits != null && account.syncIds.includes(lastDigits)) ||
+    (cardAccount != null && account.syncIds.some((syncId) => normalizeProductIdentifier(syncId) === cardAccount))
+  )
+  return matches.length === 1 ? matches[0] : null
+}
+
+/** Loads the app-wide card payment history once and maps every row to its card. */
+export const getGeneralPaymentHistory = async (
+  auth: AuthState,
+  accounts: ProductAccount[],
+  fromDate: Date,
+  toDate: Date
+): Promise<Array<NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>>> => {
+  if (accounts.length === 0) return []
+
+  const payments = mergePaymentHistoryItemsByRrn(
+    await loadPaymentHistoryItems(auth, fromDate, toDate, { productType: 'CARD' }),
+    (payment) => findPaymentHistoryAccount(payment, accounts)?.id ?? null
+  )
+  const transactions: Array<NonNullable<ReturnType<typeof convertPaymentHistoryTransaction>>> = []
+  for (const payment of payments) {
+    const account = findPaymentHistoryAccount(payment, accounts)
+    if (account == null) continue
+    const transaction = convertPaymentHistoryTransaction(payment, account)
+    if (transaction != null) transactions.push(transaction)
+  }
+  return uniquePaymentHistoryTransactions(transactions)
+}

--- a/src/plugins/belarusbank/converters.ts
+++ b/src/plugins/belarusbank/converters.ts
@@ -1,0 +1,247 @@
+import md5 from 'crypto-js/md5'
+import { getIntervalBetweenDates } from '../../common/momentDateUtils'
+import { AccountType, type ExtendedTransaction, type Transaction } from '../../types/zenmoney'
+import { asNonEmptyString, getLastCardDigits, isArchived, normalizeCurrency, parseDate, parseMinskDate, parseRequiredDate, toNumber, toOptionalNumber, uniqueStrings } from './helpers'
+import type { ProductAccount } from './models'
+import type { BankAccount, Card, CardTransaction, Credit, PaymentHistoryItem } from './types/fetch'
+
+const getTitle = (name: unknown, fallback: string): string => asNonEmptyString(name) ?? fallback
+
+const withArchived = <T extends object>(target: T, status: unknown): T & { archived?: boolean } => {
+  const archived = isArchived(status)
+  return archived == null ? target : { ...target, archived }
+}
+
+const getProductArchivedStatus = (product: { isArchived?: boolean, status?: string | number, statusName?: string }): boolean | undefined =>
+  product.isArchived ?? isArchived(product.status ?? product.statusName)
+
+const getCreditArchivedStatus = (credit: Credit): boolean | undefined => {
+  if (credit.isArchived != null) return credit.isArchived
+
+  const numericStatus = Number(credit.status)
+  if (Number.isFinite(numericStatus)) return [-1, 8, 9, 11].includes(numericStatus)
+  return isArchived(credit.status ?? credit.statusName)
+}
+
+export const convertCard = (card: Card, linkedAccount?: BankAccount): ProductAccount => {
+  const productId = String(card.productId)
+  const lastDigits = getLastCardDigits(card.cardPAN)
+  const baseTitle = getTitle(card.name, getTitle(card.cardProductKindName, 'Карта Беларусбанка'))
+  const title = lastDigits == null || baseTitle.includes(lastDigits) ? baseTitle : `${baseTitle} *${lastDigits}`
+  const hasServiceRight = (rightIndex: number): boolean => card.serviceRights == null || card.serviceRights[rightIndex] === '1'
+  const cardAvailable = toOptionalNumber(card.amount)
+  const linkedAccountBalance = toOptionalNumber(linkedAccount?.contractCurrentRest)
+
+  return withArchived({
+    id: productId,
+    type: AccountType.ccard,
+    title,
+    instrument: normalizeCurrency(card.currencyIso),
+    syncIds: uniqueStrings([
+      productId,
+      card.productCardId,
+      card.ibanNum,
+      card.cardAccountNumber,
+      card.contractNumber,
+      linkedAccount?.productId,
+      linkedAccount?.ibanNum,
+      linkedAccount?.contractNumber,
+      lastDigits
+    ]),
+    balance: cardAvailable ?? linkedAccountBalance,
+    available: cardAvailable,
+    _meta: {
+      productId,
+      transactionCardId: productId,
+      statementProductId: productId,
+      cardTransactionsAllowed: hasServiceRight(17),
+      cardStatementAllowed: hasServiceRight(16),
+      productKind: 'card' as const
+    }
+  }, card.isArchived ?? (Number(card.status) === -1 ? true : isArchived(card.status)))
+}
+
+export const convertAccount = (account: BankAccount): ProductAccount => {
+  const productId = String(account.productId)
+
+  return withArchived({
+    id: productId,
+    type: AccountType.checking,
+    title: getTitle(account.name, getTitle(account.contractKindName, getTitle(account.contractNumber, 'Счёт Беларусбанка'))),
+    instrument: normalizeCurrency(account.contractCurrencyIso ?? account.contractCurrency),
+    syncIds: uniqueStrings([productId, account.ibanNum, account.contractNumber]),
+    balance: toOptionalNumber(account.contractCurrentRest),
+    _meta: {
+      productId,
+      transactionCardId: null,
+      statementProductId: productId,
+      productKind: 'account' as const
+    }
+  }, getProductArchivedStatus(account))
+}
+
+export const convertDeposit = (deposit: BankAccount): ProductAccount => {
+  const productId = String(deposit.productId)
+  const startDate = parseDate(deposit.contractOpenDate, new Date(0))
+  const endDate = parseDate(deposit.contractEndDate ?? deposit.contractCloseDate ?? deposit.returnDate, new Date(Date.UTC(startDate.getUTCFullYear() + 1, startDate.getUTCMonth(), startDate.getUTCDate())))
+  const { count: endDateOffset, interval: endDateOffsetInterval } = getIntervalBetweenDates(startDate, endDate)
+  const balance = toOptionalNumber(deposit.contractCurrentRest)
+  const description = `${deposit.name ?? ''} ${deposit.contractKindName ?? ''}`
+  const capitalization = /капитализац|capitaliz/i.test(description) && !/без капитализац|without capitaliz/i.test(description)
+  const hasMonthlyPayoff = /ежемесяч|monthly/i.test(description)
+
+  return withArchived({
+    id: productId,
+    type: AccountType.deposit,
+    title: getTitle(deposit.name, getTitle(deposit.contractKindName, getTitle(deposit.contractNumber, 'Вклад Беларусбанка'))),
+    instrument: normalizeCurrency(deposit.contractCurrencyIso ?? deposit.contractCurrency),
+    syncIds: uniqueStrings([productId, deposit.ibanNum, deposit.contractNumber]),
+    balance,
+    startDate,
+    startBalance: balance ?? 0,
+    capitalization,
+    percent: toOptionalNumber(deposit.percRate),
+    endDateOffsetInterval,
+    endDateOffset,
+    payoffInterval: hasMonthlyPayoff ? 'month' as const : null,
+    payoffStep: hasMonthlyPayoff ? 1 : 0,
+    _meta: {
+      productId,
+      transactionCardId: null,
+      statementProductId: null,
+      productKind: 'deposit' as const
+    }
+  }, getProductArchivedStatus(deposit))
+}
+
+export const convertCredit = (credit: Credit): ProductAccount => {
+  const productId = String(credit.productId)
+  const startDate = parseDate(credit.contractOpenDate, new Date(0))
+  const endDate = parseDate(credit.returnDate, new Date(Date.UTC(startDate.getUTCFullYear() + 1, startDate.getUTCMonth(), startDate.getUTCDate())))
+  const { count: endDateOffset, interval: endDateOffsetInterval } = getIntervalBetweenDates(startDate, endDate)
+  const debt = toNumber(credit.restCredit, 0) + toNumber(credit.restPerc, 0) + toNumber(credit.restOverdue, 0)
+
+  return withArchived({
+    id: productId,
+    type: AccountType.loan,
+    title: getTitle(credit.name, getTitle(credit.contractNumber, 'Кредит Беларусбанка')),
+    instrument: normalizeCurrency(credit.contractCurrencyIso ?? credit.contractCurrency ?? 'BYN'),
+    syncIds: uniqueStrings([productId, credit.ibanNum, credit.contractNumber]),
+    balance: -debt,
+    startDate,
+    startBalance: toNumber(credit.contractFirstSum, Math.abs(debt)),
+    capitalization: true,
+    percent: toOptionalNumber(credit.percRate),
+    endDateOffsetInterval,
+    endDateOffset,
+    payoffInterval: 'month' as const,
+    payoffStep: 1,
+    _meta: {
+      productId,
+      transactionCardId: null,
+      statementProductId: null,
+      productKind: 'credit' as const
+    }
+  }, getCreditArchivedStatus(credit))
+}
+
+const getTransactionSign = (direction: CardTransaction['operationDirection']): number =>
+  direction.toLowerCase() === 'credit' ? 1 : -1
+
+const P2P_TRANSFER_TRANSACTION_TYPES = new Set(['781', '785'])
+
+const getCardAccountAmount = (
+  transaction: CardTransaction,
+  accountCurrency: string,
+  transactionCurrency: string
+): number => {
+  const transactionAmount = Math.abs(toNumber(transaction.amount, 0))
+  if (transactionCurrency === accountCurrency || transaction.amountInAccountCurrency == null) return transactionAmount
+
+  // Belarusbank returns this field in minor units (for example, 6789.00 means 67.89 BYN).
+  return Math.abs(toNumber(transaction.amountInAccountCurrency, 0)) / 100
+}
+
+export const convertCardTransaction = (transaction: CardTransaction, account: ProductAccount): ExtendedTransaction => {
+  const sign = getTransactionSign(transaction.operationDirection)
+  const accountCurrency = normalizeCurrency(transaction.accountCurrency ?? account.instrument)
+  const transactionCurrency = normalizeCurrency(transaction.currency ?? accountCurrency)
+  const accountAmount = getCardAccountAmount(transaction, accountCurrency, transactionCurrency) * sign
+  const transactionAmount = Math.abs(toNumber(transaction.amount, 0)) * sign
+  const merchantTitle = asNonEmptyString(transaction.merchantName) ?? asNonEmptyString(transaction.terminalAddress)
+  const mcc = Number(transaction.mcc)
+  const date = parseMinskDate(transaction.authorizationDate, 'authorizationDate')
+  const rrn = asNonEmptyString(transaction.rrn)
+  const groupKeys = P2P_TRANSFER_TRANSACTION_TYPES.has(String(transaction.transactionType))
+    ? [`belarusbank:p2p:${date.toISOString()}:${transactionCurrency}:${Math.abs(transactionAmount).toFixed(2)}`]
+    : undefined
+  const stableId = md5(JSON.stringify({
+    accountId: account.id,
+    authorizationDate: date.toISOString(),
+    accountAmount,
+    accountCurrency,
+    transactionAmount,
+    transactionCurrency,
+    rrn,
+    fallbackDiscriminator: rrn == null
+      ? {
+          merchantTitle,
+          mcc: Number.isFinite(mcc) ? mcc : null,
+          transactionDescription: asNonEmptyString(transaction.transactionDescription)
+        }
+      : null
+  })).toString()
+
+  return {
+    hold: null,
+    date,
+    groupKeys,
+    comment: asNonEmptyString(transaction.transactionDescription),
+    movements: [{
+      id: stableId,
+      account: { id: account.id },
+      fee: 0,
+      invoice: transactionCurrency !== account.instrument
+        ? {
+            sum: transactionAmount,
+            instrument: transactionCurrency
+          }
+        : null,
+      sum: accountAmount
+    }],
+    merchant: merchantTitle == null
+      ? null
+      : {
+          country: asNonEmptyString(transaction.merchantCountry),
+          city: asNonEmptyString(transaction.merchantCity),
+          title: merchantTitle,
+          mcc: Number.isFinite(mcc) ? mcc : null,
+          location: null
+        }
+  }
+}
+
+export const convertPaymentHistoryTransaction = (payment: PaymentHistoryItem, account: ProductAccount): Transaction | null => {
+  const currency = normalizeCurrency(payment.currency ?? account.instrument)
+  if (currency !== account.instrument) return null
+  const amount = Math.abs(toNumber(payment.amount, 0))
+  const feeAmount = Math.abs(toNumber(payment.feeAmount, 0))
+  const totalAmount = amount + feeAmount
+  if (totalAmount < 0.005) return null
+
+  return {
+    hold: false,
+    // The processing timestamp is the one printed in the official statement.
+    // The generic app timestamp may lag it by a second for otherwise identical operations.
+    date: parseRequiredDate(payment.timeBpc ?? payment.time, payment.timeBpc == null ? 'time' : 'timeBpc'),
+    comment: asNonEmptyString(payment.paymentName),
+    movements: [{
+      id: md5(`${account.id}:${String(payment.id)}`).toString(),
+      account: { id: account.id },
+      fee: 0,
+      invoice: null,
+      sum: -totalAmount
+    }],
+    merchant: null
+  }
+}

--- a/src/plugins/belarusbank/fetchApi.ts
+++ b/src/plugins/belarusbank/fetchApi.ts
@@ -1,0 +1,98 @@
+import { fetch, fetchJson } from '../../common/network'
+import { TemporaryUnavailableError } from '../../errors'
+import { BASE_API_URL } from './models'
+
+export interface ApiResponse<T> {
+  status: number
+  body: T
+}
+
+export interface RequestOptions {
+  method?: 'GET' | 'POST'
+  query?: Record<string, string | number | boolean | undefined>
+  body?: unknown
+  sessionToken?: string
+  tokenType?: string
+  rawStringBody?: boolean
+  binaryResponse?: boolean
+  accept?: string
+  retry?: boolean
+}
+
+const NETWORK_ERROR_PATTERN = /\[NER\]|\[NTI]|ECONNRESET|ETIMEDOUT|socket hang up/i
+const MAX_ATTEMPTS = 3
+
+const makeUrl = (path: string, query: RequestOptions['query']): string => {
+  const values = query ?? {}
+  const parameters = Object.keys(values)
+    .filter((key) => values[key] !== undefined)
+    .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(String(values[key]))}`)
+    .join('&')
+
+  return `${BASE_API_URL}${path}${parameters.length > 0 ? `?${parameters}` : ''}`
+}
+
+export const fetchApi = async <T>(path: string, options: RequestOptions = {}): Promise<ApiResponse<T>> => {
+  const headers: Record<string, string> = {
+    Accept: options.accept ?? 'application/json, text/plain, */*',
+    'Content-Type': 'application/json;',
+    'Platform-Type': 'MOBILE',
+    'X-Timezone': 'Europe/Minsk'
+  }
+
+  if (options.sessionToken != null) {
+    headers.Authorization = `${options.tokenType ?? 'Bearer'} ${options.sessionToken}`
+  }
+
+  const maxAttempts = options.retry === false ? 1 : MAX_ATTEMPTS
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await (options.binaryResponse === true ? fetch : fetchJson)(makeUrl(path, options.query), {
+        method: options.method ?? 'GET',
+        headers,
+        body: options.body,
+        stringify: options.rawStringBody === true ? (body: unknown): string => String(body) : JSON.stringify,
+        binaryResponse: options.binaryResponse,
+        log: false,
+        sanitizeRequestLog: {
+          headers: {
+            Authorization: true
+          },
+          body: {
+            login: true,
+            mobilePhone: true,
+            password: true,
+            code: true,
+            codeWord: true,
+            token: true,
+            refreshToken: true,
+            deviceUid: true
+          }
+        },
+        sanitizeResponseLog: {
+          body: {
+            sessionToken: true,
+            token: true,
+            refreshToken: true
+          }
+        }
+      })
+
+      if (response.status < 500 || attempt === maxAttempts) {
+        return {
+          status: response.status,
+          body: response.body as T
+        }
+      }
+    } catch (error) {
+      if (!(error instanceof Error) || !NETWORK_ERROR_PATTERN.test(error.message)) {
+        throw error
+      }
+      if (attempt === maxAttempts) break
+    }
+  }
+
+  console.error('[BELARUSBANK:API] Request failed after retries')
+  throw new TemporaryUnavailableError()
+}

--- a/src/plugins/belarusbank/helpers.ts
+++ b/src/plugins/belarusbank/helpers.ts
@@ -1,0 +1,79 @@
+import codeToCurrencyLookup from '../../common/codeToCurrencyLookup'
+
+export const asNonEmptyString = (value: unknown): string | null => {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+
+  const result = String(value).trim()
+  return result.length > 0 ? result : null
+}
+
+export const normalizeCurrency = (value: unknown): string => {
+  const currency = asNonEmptyString(value)
+  if (currency == null) throw new Error('Currency is missing')
+
+  const normalized = currency.toUpperCase()
+  if (/^[A-Z]{3}$/.test(normalized)) return normalized
+
+  const byNumericCode = codeToCurrencyLookup[normalized]
+  if (byNumericCode != null) return byNumericCode
+
+  throw new Error(`Unknown currency: ${currency}`)
+}
+
+export const uniqueStrings = (values: unknown[]): string[] =>
+  Array.from(new Set(values.map(asNonEmptyString).filter((value): value is string => value != null)))
+
+export const parseDate = (value: unknown, fallback: Date): Date => {
+  if (typeof value !== 'string' && typeof value !== 'number') return fallback
+
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? fallback : date
+}
+
+export const parseRequiredDate = (value: unknown, fieldName: string): Date => {
+  const date = parseDate(value, new Date(Number.NaN))
+  if (Number.isNaN(date.getTime())) throw new Error(`Invalid ${fieldName}`)
+  return date
+}
+
+const LOCAL_DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/
+
+/** Parses a Belarusbank timestamp without an explicit offset as Minsk local time. */
+export const parseMinskDate = (value: unknown, fieldName: string): Date => {
+  const normalizedValue = typeof value === 'string' && LOCAL_DATE_TIME_PATTERN.test(value.trim())
+    ? `${value.trim()}+03:00`
+    : value
+
+  return parseRequiredDate(normalizedValue, fieldName)
+}
+
+export const toNumber = (value: unknown, fallback: number): number => {
+  if (typeof value !== 'string' && typeof value !== 'number') return fallback
+
+  const result = Number(String(value).replace(',', '.'))
+  return Number.isFinite(result) ? result : fallback
+}
+
+export const toOptionalNumber = (value: unknown): number | null => {
+  const result = toNumber(value, Number.NaN)
+  return Number.isNaN(result) ? null : result
+}
+
+export const isArchived = (status: unknown): boolean | undefined => {
+  if (typeof status === 'boolean') return status
+
+  const value = asNonEmptyString(status)
+  if (value == null) return undefined
+
+  if (/^-?\d+$/.test(value)) return Number(value) === -1
+
+  return !/(?:ACTIVE|OPEN|ДЕЙСТВ|АКТИВ)/i.test(value)
+}
+
+export const getLastCardDigits = (value: unknown): string | null => {
+  const cardPan = asNonEmptyString(value)
+  if (cardPan == null) return null
+
+  const digits = cardPan.replace(/\D/g, '')
+  return digits.length >= 4 ? digits.slice(-4) : null
+}

--- a/src/plugins/belarusbank/index.ts
+++ b/src/plugins/belarusbank/index.ts
@@ -1,0 +1,163 @@
+import md5 from 'crypto-js/md5'
+import { adjustTransactions } from '../../common/transactionGroupHandler'
+import type { ExtendedTransaction, ScrapeFunc } from '../../types/zenmoney'
+import { authenticate, getGeneralPaymentHistory, getProducts, getStatementTransactions } from './api'
+import type { PreferenceInput } from './models'
+
+const PAYMENT_DUPLICATE_WINDOW_MS = 0
+const LEGACY_TRANSACTION_ID_STATE_KEY = 'belarusbankTransactionIds'
+
+interface CanonicalTransactionIdentity {
+  id: string
+  key: string
+  transaction: ExtendedTransaction
+}
+
+const clearLegacyTransactionIdState = (): void => {
+  if (ZenMoney.getData(LEGACY_TRANSACTION_ID_STATE_KEY, undefined) === undefined) return
+
+  ZenMoney.setData(LEGACY_TRANSACTION_ID_STATE_KEY, undefined)
+  ZenMoney.saveData()
+}
+
+const getCanonicalTransactionIdentity = (
+  transaction: ExtendedTransaction,
+  accountInstruments: Map<string, string>
+): CanonicalTransactionIdentity | null => {
+  if (transaction.movements.length !== 1) return null
+
+  const movement = transaction.movements[0]
+  if (!('id' in movement.account) || movement.sum == null) return null
+  const instrument = accountInstruments.get(movement.account.id)
+  if (instrument == null) return null
+
+  const key = JSON.stringify({
+    accountId: movement.account.id,
+    date: transaction.date.toISOString(),
+    amountInMinorUnits: Math.round(movement.sum * 100),
+    instrument
+  })
+  return {
+    id: md5(`belarusbank:${key}`).toString(),
+    key,
+    transaction
+  }
+}
+
+const assignCanonicalTransactionIds = (
+  transactions: ExtendedTransaction[],
+  accountInstruments: Map<string, string>
+): void => {
+  const groups = new Map<string, CanonicalTransactionIdentity[]>()
+  for (const transaction of transactions) {
+    const identity = getCanonicalTransactionIdentity(transaction, accountInstruments)
+    if (identity == null) continue
+    const group = groups.get(identity.key) ?? []
+    group.push(identity)
+    groups.set(identity.key, group)
+  }
+
+  for (const group of groups.values()) {
+    // An ambiguous same-second/same-amount group cannot be matched safely across sources.
+    // Keep its source-specific unique IDs instead of collapsing legitimate operations.
+    if (group.length !== 1) continue
+    group[0].transaction.movements[0].id = group[0].id
+  }
+}
+
+interface StatementMovementMatch {
+  statementIndex: number
+  movementIndex: number
+}
+
+const findStatementMovementMatch = (
+  payment: ExtendedTransaction,
+  statementTransactions: ExtendedTransaction[],
+  matchedStatementMovements: Set<string>
+): StatementMovementMatch | null => {
+  if (payment.movements.length !== 1) return null
+  const paymentMovement = payment.movements[0]
+  const paymentAccountId = 'id' in paymentMovement.account ? paymentMovement.account.id : null
+  const paymentSum = paymentMovement.sum
+  if (paymentAccountId == null || paymentSum == null) return null
+  const matches: StatementMovementMatch[] = []
+
+  for (let statementIndex = 0; statementIndex < statementTransactions.length; statementIndex += 1) {
+    const transaction = statementTransactions[statementIndex]
+    if (Math.abs(transaction.date.getTime() - payment.date.getTime()) > PAYMENT_DUPLICATE_WINDOW_MS) continue
+
+    for (let movementIndex = 0; movementIndex < transaction.movements.length; movementIndex += 1) {
+      const matchKey = `${statementIndex}:${movementIndex}`
+      if (matchedStatementMovements.has(matchKey)) continue
+
+      const movement = transaction.movements[movementIndex]
+      if (
+        'id' in movement.account &&
+        movement.account.id === paymentAccountId &&
+        movement.sum != null &&
+        Math.abs(movement.sum - paymentSum) < 0.005
+      ) {
+        matches.push({ statementIndex, movementIndex })
+      }
+    }
+  }
+
+  return matches.length === 1 ? matches[0] : null
+}
+
+const mergeStatementAndPaymentHistory = (
+  statementTransactions: ExtendedTransaction[],
+  paymentHistory: ExtendedTransaction[]
+): ExtendedTransaction[] => {
+  const matchedStatementMovements = new Set<string>()
+  const unmatchedPayments: ExtendedTransaction[] = []
+
+  for (const payment of paymentHistory) {
+    const match = findStatementMovementMatch(payment, statementTransactions, matchedStatementMovements)
+    if (match == null) {
+      unmatchedPayments.push(payment)
+      continue
+    }
+
+    matchedStatementMovements.add(`${match.statementIndex}:${match.movementIndex}`)
+  }
+
+  return [...statementTransactions, ...unmatchedPayments]
+}
+
+export const scrape: ScrapeFunc<PreferenceInput> = async ({ preferences, fromDate, toDate, isInBackground }) => {
+  clearLegacyTransactionIdState()
+  const auth = await authenticate(preferences, isInBackground)
+  console.log('[BELARUSBANK:AUTH] Success')
+
+  const products = await getProducts(auth)
+  console.log('[BELARUSBANK:PRODUCTS] Successfully fetched', products.length, 'product(s)')
+
+  const transactions: ExtendedTransaction[] = []
+  const transactionEndDate = toDate ?? new Date()
+  const cards = products.filter((product) =>
+    product._meta.productKind === 'card' && !ZenMoney.isAccountSkipped(product.id)
+  )
+  const statementTransactions: ExtendedTransaction[] = []
+
+  for (const card of cards) {
+    statementTransactions.push(...await getStatementTransactions(auth, card, fromDate, transactionEndDate))
+  }
+  const paymentHistory = await getGeneralPaymentHistory(auth, cards, fromDate, transactionEndDate)
+  const accountInstruments = new Map(products.map((product) => [product.id, product.instrument]))
+  assignCanonicalTransactionIds(statementTransactions, accountInstruments)
+  assignCanonicalTransactionIds(paymentHistory, accountInstruments)
+  transactions.push(...mergeStatementAndPaymentHistory(statementTransactions, paymentHistory))
+
+  const adjustedTransactions = adjustTransactions({ transactions })
+  for (const transaction of adjustedTransactions) {
+    if (transaction.movements.length !== 2) continue
+    transaction.movements[0].invoice = null
+    transaction.movements[1].invoice = null
+  }
+
+  return {
+    accounts: products,
+    transactions: adjustedTransactions
+  }
+}

--- a/src/plugins/belarusbank/models.ts
+++ b/src/plugins/belarusbank/models.ts
@@ -1,0 +1,31 @@
+import type { Account } from '../../types/zenmoney'
+
+export const BASE_API_URL = 'https://mb.asb.by/ibanking/'
+export const APP_VERSION = '2026.3.0'
+export const AUTH_DATA_KEY = 'belarusbankAuth'
+export const DEVICE_UID_DATA_KEY = 'belarusbankDeviceUid'
+
+export interface PreferenceInput {
+  login: string
+  password: string
+}
+
+export interface AuthState {
+  login: string
+  sessionToken: string
+  refreshToken: string
+  tokenType: string
+}
+
+export type ProductKind = 'card' | 'account' | 'deposit' | 'credit'
+
+export interface ProductMeta {
+  productId: string
+  transactionCardId: string | null
+  statementProductId: string | null
+  cardTransactionsAllowed?: boolean
+  cardStatementAllowed?: boolean
+  productKind: ProductKind
+}
+
+export type ProductAccount = Account & { _meta: ProductMeta }

--- a/src/plugins/belarusbank/preferences.xml
+++ b/src/plugins/belarusbank/preferences.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="login"
+        obligatory="true"
+        title="Логин или номер телефона"
+        dialogTitle="Логин или номер телефона от приложения Беларусбанк"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||{@s}"
+    />
+    <EditTextPreference
+        key="password"
+        obligatory="true"
+        inputType="textPassword"
+        title="Пароль"
+        dialogTitle="Пароль от приложения Беларусбанк"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||***********"
+    />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="С какой даты загружать операции"
+        defaultValue="2025-01-01T00:00:00.000Z"
+        dialogTitle="С какой даты загружать операции"
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    />
+</PreferenceScreen>

--- a/src/plugins/belarusbank/statement.ts
+++ b/src/plugins/belarusbank/statement.ts
@@ -1,0 +1,180 @@
+import md5 from 'crypto-js/md5'
+import type { ExtendedTransaction } from '../../types/zenmoney'
+import { normalizeCurrency } from './helpers'
+import type { ProductAccount } from './models'
+
+const DATE_PATTERN = '(\\d{2}\\.\\d{2}\\.\\d{4})'
+const TIME_PATTERN = /^\d{2}:\d{2}:\d{2}$/
+const STANDARD_DATE_PATTERN = new RegExp(`^${DATE_PATTERN}$`)
+const BOOKING_LINE_PATTERN = new RegExp(`^${DATE_PATTERN}(.+)$`)
+const INLINE_DATE_PATTERN = new RegExp(`^${DATE_PATTERN}\\s+${DATE_PATTERN}(.+)$`)
+const AMOUNT_LINE_PATTERN = /^([\d ]+,\d{2})\s*([A-Z]{3})\s*([+-]?[\d ]+,\d{2})\s*(-?[\d ]+,\d{2})(.*)$/
+const CARD_NUMBER_PATTERN = /^\d{4}\*{3}\d{4}$/
+const P2P_DESCRIPTION_PATTERN = /\b(?:PERSON TO PERSON|P2P)\b/i
+
+interface StatementEntryStart {
+  index: number
+  operationDate: string
+  time: string | null
+  bookingDate: string
+  amountPayload: string
+  descriptionStartIndex: number
+}
+
+interface ParsedAmountLine {
+  transactionAmount: number
+  transactionCurrency: string
+  accountAmount: number
+  accountAmountIsCredit: boolean
+  inlineDescription: string
+}
+
+const parseMoney = (value: string): number => Number(value.replace(/\s/g, '').replace(',', '.'))
+
+const parseAmountLine = (value: string): ParsedAmountLine | null => {
+  const match = AMOUNT_LINE_PATTERN.exec(value.trim())
+  if (match == null) return null
+
+  const transactionAmount = parseMoney(match[1])
+  const accountAmount = parseMoney(match[3])
+  if (!Number.isFinite(transactionAmount) || !Number.isFinite(accountAmount)) return null
+
+  return {
+    transactionAmount,
+    transactionCurrency: normalizeCurrency(match[2]),
+    accountAmount,
+    accountAmountIsCredit: match[3].startsWith('+'),
+    inlineDescription: match[5].trim()
+  }
+}
+
+const findEntryStarts = (lines: string[]): StatementEntryStart[] => {
+  const starts: StatementEntryStart[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const standardDate = STANDARD_DATE_PATTERN.exec(lines[index])
+    const bookingLine = BOOKING_LINE_PATTERN.exec(lines[index + 2] ?? '')
+    if (standardDate != null && TIME_PATTERN.test(lines[index + 1] ?? '') && bookingLine != null) {
+      starts.push({
+        index,
+        operationDate: standardDate[1],
+        time: lines[index + 1],
+        bookingDate: bookingLine[1],
+        amountPayload: bookingLine[2],
+        descriptionStartIndex: index + 3
+      })
+      index += 2
+      continue
+    }
+
+    const inlineDate = INLINE_DATE_PATTERN.exec(lines[index])
+    if (inlineDate != null) {
+      starts.push({
+        index,
+        operationDate: inlineDate[1],
+        time: null,
+        bookingDate: inlineDate[2],
+        amountPayload: inlineDate[3],
+        descriptionStartIndex: index + 1
+      })
+    }
+  }
+
+  return starts
+}
+
+const cleanDescription = (lines: string[], inlineDescription: string): string | null => {
+  const result: string[] = inlineDescription.length > 0 ? [inlineDescription] : []
+  let skippingTableHeader = false
+
+  for (const line of lines) {
+    if (line === 'Дата и') {
+      skippingTableHeader = true
+      continue
+    }
+    if (skippingTableHeader) {
+      if (line === 'Номер карты') skippingTableHeader = false
+      continue
+    }
+    if (TIME_PATTERN.test(line) || CARD_NUMBER_PATTERN.test(line) || line.startsWith('Реквизиты банка:')) continue
+    if (line.startsWith('No расчетного счета') || line.startsWith('БИК ') || line.startsWith('УНП ')) continue
+    if (line.length > 0) result.push(line)
+  }
+
+  const description = result.join(' ').replace(/\s+/g, ' ').trim()
+  return description.length > 0 ? description : null
+}
+
+const parseStatementDate = (date: string, time: string): Date => {
+  const [day, month, year] = date.split('.')
+  const result = new Date(`${year}-${month}-${day}T${time}+03:00`)
+  if (!Number.isFinite(result.getTime())) throw new Error(`Invalid Belarusbank statement date: ${date} ${time}`)
+  return result
+}
+
+/** Converts the text layer of an official Belarusbank account statement to posted transactions. */
+export const parseStatementTransactions = (text: string, account: ProductAccount): ExtendedTransaction[] => {
+  const lines = text
+    .replace(/\r/g, '')
+    .replace(/\u00a0/g, ' ')
+    .split('\n')
+    .map((line) => line.trim())
+  const starts = findEntryStarts(lines)
+  const transactions: ExtendedTransaction[] = []
+  const identityOccurrences = new Map<string, number>()
+
+  for (let entryIndex = 0; entryIndex < starts.length; entryIndex += 1) {
+    const entry = starts[entryIndex]
+    const amount = parseAmountLine(entry.amountPayload)
+    if (amount == null || amount.accountAmount === 0) continue
+
+    const endIndex = starts[entryIndex + 1]?.index ?? lines.length
+    const descriptionLines = lines.slice(entry.descriptionStartIndex, endIndex)
+    const time = entry.time ?? descriptionLines.find((line) => TIME_PATTERN.test(line))
+    if (time == null) continue
+
+    const date = parseStatementDate(entry.operationDate, time)
+    const sign = amount.accountAmountIsCredit ? 1 : -1
+    const sum = Math.abs(amount.accountAmount) * sign
+    const invoiceSum = Math.abs(amount.transactionAmount) * sign
+    const comment = cleanDescription(descriptionLines, amount.inlineDescription)
+    const groupKeys = comment != null && P2P_DESCRIPTION_PATTERN.test(comment)
+      ? [`belarusbank:p2p:${date.toISOString()}:${amount.transactionCurrency}:${Math.abs(invoiceSum).toFixed(2)}`]
+      : undefined
+    const identity = JSON.stringify({
+      accountId: account.id,
+      operationDate: entry.operationDate,
+      time,
+      bookingDate: entry.bookingDate,
+      sum,
+      transactionCurrency: amount.transactionCurrency,
+      transactionAmount: invoiceSum,
+      comment
+    })
+    const occurrence = identityOccurrences.get(identity) ?? 0
+    identityOccurrences.set(identity, occurrence + 1)
+    const id = md5(JSON.stringify({ identity, occurrence })).toString()
+
+    transactions.push({
+      hold: false,
+      date,
+      groupKeys,
+      comment,
+      movements: [{
+        id,
+        account: { id: account.id },
+        fee: 0,
+        invoice: amount.transactionCurrency !== account.instrument
+          ? {
+              sum: invoiceSum,
+              instrument: amount.transactionCurrency
+            }
+          : null,
+        sum
+      }],
+      merchant: null
+    })
+  }
+
+  return transactions
+}

--- a/src/plugins/belarusbank/types/fetch.ts
+++ b/src/plugins/belarusbank/types/fetch.ts
@@ -1,0 +1,165 @@
+export interface ErrorInfo {
+  code?: string | number
+  errorText?: string
+  errorDescription?: string
+}
+
+export interface ErrorResponse {
+  errorInfo?: ErrorInfo
+  error?: {
+    errorInfo?: ErrorInfo
+  }
+}
+
+export interface LoginRequest {
+  appVersion: string
+  deviceModel: string
+  deviceUid: string
+  login?: string
+  mobilePhone?: string
+  osType: string
+  osVersion: string
+  password: string
+  token: string
+}
+
+export interface LoginPreparationResponse extends ErrorResponse {
+  requestId: string
+  sendCodeResponse?: unknown
+  needCodeWord?: boolean
+}
+
+export interface LoginResponse extends ErrorResponse {
+  sessionToken?: string
+  token?: string
+  refreshToken?: string
+  firstName?: string
+  tokenType?: string
+}
+
+export type ApiMoney = string | number
+
+export interface Card {
+  productId: string | number
+  productCardId?: string | number
+  cardPAN?: string
+  cardProductKindName?: string
+  name?: string
+  expiryDate?: string
+  amount?: ApiMoney
+  currencyIso?: string | number
+  ibanNum?: string
+  cardAccountNumber?: string
+  contractNumber?: string
+  status?: string | number
+  isArchived?: boolean
+  blocked?: boolean
+  temporarilyBlocked?: boolean
+  isOrdered?: boolean
+  markBalance?: boolean
+  viewRights?: string
+  serviceRights?: string
+  userErrorHintMessages?: Record<string, string>
+}
+
+export interface CardsResponse extends ErrorResponse {
+  cards?: Card[]
+}
+
+export interface BankAccount extends ErrorResponse {
+  productId: string | number
+  name?: string
+  ibanNum?: string
+  contractCurrency?: string
+  contractCurrencyIso?: string | number
+  contractCurrentRest?: ApiMoney
+  contractNumber?: string
+  contractKindName?: string
+  status?: string | number
+  statusName?: string
+  isArchived?: boolean
+  contractOpenDate?: string
+  contractCloseDate?: string
+  contractEndDate?: string
+  returnDate?: string
+  percRate?: ApiMoney
+  markBalance?: boolean
+}
+
+export interface AccountsResponse extends ErrorResponse {
+  accounts?: BankAccount[]
+}
+
+export interface Credit extends ErrorResponse {
+  productId: string | number
+  name?: string
+  ibanNum?: string
+  contractNumber?: string
+  contractCurrency?: string
+  contractCurrencyIso?: string | number
+  contractFirstSum?: ApiMoney
+  percRate?: ApiMoney
+  restCredit?: ApiMoney
+  restPerc?: ApiMoney
+  restOverdue?: ApiMoney
+  percSumForClose?: ApiMoney
+  contractOpenDate?: string
+  returnDate?: string
+  status?: string | number
+  statusName?: string
+  isArchived?: boolean
+  markBalance?: boolean
+}
+
+export interface CreditsResponse extends ErrorResponse {
+  credits?: Credit[]
+}
+
+export type OperationDirection = 'debit' | 'credit' | 'DEBIT' | 'CREDIT'
+
+export interface CardTransaction {
+  id: string | number
+  transactionDescription?: string
+  operationDirection: OperationDirection
+  amount: ApiMoney
+  currency?: string | number
+  amountInAccountCurrency?: ApiMoney
+  accountCurrency?: string | number
+  authorizationDate: string
+  accountNumber?: string
+  transactionType?: string
+  mcc?: string | number
+  terminalAddress?: string
+  merchantCountry?: string
+  merchantCity?: string
+  merchantName?: string
+  rrn?: string
+}
+
+export interface CardTransactionsResponse extends ErrorResponse {
+  dataTable?: CardTransaction[]
+  total?: number
+}
+
+export interface PaymentHistoryItem {
+  id: string | number
+  paymentName?: string
+  amount: ApiMoney
+  feeAmount?: ApiMoney
+  currency?: string | number
+  time: string
+  cardNumber?: string
+  cardAccount?: string
+  channelTypeId?: string | number
+  rrn?: string | number
+  approvalId?: string | number
+  paymentId?: string | number
+  paymentIdLeaf?: string | number
+  statusType?: string
+  timeBpc?: string
+}
+
+export interface PaymentHistoryResponse extends ErrorResponse {
+  dataTable?: PaymentHistoryItem[]
+  total?: number
+}


### PR DESCRIPTION
## Summary

- add a Belarusbank plugin using the official mobile banking API
- support cards, accounts, deposits, credits, and card transactions
- persist and rotate sessions, with trusted no-SMS re-login after token expiry
- enforce the bank transaction-history limits of 30 dates per request and a 90-date lookback
- prevent authentication secrets from being written to request or response logs

## Verification

- yarn jest src/plugins/belarusbank --runInBand (21 tests)
- yarn ts-standard src/plugins/belarusbank/**/*.ts
- scoped TypeScript compilation
- production webpack build
- live Opera flow against https://mb.asb.by/ibanking/: initial SMS enrollment, saved session, expired-token no-SMS re-login, products and transactions