### PR TITLE
fix(bnbank): stabilize transaction synchronization

### DIFF
--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>8</build>
+    <build>9</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -68,7 +68,7 @@ describe('Iskra API', () => {
     })
     const [, refreshRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/oauth/refresh`)
     expect(refreshRequest.headers).toMatchObject({
-      'user-agent': 'Android/GOOGLE/16/samsung/SM-S948B/1.8.3',
+      'user-agent': 'Android/GOOGLE/16/samsung/SM-S948B/1.9.0',
       'accept-language': 'RU'
     })
     expect(pluginData.saveDataRequested).toBe(true)
@@ -429,6 +429,187 @@ describe('Iskra API', () => {
       },
       pagination: { limit: 20, offset: 20 }
     }])
+  })
+
+  it('restarts pagination when pages overlap and returns a stable snapshot', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({ id: `operation-${index}` }))
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-19' }], totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-20' }], totalCount: 21 }
+    }, { method: 'POST' })
+
+    const result = await fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )
+
+    expect(result.map(operation => operation.id)).toEqual(
+      Array.from({ length: 21 }, (_, index) => `operation-${index}`)
+    )
+    const requestOffsets = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)
+      .map(([, options]) => JSON.parse(options.body).pagination.offset)
+    expect(requestOffsets).toEqual([0, 20, 0, 20])
+  })
+
+  it('detects overlapping ACCOUNT operations when only the volatile UUID suffix changes', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const stablePrefix = '123456789'
+    const firstPage = [
+      ...Array.from({ length: 19 }, (_, index) => ({ id: `operation-${index}` })),
+      {
+        id: `${stablePrefix}_11111111-1111-4111-8111-111111111111`,
+        idType: 'actionId',
+        productId: 'account-1',
+        productType: 'ACCOUNT'
+      }
+    ]
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: {
+        operations: [{
+          id: `${stablePrefix}_22222222-2222-4222-8222-222222222222`,
+          idType: 'actionId',
+          productId: 'account-1',
+          productType: 'ACCOUNT'
+        }],
+        totalCount: 21
+      }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-20' }], totalCount: 21 }
+    }, { method: 'POST' })
+
+    const result = await fetchTransactions(
+      'access-token',
+      [{ id: 'account-1', type: 'checking' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )
+
+    expect(result).toHaveLength(21)
+    expect(result[result.length - 1].id).toBe('operation-20')
+    const requestOffsets = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)
+      .map(([, options]) => JSON.parse(options.body).pagination.offset)
+    expect(requestOffsets).toEqual([0, 20, 0, 20])
+  })
+
+  it('restarts pagination when totalCount changes between pages', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({ id: `operation-${index}` }))
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-20' }], totalCount: 22 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-20' }], totalCount: 21 }
+    }, { method: 'POST' })
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )).resolves.toHaveLength(21)
+    const requestOffsets = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)
+      .map(([, options]) => JSON.parse(options.body).pagination.offset)
+    expect(requestOffsets).toEqual([0, 20, 0, 20])
+  })
+
+  it('fails instead of returning duplicate or incomplete operations after two unstable snapshots', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({ id: `operation-${index}` }))
+    for (let attempt = 0; attempt < 2; attempt++) {
+      fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+        status: 200,
+        body: { operations: firstPage, totalCount: 21 }
+      }, { method: 'POST' })
+      fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+        status: 200,
+        body: { operations: [{ id: 'operation-19' }], totalCount: 21 }
+      }, { method: 'POST' })
+    }
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
+    expect(fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)).toHaveLength(4)
+  })
+
+  it.each([undefined, '', '   '])('fails instead of accepting an operation with bank identifier %p', async id => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    for (let attempt = 0; attempt < 2; attempt++) {
+      fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+        status: 200,
+        body: {
+          operations: [{ id, productId: 'card-1', productType: 'CARD' }],
+          totalCount: 1
+        }
+      }, { method: 'POST' })
+    }
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
+    expect(fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)).toHaveLength(2)
   })
 
   it('refreshes an expired bearer token and retries a protected request once', async () => {

--- a/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
+++ b/src/plugins/bnbank/__tests__/converters/transactions/iskra.test.js
@@ -56,6 +56,33 @@ describe('Iskra transactions', () => {
     expect(transaction.date).toEqual(new Date('2026-07-27T15:45:00.000Z'))
   })
 
+  it('falls back to operationDate when paymentDate is malformed', () => {
+    const transaction = convertTransaction(makeOperation({
+      paymentDate: '-',
+      operationDetail: {
+        statusCode: 'EXECUTED',
+        operationDate: '2026-07-28T09:00:00+03:00'
+      }
+    }), accounts)
+
+    expect(transaction.date).toEqual(new Date('2026-07-28T06:00:00.000Z'))
+  })
+
+  it('uses operationSum when transactionSum is absent', () => {
+    const transaction = convertTransaction(makeOperation({
+      operationSum: { amount: '32.15', currency: 'BYN', sign: 'MINUS' },
+      transactionSum: null
+    }), accounts)
+
+    expect(transaction).toMatchObject({
+      movements: [{
+        account: { id: 'card-1' },
+        sum: -32.15,
+        invoice: null
+      }]
+    })
+  })
+
   it('uses the API operation type and id instead of a reusable authorization code', () => {
     const transaction = convertTransaction(makeOperation({
       idType: 'CARD_OPERATION',

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -3,8 +3,9 @@ import { generateRandomString } from '../../common/utils'
 import { InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../errors'
 
 const BASE_URL = 'https://bnb-mobile.bnb.by/'
-const APP_VERSION = '1.8.3'
+const APP_VERSION = '1.9.0'
 const PAGE_SIZE = 20
+const MAX_TRANSACTION_SNAPSHOT_ATTEMPTS = 2
 const DEVICE_KEY = 'device'
 const AUTH_KEY = 'auth'
 const TRUSTED_DEVICE_STATUS = 'TRUSTED'
@@ -562,30 +563,32 @@ function toIskraProductType (account) {
   }
 }
 
-/**
- * Fetches every operation in the requested interval using offset pagination.
- */
-export async function fetchTransactions (accessToken, accounts, fromDate, toDate = new Date()) {
-  console.log('>>> Загрузка списка транзакций...')
-  const productTypes = accounts
-    .map(account => ({ id: account.id, type: toIskraProductType(account) }))
-    .filter(product => product.type)
-  if (productTypes.length === 0) {
-    return []
+function getOperationKey (operation) {
+  if (!operation || typeof operation.id !== 'string' || !operation.id.trim()) return null
+  if (operation.productType === 'ACCOUNT') {
+    const stableActionId = /^([0-9]+)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.exec(operation.id)?.[1]
+    if (stableActionId) {
+      return [operation.productId, operation.productType, stableActionId].join('|')
+    }
   }
+  return [operation.productId, operation.productType, operation.idType, operation.id]
+    .map(value => value == null ? '' : String(value))
+    .join('|')
+}
 
+async function fetchTransactionSnapshot (accessToken, productTypes, dateRange) {
   const operations = []
-  let totalCount = 0
+  const operationKeys = new Set()
+  let totalCount = null
+  let unstable = false
+
   do {
     const response = await fetchApiJson('product-transaction/v1/operations', {
       method: 'POST',
       headers: authHeaders(accessToken),
       body: {
         filter: {
-          date: {
-            till: (toDate || new Date()).toISOString(),
-            from: fromDate.toISOString()
-          },
+          date: dateRange,
           productTypes
         },
         pagination: {
@@ -601,10 +604,54 @@ export async function fetchTransactions (accessToken, accounts, fromDate, toDate
     if (response.operations.length === 0 && responseTotalCount > operations.length) {
       throw new TemporaryError('Банк вернул неполную страницу операций. Повторите синхронизацию позже.')
     }
+    if (totalCount != null && responseTotalCount !== totalCount) {
+      unstable = true
+    }
+    for (const operation of response.operations) {
+      const key = getOperationKey(operation)
+      if (!key || operationKeys.has(key)) {
+        unstable = true
+      } else {
+        operationKeys.add(key)
+      }
+    }
     operations.push(...response.operations)
+    if (operations.length > responseTotalCount) {
+      unstable = true
+    }
     totalCount = responseTotalCount
-  } while (operations.length < totalCount)
+  } while (!unstable && operations.length < totalCount)
 
-  console.log(`>>> Загружено ${operations.length} операций.`)
-  return operations
+  return { operations, unstable }
+}
+
+/**
+ * Fetches every operation in the requested interval using offset pagination and
+ * retries once if the bank changes the result set between pages.
+ */
+export async function fetchTransactions (accessToken, accounts, fromDate, toDate = new Date()) {
+  console.log('>>> Загрузка списка транзакций...')
+  const productTypes = accounts
+    .map(account => ({ id: account.id, type: toIskraProductType(account) }))
+    .filter(product => product.type)
+  if (productTypes.length === 0) {
+    return []
+  }
+
+  const dateRange = {
+    till: (toDate || new Date()).toISOString(),
+    from: fromDate.toISOString()
+  }
+  for (let attempt = 0; attempt < MAX_TRANSACTION_SNAPSHOT_ATTEMPTS; attempt++) {
+    const snapshot = await fetchTransactionSnapshot(accessToken, productTypes, dateRange)
+    if (!snapshot.unstable) {
+      console.log(`>>> Загружено ${snapshot.operations.length} операций.`)
+      return snapshot.operations
+    }
+    if (attempt + 1 < MAX_TRANSACTION_SNAPSHOT_ATTEMPTS) {
+      console.log('>>> Список операций изменился во время загрузки, повторяем...')
+    }
+  }
+
+  throw new TemporaryError('Банк изменил список операций во время загрузки. Повторите синхронизацию позже.')
 }

--- a/src/plugins/bnbank/converters.js
+++ b/src/plugins/bnbank/converters.js
@@ -136,7 +136,7 @@ function convertIskraAccount (json, accountType) {
 }
 
 export function convertTransaction (apiTransaction, accounts, hold = false) {
-  if (apiTransaction.productId && apiTransaction.transactionSum) {
+  if (apiTransaction.productId) {
     return convertIskraTransaction(apiTransaction, accounts)
   }
   if (apiTransaction.accountNumber.length > 16) {
@@ -203,13 +203,20 @@ function convertIskraTransaction (apiTransaction, accounts) {
 
   const operationInstrument = getInstrument(apiTransaction.operationSum?.currency) || account.instrument
   const transactionInstrument = getInstrument(apiTransaction.transactionSum?.currency) || operationInstrument
-  const transactionMoney = { sum: transactionSum, instrument: transactionInstrument }
-  const operationMoney = { sum: operationSum, instrument: operationInstrument }
-  const accountMoney = [transactionMoney, operationMoney].find(money => money.instrument === account.instrument) || transactionMoney
-  const invoiceMoney = [transactionMoney, operationMoney]
+  const moneyCandidates = [
+    apiTransaction.transactionSum ? { sum: transactionSum, instrument: transactionInstrument } : null,
+    apiTransaction.operationSum ? { sum: operationSum, instrument: operationInstrument } : null
+  ].filter(Boolean)
+  const accountMoney = moneyCandidates.find(money => money.instrument === account.instrument && money.sum !== 0) ||
+    moneyCandidates.find(money => money.instrument === account.instrument) ||
+    moneyCandidates.find(money => money.sum !== 0)
+  const invoiceMoney = moneyCandidates
     .find(money => money !== accountMoney && money.instrument !== accountMoney.instrument)
-  const date = new Date(apiTransaction.paymentDate || detail.operationDate)
-  if (Number.isNaN(date.getTime())) return null
+  const date = [apiTransaction.paymentDate, detail.operationDate]
+    .filter(Boolean)
+    .map(value => new Date(value))
+    .find(value => !Number.isNaN(value.getTime()))
+  if (!date) return null
   const invoice = invoiceMoney ? { sum: invoiceMoney.sum, instrument: invoiceMoney.instrument } : null
   const merchantTitle = cleanMerchantTitle(detail.merchantName)
   const { city, country } = parseLocation(apiTransaction)


### PR DESCRIPTION
## Summary

- retry Iskra operation pagination when pages overlap or `totalCount` changes, and fail safely after two unstable snapshots instead of returning duplicate or incomplete data
- detect ACCOUNT overlaps by the existing stable action prefix, including UUID-suffix churn, and reject operations without a usable bank identifier
- convert operations with a missing `transactionSum` from `operationSum` and fall back to a valid `operationDate` only when `paymentDate` is malformed
- update the Iskra user agent to 1.9.0 and bump the plugin build to 9
- keep the established movement ID rules and valid `paymentDate` preference unchanged to avoid another migration

## Verification

- BNB Jest suite: 13 suites, 83 tests passed
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build bnbank`
- independent diff review passed after adding regressions for volatile ACCOUNT IDs and empty identifiers