### PR TITLE
[trading212] fix export timestamp parsing

### DIFF
--- a/src/plugins/trading212/__tests__/convertTransactions.test.ts
+++ b/src/plugins/trading212/__tests__/convertTransactions.test.ts
@@ -106,9 +106,12 @@ describe('convertTransactions', () => {
     expect(result[0].movements[0].account).toEqual({ id: 'acc-1' })
   })
 
-  it('converts current export fields for interest on cash', () => {
+  it.each([
+    '2026-07-18 01:15:00+00:00',
+    '2026-07-18 01:15:00'
+  ])('converts Time (UTC) value %s for interest on cash', (time) => {
     const operations: ExportOperation[] = [
-      { ID: 'interest-001', Action: 'Interest on cash', 'Time (UTC)': '2026-07-18 01:15:00', Total: '2.48', 'Currency (Total)': 'USD' }
+      { ID: 'interest-001', Action: 'Interest on cash', 'Time (UTC)': time, Total: '2.48', 'Currency (Total)': 'USD' }
     ]
     const result = convertTransactions(operations, 'acc-1', 'acc-1-card', defaultPreferences)
 

--- a/src/plugins/trading212/converters.ts
+++ b/src/plugins/trading212/converters.ts
@@ -32,8 +32,8 @@ function convertTransaction (op: ExportOperation, accountId: string, cardId: str
   const isCardDebit = op.Action === 'Card debit'
   const isCardCashback = op.Action === 'Spending cashback' && !preferences.investCashback
   const isCardTransaction = isCardDebit || isCardCashback
-  const time = op['Time (UTC)'] ?? op.Time
-  const date = new Date(op['Time (UTC)'] != null && time != null ? `${time.replace(' ', 'T')}Z` : time ?? '')
+  const time = (op['Time (UTC)'] ?? op.Time)?.replace(' ', 'T')
+  const date = new Date(op['Time (UTC)'] != null && time != null && !/(?:Z|[+-]\d{2}:?\d{2})$/i.test(time) ? `${time}Z` : time ?? '')
   const sum = Number(op.Total ?? op['Gross Total'])
 
   console.log('Converting operation', op)


### PR DESCRIPTION
Trading 212 CSV exports now return Time (UTC) values with an explicit +00:00 offset. The converter previously appended Z unconditionally, producing timestamps such as ...+00:00Z

<details><summary>Screenshots</summary>
<p>
<img width="1260" height="1201" alt="image" src="https://github.com/user-attachments/assets/c740a905-843c-4260-8258-aad8c2ed1481" />

<img width="590" height="541" alt="image" src="https://github.com/user-attachments/assets/ab1adc06-8520-4f60-972d-760263110ba5" />

</p>
</details> 


From their forum - https://community.trading212.com/t/annual-statement-for-tax/90163/15

<img width="832" height="313" alt="image" src="https://github.com/user-attachments/assets/23e3196a-0781-4226-a045-b73d25c644e5" />