### PR TITLE
[pumb] improve authentication diagnostics

### DIFF
--- a/src/plugins/pumb/__tests__/fetchApi.sanitization.test.js
+++ b/src/plugins/pumb/__tests__/fetchApi.sanitization.test.js
@@ -1,4 +1,5 @@
 import { fetchAccounts, fetchAuthenticationByPassword } from '../fetchApi'
+import { TemporaryUnavailableError } from '../../../errors'
 
 function makeResponse (body, headers = {}) {
   const headerEntries = Object.entries(headers)
@@ -22,16 +23,19 @@ function makeResponse (body, headers = {}) {
 
 describe('PUMB network log sanitization', () => {
   let debugSpy
+  let warnSpy
 
   beforeEach(() => {
     global.ZenMoney = {
       device: { model: 'Pixel 8', os: { version: '16' } }
     }
     debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => {
     debugSpy.mockRestore()
+    warnSpy.mockRestore()
     delete global.fetch
   })
 
@@ -67,7 +71,12 @@ describe('PUMB network log sanitization', () => {
         data: null,
         errors: [{
           message: 'Customer 380501234567 request failed',
-          extensions: { code: 'DIAGNOSTIC_ERROR_CODE' }
+          extensions: {
+            classification: 'UnexpectedException',
+            code: 'DIAGNOSTIC_ERROR_CODE',
+            message: 'Phone 380501234567 is unavailable',
+            title: 'Authentication failed'
+          }
         }]
       }))
 
@@ -85,7 +94,7 @@ describe('PUMB network log sanitization', () => {
       sessionId: 'private-session-id',
       device: { deviceId: 'bank-device-id', hardwareID: 'hardware-id-secret' }
     })).rejects.toMatchObject({
-      message: 'Customer <phone> request failed',
+      message: '[HTTP 200, DIAGNOSTIC_ERROR_CODE; extensions=classification|code|message|title; classification=UnexpectedException; code=DIAGNOSTIC_ERROR_CODE] Customer <phone> request failed',
       code: 'DIAGNOSTIC_ERROR_CODE'
     })
 
@@ -120,5 +129,29 @@ describe('PUMB network log sanitization', () => {
     ]) {
       expect(log).toContain(diagnostic)
     }
+  })
+
+  it('turns a bank data-fetching failure into a retryable error without logging credentials', async () => {
+    global.fetch = jest.fn().mockResolvedValue(makeResponse({
+      data: null,
+      errors: [{
+        message: 'Bank backend failed',
+        extensions: { classification: 'DataFetchingException' }
+      }]
+    }))
+
+    await expect(fetchAuthenticationByPassword('380501234567', '1234', {
+      deviceId: 'bank-device-id',
+      hardwareID: 'hardware-id-secret'
+    })).rejects.toBeInstanceOf(TemporaryUnavailableError)
+
+    const log = JSON.stringify(warnSpy.mock.calls)
+    expect(log).toContain('AuthenticationByPasswordV2')
+    expect(log).toContain('DataFetchingException')
+    expect(log).not.toContain('380501234567')
+    expect(log).not.toContain('1234')
+    expect(log).not.toContain('bank-device-id')
+    expect(log).not.toContain('hardware-id-secret')
+    expect(log).not.toContain('Bank backend failed')
   })
 })

--- a/src/plugins/pumb/__tests__/fetchApi.test.js
+++ b/src/plugins/pumb/__tests__/fetchApi.test.js
@@ -75,7 +75,7 @@ describe('PUMB fetch API', () => {
       login: '+380501234567',
       password: 'MTIzNA==',
       deviceId: 'bank-device-id',
-      appVersion: '2.338.05',
+      appVersion: '2.339.05',
       appType: 'A_PROD',
       deviceData: {
         os: 'ANDROID',
@@ -134,7 +134,7 @@ describe('PUMB fetch API', () => {
 
     expect(publicConnection.send.mock.calls[0][1].body).toMatchObject({
       data: {
-        app_version: '2.338.05',
+        app_version: '2.339.05',
         hardware_id: '0123456789abcdef',
         cz: { functional: 'INIT', request: 'IDENTIFY', version: 6 }
       },

--- a/src/plugins/pumb/fetchApi.js
+++ b/src/plugins/pumb/fetchApi.js
@@ -2,8 +2,9 @@ import forge from 'node-forge'
 import { fetch } from '../../common/network'
 import Connection from '../../common/protocols/webSocket'
 import { delay, generateUUID } from '../../common/utils'
+import { TemporaryUnavailableError } from '../../errors'
 
-const APP_VERSION = '2.338.05'
+const APP_VERSION = '2.339.05'
 const GRAPHQL_URL = 'https://mobile.pumb.ua/graphql'
 const WEB_SOCKET_URL = 'wss://mobile.pumb.ua/ws'
 const GRAPHQL_API_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoibW9iaWxlIGFwcCIsImlhdCI6MTY4OTMxODI2Miwic2NvcGUiOlsiYXV0aCIsInNldHRpbmdzLW1ldGFkYXRhIl19.TdQl0F-tudg9-XdnFSyBtT2fopFqtjCNK2tSCNQLkaw'
@@ -151,16 +152,44 @@ function getGraphqlError (response) {
     .find(value => typeof value === 'string' && value)
   const message = [error.message, extension?.message, extension?.title]
     .find(value => typeof value === 'string' && value)
+  const extensionKeys = extension ? Object.keys(extension).sort() : []
+  const originalErrorKeys = originalError ? Object.keys(originalError).sort() : []
+  const diagnosticValues = extension == null
+    ? []
+    : ['classification', 'code']
+        .map(key => {
+          const value = extension[key]
+          if (typeof value !== 'string' || value.trim() === '') return null
+          return `${key}=${sanitizePersonalDataInText(value.trim()).slice(0, 120)}`
+        })
+        .filter(Boolean)
   return {
     code: typeof code === 'string' ? code.toUpperCase() : null,
-    message: typeof message === 'string' ? message : null
+    classification: typeof extension?.classification === 'string' ? extension.classification : null,
+    message: typeof message === 'string' ? message : null,
+    diagnosticKeys: {
+      extensions: extensionKeys,
+      originalError: originalErrorKeys
+    },
+    diagnosticValues
   }
 }
 
 function makeHttpError (response, operationName, graphqlError) {
-  const message = sanitizePersonalDataInText(graphqlError?.message || `PUMB returned HTTP ${response.status}`)
+  const status = Number.isInteger(response.status) ? response.status : 'unknown'
+  const code = graphqlError?.code || null
+  const bankMessage = sanitizePersonalDataInText(graphqlError?.message || 'PUMB returned an unexpected response')
+  const extensionKeys = graphqlError?.diagnosticKeys?.extensions || []
+  const originalErrorKeys = graphqlError?.diagnosticKeys?.originalError || []
+  const diagnosticValues = graphqlError?.diagnosticValues || []
+  const diagnostic = [
+    extensionKeys.length > 0 ? `extensions=${extensionKeys.join('|')}` : null,
+    originalErrorKeys.length > 0 ? `originalError=${originalErrorKeys.join('|')}` : null,
+    ...diagnosticValues
+  ].filter(Boolean).join('; ')
+  const message = `[HTTP ${status}${code ? `, ${code}` : ''}${diagnostic ? `; ${diagnostic}` : ''}] ${bankMessage}`
   const error = new Error(message)
-  error.code = graphqlError?.code || null
+  error.code = code
   error.httpStatus = response.status
   error.operationName = operationName
   return error
@@ -170,6 +199,16 @@ function throwGraphqlError (response, operationName) {
   const graphqlError = getGraphqlError(response)
   if (graphqlError?.code && SESSION_EXPIRED_CODES.has(graphqlError.code)) {
     throw new SessionExpiredError(graphqlError.code, operationName)
+  }
+  if (graphqlError?.classification === 'DataFetchingException') {
+    console.warn('PUMB GraphQL data-fetching failure', {
+      operationName,
+      status: Number.isInteger(response.status) ? response.status : null,
+      code: graphqlError.code,
+      diagnosticKeys: graphqlError.diagnosticKeys,
+      diagnosticValues: graphqlError.diagnosticValues
+    })
+    throw new TemporaryUnavailableError()
   }
   if (response.status < 200 || response.status >= 300 || graphqlError) {
     throw makeHttpError(response, operationName, graphqlError)


### PR DESCRIPTION
## What changed

- update the PUMB mobile client version used by GraphQL and WebSocket requests to 2.339.05;
- classify bank-side `DataFetchingException` failures as retryable temporary errors;
- keep safe GraphQL diagnostic structure and codes while excluding credentials and raw bank error details from logs;
- add regression coverage for authentication diagnostics and log sanitization.

## Context

This is the reviewed plugin-side part of #1137. It does not fabricate or bypass app attestation and does not claim that the current published application runtime can complete cold authentication. The end-to-end flow still needs to be retested after the new ZenMoney application version mentioned by the maintainers is released.

## Verification

- 46 PUMB tests passed;
- changed files pass `ts-standard`;
- author and committer use the GitHub noreply identity.