### PR TITLE
[bnbank] bump app version to 1.9.0

### DIFF
--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -68,7 +68,7 @@ describe('Iskra API', () => {
     })
     const [, refreshRequest] = fetchMock.lastCall(`${BASE_URL}user/v1/oauth/refresh`)
     expect(refreshRequest.headers).toMatchObject({
-      'user-agent': 'Android/GOOGLE/16/samsung/SM-S948B/1.8.3',
+      'user-agent': 'Android/GOOGLE/16/samsung/SM-S948B/1.9.0',
       'accept-language': 'RU'
     })
     expect(pluginData.saveDataRequested).toBe(true)

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -3,7 +3,7 @@ import { generateRandomString } from '../../common/utils'
 import { InvalidOtpCodeError, InvalidPreferencesError, TemporaryError } from '../../errors'
 
 const BASE_URL = 'https://bnb-mobile.bnb.by/'
-const APP_VERSION = '1.8.3'
+const APP_VERSION = '1.9.0'
 const PAGE_SIZE = 20
 const DEVICE_KEY = 'device'
 const AUTH_KEY = 'auth'
@@ -203,7 +203,8 @@ function getUserAgent () {
 }
 
 function getErrorMessage (response) {
-  return response.body?.userMessage || response.body?.message || response.statusText || `HTTP ${response.status}`
+  return response.body?.userMessage || response.body?.message || response.body?.systemMessage ||
+    response.statusText || `HTTP ${response.status}`
 }
 
 function throwApiError (response, url, context) {
@@ -222,6 +223,9 @@ function throwApiError (response, url, context) {
   }
   if (url === 'user/v1/auth' && invalidPreferenceCodes.has(code)) {
     throw new InvalidPreferencesError(message)
+  }
+  if (code === 'APP_VERSION_IS_NOT_SUPPORTED') {
+    throw new TemporaryError(`BNB Iskra больше не поддерживает версию приложения, которую использует плагин. ${bankMessage}`)
   }
   if (blockedUserCodes.has(code)) {
     throw new TemporaryError('BNB Iskra заблокировал доступ к данным. Откройте приложение Iskra и выполните указанные там действия или обратитесь в поддержку BNB, затем повторите синхронизацию.')


### PR DESCRIPTION
## Проблема

БНБ-Банк поднял минимальную версию приложения Iskra до 1.9.0. Плагин отправляет `user-agent: Android/GOOGLE/16/samsung/SM-S948B/1.8.3`, и банк отвечает 426 на любой запрос:

```
[debug] response { id: '0', ms: 429,
  url: 'https://bnb-mobile.bnb.by/user/v1/oauth/refresh',
  status: 426,
  body: { systemMessage: 'Version \'1.8.3\' is not supported. Minimal required version is \'1.9.0\'.',
          code: 'APP_VERSION_IS_NOT_SUPPORTED' } }
[error] bw call rejected with { message: 'Не удалось обновить сессию. Ответ банка: Upgrade Required' }
```

Синхронизация не проходит ни у кого: проверка версии стоит на всех эндпоинтах, не только на обновлении сессии.

## Что сделано

- `APP_VERSION` 1.8.3 → 1.9.0 (текущая версия `com.iskra.mobile` в Google Play).
- `getErrorMessage` дополнительно читает `systemMessage`. Банк кладёт текст именно туда, из-за чего пользователь видел бесполезное «Ответ банка: Upgrade Required» вместо названной требуемой версии.
- Отдельная ветка для кода `APP_VERSION_IS_NOT_SUPPORTED` с понятным сообщением, чтобы следующий такой отказ сразу читался как «плагин устарел».

## Проверка

- `npx jest src/plugins/bnbank` – 13 suites, 74 теста, зелёные.
- `npx ts-standard src/plugins/bnbank` – чисто.