### PR TITLE
[bnbank] reconcile card operation versions

### DIFF
--- a/src/plugins/bnbank/ZenmoneyManifest.xml
+++ b/src/plugins/bnbank/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>bnbank</id>
     <version>1.0</version>
-    <build>9</build>
+    <build>10</build>
     <company>15435</company>
     <modular>true</modular>
     <codeRequired>false</codeRequired>

--- a/src/plugins/bnbank/__tests__/api.test.js
+++ b/src/plugins/bnbank/__tests__/api.test.js
@@ -431,6 +431,196 @@ describe('Iskra API', () => {
     }])
   })
 
+  it('deduplicates repeated RRN versions without treating the result as page movement', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const operations = Array.from({ length: 87 }, (_, index) => ({
+      id: `operation-${index}`,
+      idType: 'rrn',
+      productId: 'card-1',
+      productType: 'CARD',
+      paymentDate: `2026-08-${String((index % 27) + 1).padStart(2, '0')}T12:00:00Z`,
+      operationDetail: { statusCode: 'EXECUTED' }
+    }))
+    operations[79] = {
+      ...operations[79],
+      id: 'shared-rrn',
+      paymentDate: '2026-08-27T16:18:22Z',
+      transactionSum: { amount: '-37.18', currency: 'BYN', sign: 'MINUS' },
+      operationDetail: { statusCode: 'IN_PROGRESS' }
+    }
+    const executedVersion = {
+      ...operations[79],
+      paymentDate: '2026-08-27T16:18:22Z',
+      transactionSum: { amount: '-37.18', currency: 'BYN', sign: 'MINUS' },
+      operationDetail: {
+        statusCode: 'EXECUTED',
+        operationDate: '2026-08-31T13:23:05Z',
+        authorizationCode: '861817'
+      }
+    }
+    const pages = [
+      operations.slice(0, 20),
+      operations.slice(20, 40),
+      operations.slice(40, 60),
+      operations.slice(60, 80),
+      [executedVersion, ...operations.slice(80)]
+    ]
+    for (const page of pages) {
+      fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+        status: 200,
+        body: { operations: page, totalCount: 88 }
+      }, { method: 'POST' })
+    }
+
+    const result = await fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-09-01T00:00:00Z')
+    )
+
+    expect(result).toHaveLength(87)
+    expect(result.filter(operation => operation.id === 'shared-rrn')).toEqual([executedVersion])
+    const requestOffsets = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)
+      .map(([, options]) => JSON.parse(options.body).pagination.offset)
+    expect(requestOffsets).toEqual([0, 20, 40, 60, 80])
+  })
+
+  it('deduplicates an exact repeated row within one page while advancing the raw offset', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const operation = { id: 'operation-0' }
+    const firstPage = [operation, operation, ...Array.from({ length: 18 }, (_, index) => ({ id: `operation-${index + 1}` }))]
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: firstPage, totalCount: 21 }
+    }, { method: 'POST' })
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations: [{ id: 'operation-19' }], totalCount: 21 }
+    }, { method: 'POST' })
+
+    const result = await fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-07-29T00:00:00Z')
+    )
+
+    expect(result.map(item => item.id)).toEqual(
+      Array.from({ length: 20 }, (_, index) => `operation-${index}`)
+    )
+    const requestOffsets = fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)
+      .map(([, options]) => JSON.parse(options.body).pagination.offset)
+    expect(requestOffsets).toEqual([0, 20])
+  })
+
+  it('keeps reused RRN values separate when the card occurrence differs', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const operations = [
+      {
+        id: 'shared-rrn',
+        idType: 'rrn',
+        productId: 'card-1',
+        productType: 'CARD',
+        paymentDate: '2026-08-27T16:18:22Z',
+        transactionSum: { amount: '-37.18', currency: 'BYN', sign: 'MINUS' },
+        operationDetail: { statusCode: 'EXECUTED' }
+      },
+      {
+        id: 'shared-rrn',
+        idType: 'rrn',
+        productId: 'card-1',
+        productType: 'CARD',
+        paymentDate: '2026-08-28T16:18:22Z',
+        transactionSum: { amount: '-12.00', currency: 'BYN', sign: 'MINUS' },
+        operationDetail: { statusCode: 'EXECUTED' }
+      }
+    ]
+    fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+      status: 200,
+      body: { operations, totalCount: 2 }
+    }, { method: 'POST' })
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-09-01T00:00:00Z')
+    )).resolves.toEqual(operations)
+  })
+
+  it('fails safely when terminal versions of the same card occurrence conflict', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const makeVersion = statusCode => ({
+      id: 'shared-rrn',
+      idType: 'rrn',
+      productId: 'card-1',
+      productType: 'CARD',
+      paymentDate: '2026-08-27T16:18:22Z',
+      transactionSum: { amount: '-37.18', currency: 'BYN', sign: 'MINUS' },
+      operationDetail: { statusCode }
+    })
+    for (let attempt = 0; attempt < 2; attempt++) {
+      fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+        status: 200,
+        body: { operations: [makeVersion('EXECUTED'), makeVersion('CANCELLED')], totalCount: 2 }
+      }, { method: 'POST' })
+    }
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-09-01T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
+    expect(fetchMock.calls(`${BASE_URL}product-transaction/v1/operations`)).toHaveLength(2)
+  })
+
+  it('fails safely when repeated card identifiers lack fields required to identify an occurrence', async () => {
+    const pluginData = makePluginDataApi({})
+    global.ZenMoney = {
+      device: { manufacturer: 'Zenmoney', model: 'Sync' },
+      ...pluginData.methods
+    }
+    const makeVersion = statusCode => ({
+      id: 'shared-rrn',
+      idType: 'rrn',
+      productId: 'card-1',
+      productType: 'CARD',
+      paymentDate: '2026-08-27T16:18:22Z',
+      operationDetail: { statusCode }
+    })
+    for (let attempt = 0; attempt < 2; attempt++) {
+      fetchMock.once(`${BASE_URL}product-transaction/v1/operations`, {
+        status: 200,
+        body: { operations: [makeVersion('IN_PROGRESS'), makeVersion('EXECUTED')], totalCount: 2 }
+      }, { method: 'POST' })
+    }
+
+    await expect(fetchTransactions(
+      'access-token',
+      [{ id: 'card-1', type: 'card' }],
+      new Date('2026-07-01T00:00:00Z'),
+      new Date('2026-09-01T00:00:00Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
+  })
+
   it('restarts pagination when pages overlap and returns a stable snapshot', async () => {
     const pluginData = makePluginDataApi({})
     global.ZenMoney = {

--- a/src/plugins/bnbank/api.js
+++ b/src/plugins/bnbank/api.js
@@ -580,9 +580,58 @@ function getOperationKey (operation) {
     .join('|')
 }
 
+function stringifyCanonical (value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stringifyCanonical).join(',')}]`
+  }
+  if (value != null && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stringifyCanonical(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function getOperationVariantKey (operation, operationKey) {
+  return stringifyCanonical({ ...operation, id: operationKey })
+}
+
+function getMoneyKey (money) {
+  if (!money || typeof money !== 'object') return null
+  const amount = money.amount ?? (
+    money.integerPart != null && money.fractionalPart != null
+      ? `${money.sign || ''}:${money.integerPart}:${money.fractionalPart}`
+      : null
+  )
+  if (amount == null) return null
+  return [money.currency, money.sign, amount]
+    .map(value => value == null ? '' : String(value))
+    .join('|')
+}
+
+function getCardOccurrenceKey (operation, operationKey) {
+  if (operation.productType !== 'CARD' || !operation.paymentDate) return null
+  const moneyKey = getMoneyKey(operation.transactionSum) || getMoneyKey(operation.operationSum)
+  if (!moneyKey) return null
+  return [operationKey, operation.paymentDate, moneyKey, operation.operationName]
+    .map(value => value == null ? '' : String(value))
+    .join('|')
+}
+
+function selectCardOperationVersion (previous, next) {
+  const previousStatus = previous.operationDetail?.statusCode
+  const nextStatus = next.operationDetail?.statusCode
+  const terminalStatuses = new Set(['EXECUTED', 'CANCELLED'])
+
+  if (previousStatus === 'IN_PROGRESS' && terminalStatuses.has(nextStatus)) return next
+  if (nextStatus === 'IN_PROGRESS' && terminalStatuses.has(previousStatus)) return previous
+  return null
+}
+
 async function fetchTransactionSnapshot (accessToken, productTypes, dateRange) {
   const operations = []
-  const operationKeys = new Set()
+  const operationVariantPages = new Map()
+  const operationIndexes = new Map()
+  const operationOccurrences = new Map()
+  let rawOperationCount = 0
   let totalCount = null
   let unstable = false
 
@@ -597,7 +646,7 @@ async function fetchTransactionSnapshot (accessToken, productTypes, dateRange) {
         },
         pagination: {
           limit: PAGE_SIZE,
-          offset: operations.length
+          offset: rawOperationCount
         }
       }
     }, 'Не удалось загрузить операции')
@@ -605,33 +654,75 @@ async function fetchTransactionSnapshot (accessToken, productTypes, dateRange) {
     if (!Array.isArray(response?.operations) || !Number.isInteger(responseTotalCount) || responseTotalCount < 0) {
       throw new TemporaryError('Банк вернул некорректный список операций. Повторите синхронизацию позже.')
     }
-    if (response.operations.length === 0 && responseTotalCount > operations.length) {
+    if (response.operations.length === 0 && responseTotalCount > rawOperationCount) {
       throw new TemporaryError('Банк вернул неполную страницу операций. Повторите синхронизацию позже.')
     }
     if (totalCount != null && responseTotalCount !== totalCount) {
       unstable = true
     }
+    const pageOffset = rawOperationCount
     for (const operation of response.operations) {
       const key = getOperationKey(operation)
-      if (!key || operationKeys.has(key)) {
+      if (!key) {
         unstable = true
-      } else {
-        operationKeys.add(key)
+        continue
       }
+
+      const variantKey = getOperationVariantKey(operation, key)
+      const previousVariantPage = operationVariantPages.get(variantKey)
+      if (previousVariantPage != null) {
+        if (previousVariantPage !== pageOffset) {
+          unstable = true
+        }
+        continue
+      }
+      operationVariantPages.set(variantKey, pageOffset)
+
+      const occurrenceKey = getCardOccurrenceKey(operation, key)
+      const previousOccurrences = operationOccurrences.get(key)
+      if (occurrenceKey) {
+        const previousIndex = operationIndexes.get(occurrenceKey)
+        if (previousIndex != null) {
+          const selectedOperation = selectCardOperationVersion(operations[previousIndex], operation)
+          if (selectedOperation) {
+            operations[previousIndex] = selectedOperation
+          } else {
+            unstable = true
+          }
+          continue
+        }
+        if (previousOccurrences?.has(null)) {
+          unstable = true
+          continue
+        }
+        operationIndexes.set(occurrenceKey, operations.length)
+      } else {
+        if (previousOccurrences) {
+          unstable = true
+          continue
+        }
+      }
+      if (previousOccurrences) {
+        previousOccurrences.add(occurrenceKey)
+      } else {
+        operationOccurrences.set(key, new Set([occurrenceKey]))
+      }
+      operations.push(operation)
     }
-    operations.push(...response.operations)
-    if (operations.length > responseTotalCount) {
+    rawOperationCount += response.operations.length
+    if (rawOperationCount > responseTotalCount) {
       unstable = true
     }
     totalCount = responseTotalCount
-  } while (!unstable && operations.length < totalCount)
+  } while (!unstable && rawOperationCount < totalCount)
 
   return { operations, unstable }
 }
 
 /**
- * Fetches every operation in the requested interval using offset pagination and
- * retries once if the bank changes the result set between pages.
+ * Fetches every raw operation in the requested interval using offset pagination,
+ * reconciles card lifecycle versions, and retries once if pages overlap or the
+ * bank changes the result set between pages.
  */
 export async function fetchTransactions (accessToken, accounts, fromDate, toDate = new Date()) {
   console.log('>>> Загрузка списка транзакций...')


### PR DESCRIPTION
## Problem

Iskra can include multiple lifecycle rows for one CARD/RRN operation in `totalCount` (for example, `IN_PROGRESS` and `EXECUTED`). The pagination guard introduced in #1144 treated any repeated logical ID as a shifted page, so a stable 88-row response could be retried and rejected every time.

## Fix

- advance pagination and validate `totalCount` by the raw row count;
- distinguish exact row variants from the logical operation ID;
- reconcile `IN_PROGRESS` with the terminal `EXECUTED`/`CANCELLED` row only when card, RRN, payment date, amount, and operation name identify the same occurrence;
- keep retry/failure behavior for true cross-page overlap, changing totals, missing identity fields, and ambiguous terminal conflicts;
- keep existing movement IDs and date conversion unchanged;
- bump the plugin build from 9 to 10. The Iskra app version remains the current `1.9.0` inherited from master.

## Regression coverage

- production-shaped 88-row/5-page response becomes 87 unique operations with offsets `0, 20, 40, 60, 80` and no retry;
- exact duplicates within a page are collapsed without changing the next offset;
- reused RRN values with different date/amount stay separate;
- conflicting terminal versions fail safely;
- existing overlap, ACCOUNT UUID-suffix, and `totalCount` drift protections remain covered.

## Checks

- `yarn jest src/plugins/bnbank --runInBand` — 13 suites, 88 tests passed
- `yarn lint`
- `yarn tsc --noEmit`
- `yarn build bnbank`
- `git diff --check`