### PR TITLE
[zepterbank-by] Сопоставлять обрезанные названия торговых точек

### DIFF
--- a/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
+++ b/src/plugins/zepterbank-by/__tests__/api/get-transactions.test.ts
@@ -168,6 +168,132 @@ describe('getTransactions', () => {
     ])
   })
 
+  it('deduplicates statement merchants truncated after a safe token prefix', () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const purchases = [
+      { amount: '12.34', effectiveDate: '2026-09-04T19:55:09' },
+      { amount: '56.78', effectiveDate: '2026-09-04T19:45:58' },
+      { amount: '90.12', effectiveDate: '2026-09-04T19:44:18' }
+    ]
+    const historyTransactions = purchases.map(({ amount, effectiveDate }) => convertCardTransaction({
+      effectiveDate,
+      transacName: 'POS PURCHASE ',
+      amount,
+      currencyIso: 'BYN',
+      cardAcceptor: 'SHOP SAMPLE.MARKET LONGNAME',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5411'
+    }, account))
+    const statementTransactions = purchases.map(({ amount }) => convertStatementTransaction({
+      transactionDate: '2026-09-04T00:00:00',
+      balanceDate: '2026-09-07',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: amount,
+      transactionSum: amount,
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'SHOP SAMPLE.MARKET LONGNA',
+      MCC: 'MCC 5411'
+    }, account))
+    const historyOnlyIds = mergeTransactions(historyTransactions, [])
+      .map((transaction) => transaction.movements[0].id)
+
+    const transactions = mergeTransactions(historyTransactions, statementTransactions)
+
+    expect(transactions).toHaveLength(3)
+    expect(transactions.map((transaction) => transaction.movements[0].sum)).toEqual([-12.34, -56.78, -90.12])
+    expect(transactions.map((transaction) => transaction.movements[0].id)).toEqual(historyOnlyIds)
+    expect(transactions.map((transaction) => transaction.merchant)).toEqual(statementTransactions.map((transaction) => transaction.merchant))
+  })
+
+  it('does not deduplicate different merchants with the same transaction identity fields', () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction = convertCardTransaction({
+      effectiveDate: '2026-09-04T19:55:09',
+      transacName: 'POS PURCHASE ',
+      amount: '20.00',
+      currencyIso: 'BYN',
+      cardAcceptor: 'SHOP ALPHA SUPERMARKET',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5411'
+    }, account)
+    const statementTransaction = convertStatementTransaction({
+      transactionDate: '2026-09-04T00:00:00',
+      balanceDate: '2026-09-07',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: '20.00',
+      transactionSum: '20.00',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'SHOP BRAVO SUPERMARKET',
+      MCC: 'MCC 5411'
+    }, account)
+
+    const transactions = mergeTransactions([historyTransaction], [statementTransaction])
+
+    expect(transactions).toHaveLength(2)
+    expect(transactions[0].movements[0].id).not.toBe(transactions[1].movements[0].id)
+  })
+
+  it('does not deduplicate merchants when their shared prefix is too short', () => {
+    const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
+
+    if (rawCardAccount == null) {
+      throw new Error('Card account not found')
+    }
+
+    const account = convertCardAccount(rawCardAccount)
+    const historyTransaction = convertCardTransaction({
+      effectiveDate: '2026-09-04T19:55:09',
+      transacName: 'POS PURCHASE ',
+      amount: '20.00',
+      currencyIso: 'BYN',
+      cardAcceptor: 'SHOP ALPHA',
+      repeatable: false,
+      transOperType: 'debit',
+      transMcc: 'МСС5411'
+    }, account)
+    const statementTransaction = convertStatementTransaction({
+      transactionDate: '2026-09-04T00:00:00',
+      balanceDate: '2026-09-07',
+      operationName: 'Оплата товаров и услуг в устройствах других банков',
+      operationSum: '20.00',
+      transactionSum: '20.00',
+      transactionCurrency: '933',
+      transactionCurrencyISO: 'BYN',
+      operationSign: -1,
+      operationCurrency: '933',
+      operationCurrencyIso: 'BYN',
+      merchant: 'BLR MINSK',
+      terminalLocation: 'SHOP ALPHA EXPRESS',
+      MCC: 'MCC 5411'
+    }, account)
+
+    expect(mergeTransactions([historyTransaction], [statementTransaction])).toHaveLength(2)
+  })
+
   it('deduplicates capitalization rows using statement balance date', async () => {
     const rawCardAccount = TEST_ACCOUNTS.CARD.find((account) => account.productCardId === 'Ch8xqhoVt978H4A8qpjgw4vGkhi9M35r2LL45im8')
 

--- a/src/plugins/zepterbank-by/mergeTransactions.ts
+++ b/src/plugins/zepterbank-by/mergeTransactions.ts
@@ -13,8 +13,19 @@ interface SourcedTransaction {
 
 type TransactionWithDedupDate = Transaction & { dedupDate?: Date }
 
+const MERCHANT_ID_PREFIX_LENGTH = 25
+const SAFE_MERCHANT_PREFIX_MIN_LENGTH = 16
+
 const normalizeText = (text: string | null | undefined): string =>
   (text ?? '').replace(/\s+/g, ' ').trim()
+
+const normalizeMerchant = (text: string | null | undefined): string =>
+  normalizeText(text)
+    .replace(/&quot;/g, '"')
+    .toUpperCase()
+    .split(/[^0-9A-ZА-ЯЁІЎ]+/g)
+    .filter(Boolean)
+    .join(' ')
 
 const getMerchantTitle = (transaction: Transaction): string => {
   const { merchant } = transaction
@@ -64,13 +75,35 @@ const getMccSignature = (transaction: Transaction): string => {
 const getDaySignature = (transaction: Transaction): string =>
   getBusinessDateIdentityKey((transaction as TransactionWithDedupDate).dedupDate ?? transaction.date)
 
-const getDuplicateFingerprint = (transaction: Transaction): string => [
+const getDuplicateBaseFingerprint = (transaction: Transaction): string => [
   getMovementAccountId(transaction),
   getDaySignature(transaction),
   getAmountSignature(transaction),
-  getMccSignature(transaction),
-  normalizeText(getMerchantTitle(transaction))
+  getMccSignature(transaction)
 ].join('|')
+
+const areMerchantTitlesCompatible = (left: Transaction, right: Transaction): boolean => {
+  const leftMerchant = normalizeMerchant(getMerchantTitle(left))
+  const rightMerchant = normalizeMerchant(getMerchantTitle(right))
+
+  if (leftMerchant === rightMerchant) {
+    return true
+  }
+
+  if (leftMerchant === '' || rightMerchant === '') {
+    return false
+  }
+
+  const leftPrefix = leftMerchant.slice(0, MERCHANT_ID_PREFIX_LENGTH)
+  const rightPrefix = rightMerchant.slice(0, MERCHANT_ID_PREFIX_LENGTH)
+
+  if (leftPrefix === rightPrefix) {
+    return true
+  }
+
+  return Math.min(leftMerchant.length, rightMerchant.length) >= SAFE_MERCHANT_PREFIX_MIN_LENGTH &&
+    (leftMerchant.startsWith(rightMerchant) || rightMerchant.startsWith(leftMerchant))
+}
 
 const getStableIdFingerprint = (transaction: Transaction): string => [
   getMovementAccountId(transaction),
@@ -92,7 +125,7 @@ const getPartialSettlementFingerprint = (transaction: Transaction): string => [
   getMovementInstrumentSignature(transaction),
   getMovementDirection(transaction),
   getMccSignature(transaction),
-  normalizeText(getMerchantTitle(transaction)).toUpperCase()
+  normalizeMerchant(getMerchantTitle(transaction)).slice(0, MERCHANT_ID_PREFIX_LENGTH)
 ].join('|')
 
 const getAbsoluteMovementAmount = (transaction: Transaction): number => {
@@ -115,11 +148,12 @@ const isMatchingDuplicate = (left: Transaction, right: Transaction): boolean => 
   const leftId = getMovementId(left)
   const rightId = getMovementId(right)
 
-  if (leftId !== null && rightId !== null) {
-    return leftId === rightId || getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
+  if (leftId !== null && rightId !== null && leftId === rightId) {
+    return true
   }
 
-  return getDuplicateFingerprint(left) === getDuplicateFingerprint(right)
+  return getDuplicateBaseFingerprint(left) === getDuplicateBaseFingerprint(right) &&
+    areMerchantTitlesCompatible(left, right)
 }
 
 const reconcileUnambiguousPartialSettlements = (entries: SourcedTransaction[]): SourcedTransaction[] => {


### PR DESCRIPTION
## Проблема

Zepter Bank может вернуть одну покупку одновременно в карточной мини-истории и в проведённой выписке, обрезав название торговой точки в выписке. Строгое сравнение названий не распознавало такую пару, поэтому плагин экспортировал обе записи.

## Решение

- Названия торговых точек нормализуются в последовательность токенов без учёта регистра и разделителей.
- После обязательного совпадения счёта, банковского дня, суммы со знаком, валюты и MCC допускается совпадение по 25-символьному банковскому префиксу либо по взаимному префиксу длиной не менее 16 символов.
- Та же канонизация применяется к защищённому сопоставлению частичных списаний.
- Финальная схема стабильных 32-символьных ID не меняется.
- Добавлены регрессионные проверки для трёх обрезанных покупок, разных торговых точек с одинаковыми реквизитами и слишком короткого общего префикса.

## Проверка

- scoped `ts-standard` для изменённых файлов — успешно;
- `tsc --noEmit` — успешно;
- `yarn jest zepterbank-by --runInBand` — 8 suites, 58 tests успешно;
- production-сборка `yarn build zepterbank-by` — успешно;
- обезличенная живая проверка ответа банка: три пары мини-история/выписка преобразованы в три операции с тремя уникальными ID;
- `git diff --check` — успешно.

Полная команда `yarn test zepterbank-by` локально останавливается до тестов на уже существующих repo-wide lint-ошибках в неизменённых плагинах. Изменённые файлы проходят отдельную проверку без замечаний.