### PR TITLE
Add Q-Pay plugin

### DIFF
--- a/src/plugins/q-pay/ZenmoneyManifest.xml
+++ b/src/plugins/q-pay/ZenmoneyManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<provider>
+    <id>q-pay</id>
+    <company>0</company>
+    <description>Q-Pay (pay.quantera.pro) — синхронизация балансов открытых кошельков и активных карт без истории операций.</description>
+    <version>1.0</version>
+    <build>1</build>
+    <modular>true</modular>
+    <codeRequired>false</codeRequired>
+    <files>
+        <js>index.js</js>
+        <preferences>preferences.xml</preferences>
+    </files>
+</provider>

--- a/src/plugins/q-pay/ZenmoneyManifest.xml
+++ b/src/plugins/q-pay/ZenmoneyManifest.xml
@@ -2,7 +2,7 @@
 <provider>
     <id>q-pay</id>
     <company>0</company>
-    <description>Q-Pay (pay.quantera.pro) — синхронизация балансов открытых кошельков и активных карт без истории операций.</description>
+    <description>Q-Pay (pay.quantera.pro) — синхронизация кошельков, активных карт и истории операций.</description>
     <version>1.0</version>
     <build>1</build>
     <modular>true</modular>

--- a/src/plugins/q-pay/__tests__/api.test.ts
+++ b/src/plugins/q-pay/__tests__/api.test.ts
@@ -1,0 +1,78 @@
+const mockLogin = jest.fn()
+const mockFetchCurrentUser = jest.fn()
+const mockFetchCards = jest.fn()
+const mockFetchCardBalance = jest.fn()
+
+jest.mock('../fetchApi', () => {
+  const actual = jest.requireActual('../fetchApi')
+  return {
+    ...actual,
+    login: mockLogin,
+    fetchCurrentUser: mockFetchCurrentUser,
+    fetchCards: mockFetchCards,
+    fetchCardBalance: mockFetchCardBalance
+  }
+})
+
+describe('Q-Pay scrape orchestration', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { scrapeQPay } = require('../api') as typeof import('../api')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { SessionExpiredError } = require('../fetchApi') as typeof import('../fetchApi')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFetchCurrentUser.mockResolvedValue({
+      wallets: [{ address: '0x-example', network: 'evm:1', balances: [{ asset: 'USDT', value: '10' }] }]
+    })
+    mockFetchCards.mockResolvedValue([
+      { id: 'open-card', status: 'ACTIVE', is_revoked: false },
+      { id: 'closed-card', status: 'CLOSED', is_revoked: false },
+      { id: 'revoked-card', status: 'ACTIVE', is_revoked: true }
+    ])
+    mockFetchCardBalance.mockResolvedValue({ available_balance: '20', card_currency: 'USD' })
+  })
+
+  it('reuses a valid stored session and fetches balances only for open cards', async () => {
+    const stored = { email: 'user@example.com', accessToken: 'stored-token' }
+    const result = await scrapeQPay({ email: 'USER@example.com', password: 'password' }, stored)
+
+    expect(mockLogin).not.toHaveBeenCalled()
+    expect(mockFetchCardBalance).toHaveBeenCalledTimes(1)
+    expect(mockFetchCardBalance).toHaveBeenCalledWith(stored, 'open-card')
+    expect(result.accounts.map(account => account.id)).toEqual([
+      'q-pay:wallet:evm:1:0x-example:USDT',
+      'q-pay:card:open-card'
+    ])
+    expect(result.transactions).toEqual([])
+  })
+
+  it('logs in once more when the stored bearer session expired', async () => {
+    const stored = { email: 'user@example.com', accessToken: 'expired-token' }
+    const fresh = { email: 'user@example.com', accessToken: 'fresh-token' }
+    mockFetchCurrentUser
+      .mockRejectedValueOnce(new SessionExpiredError())
+      .mockResolvedValueOnce({ wallets: [] })
+    mockLogin.mockResolvedValue(fresh)
+
+    const result = await scrapeQPay({ email: 'user@example.com', password: 'password' }, stored)
+
+    expect(mockLogin).toHaveBeenCalledTimes(1)
+    expect(mockFetchCurrentUser).toHaveBeenLastCalledWith(fresh)
+    expect(result.session).toBe(fresh)
+  })
+
+  it('does not reuse a session belonging to another login', async () => {
+    const fresh = { email: 'new@example.com', accessToken: 'fresh-token' }
+    mockLogin.mockResolvedValue(fresh)
+    mockFetchCards.mockResolvedValue([])
+
+    await scrapeQPay(
+      { email: 'new@example.com', password: 'password' },
+      { email: 'old@example.com', accessToken: 'old-token' }
+    )
+
+    expect(mockLogin).toHaveBeenCalledTimes(1)
+    expect(mockFetchCurrentUser).toHaveBeenCalledWith(fresh)
+  })
+})

--- a/src/plugins/q-pay/__tests__/api.test.ts
+++ b/src/plugins/q-pay/__tests__/api.test.ts
@@ -2,6 +2,8 @@ const mockLogin = jest.fn()
 const mockFetchCurrentUser = jest.fn()
 const mockFetchCards = jest.fn()
 const mockFetchCardBalance = jest.fn()
+const mockFetchWalletTransactions = jest.fn()
+const mockFetchCardTransactions = jest.fn()
 
 jest.mock('../fetchApi', () => {
   const actual = jest.requireActual('../fetchApi')
@@ -10,7 +12,9 @@ jest.mock('../fetchApi', () => {
     login: mockLogin,
     fetchCurrentUser: mockFetchCurrentUser,
     fetchCards: mockFetchCards,
-    fetchCardBalance: mockFetchCardBalance
+    fetchCardBalance: mockFetchCardBalance,
+    fetchWalletTransactions: mockFetchWalletTransactions,
+    fetchCardTransactions: mockFetchCardTransactions
   }
 })
 
@@ -19,6 +23,8 @@ describe('Q-Pay scrape orchestration', () => {
   const { scrapeQPay } = require('../api') as typeof import('../api')
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const { SessionExpiredError } = require('../fetchApi') as typeof import('../fetchApi')
+  const fromDate = new Date('2026-01-01T00:00:00Z')
+  const toDate = new Date('2026-12-31T23:59:59Z')
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -31,15 +37,20 @@ describe('Q-Pay scrape orchestration', () => {
       { id: 'revoked-card', status: 'ACTIVE', is_revoked: true }
     ])
     mockFetchCardBalance.mockResolvedValue({ available_balance: '20', card_currency: 'USD' })
+    mockFetchWalletTransactions.mockResolvedValue([])
+    mockFetchCardTransactions.mockResolvedValue([])
   })
 
-  it('reuses a valid stored session and fetches balances only for open cards', async () => {
+  it('reuses a valid stored session and fetches balances and history only for open cards', async () => {
     const stored = { email: 'user@example.com', accessToken: 'stored-token' }
-    const result = await scrapeQPay({ email: 'USER@example.com', password: 'password' }, stored)
+    const result = await scrapeQPay({ email: 'USER@example.com', password: 'password' }, stored, fromDate, toDate)
 
     expect(mockLogin).not.toHaveBeenCalled()
     expect(mockFetchCardBalance).toHaveBeenCalledTimes(1)
     expect(mockFetchCardBalance).toHaveBeenCalledWith(stored, 'open-card')
+    expect(mockFetchWalletTransactions).toHaveBeenCalledWith(stored, fromDate, toDate)
+    expect(mockFetchCardTransactions).toHaveBeenCalledTimes(1)
+    expect(mockFetchCardTransactions).toHaveBeenCalledWith(stored, 'open-card', fromDate, toDate)
     expect(result.accounts.map(account => account.id)).toEqual([
       'q-pay:wallet:evm:1:0x-example:USDT',
       'q-pay:card:open-card'
@@ -55,7 +66,7 @@ describe('Q-Pay scrape orchestration', () => {
       .mockResolvedValueOnce({ wallets: [] })
     mockLogin.mockResolvedValue(fresh)
 
-    const result = await scrapeQPay({ email: 'user@example.com', password: 'password' }, stored)
+    const result = await scrapeQPay({ email: 'user@example.com', password: 'password' }, stored, fromDate, toDate)
 
     expect(mockLogin).toHaveBeenCalledTimes(1)
     expect(mockFetchCurrentUser).toHaveBeenLastCalledWith(fresh)
@@ -69,7 +80,9 @@ describe('Q-Pay scrape orchestration', () => {
 
     await scrapeQPay(
       { email: 'new@example.com', password: 'password' },
-      { email: 'old@example.com', accessToken: 'old-token' }
+      { email: 'old@example.com', accessToken: 'old-token' },
+      fromDate,
+      toDate
     )
 
     expect(mockLogin).toHaveBeenCalledTimes(1)

--- a/src/plugins/q-pay/__tests__/converters.test.ts
+++ b/src/plugins/q-pay/__tests__/converters.test.ts
@@ -1,0 +1,90 @@
+import { convertCard, convertWallets, isOpenCard } from '../converters'
+
+describe('Q-Pay account conversion', () => {
+  it('keeps each opened network and asset as a separate wallet account', () => {
+    expect(convertWallets([
+      {
+        address: '0x-example',
+        network: 'evm:1',
+        balances: [
+          { asset: 'USDT', value: '12.34' },
+          { asset: 'USDC', value: '0' }
+        ]
+      },
+      {
+        address: 'T-example',
+        network: 'tron:mainnet',
+        balances: [{ asset: 'USDT', value: 5 }]
+      }
+    ])).toEqual([
+      {
+        id: 'q-pay:wallet:evm:1:0x-example:USDT',
+        type: 'checking',
+        title: 'Q-Pay USDT · Ethereum',
+        instrument: 'USD',
+        balance: 12.34,
+        syncIds: ['q-pay:wallet:evm:1:0x-example:USDT'],
+        savings: false
+      },
+      {
+        id: 'q-pay:wallet:evm:1:0x-example:USDC',
+        type: 'checking',
+        title: 'Q-Pay USDC · Ethereum',
+        instrument: 'USD',
+        balance: 0,
+        syncIds: ['q-pay:wallet:evm:1:0x-example:USDC'],
+        savings: false
+      },
+      {
+        id: 'q-pay:wallet:tron:mainnet:T-example:USDT',
+        type: 'checking',
+        title: 'Q-Pay USDT · TRON',
+        instrument: 'USD',
+        balance: 5,
+        syncIds: ['q-pay:wallet:tron:mainnet:T-example:USDT'],
+        savings: false
+      }
+    ])
+  })
+
+  it('does not invent a zero balance for malformed data', () => {
+    expect(convertWallets([
+      { address: '0x-example', network: 'evm:56', balances: [{ asset: 'USDT', value: 'not-a-number' }] },
+      { network: null, balances: [{ asset: 'USDT', value: '1' }] },
+      { address: '0x-other', network: 'evm:1', balances: [{ asset: null, value: '1' }] }
+    ])).toEqual([{
+      id: 'q-pay:wallet:evm:56:0x-example:USDT',
+      type: 'checking',
+      title: 'Q-Pay USDT · BNB Smart Chain',
+      instrument: 'USD',
+      balance: null,
+      syncIds: ['q-pay:wallet:evm:56:0x-example:USDT'],
+      savings: false
+    }])
+  })
+
+  it('accepts only active, non-revoked cards', () => {
+    expect(isOpenCard({ id: '1', status: 'ACTIVE', is_revoked: false })).toBe(true)
+    expect(isOpenCard({ id: '2', status: 'active', is_revoked: false })).toBe(true)
+    expect(isOpenCard({ id: '3', status: 'ACTIVE', is_revoked: true })).toBe(false)
+    expect(isOpenCard({ id: '4', status: 'CLOSED', is_revoked: false })).toBe(false)
+    expect(isOpenCard({ status: 'ACTIVE', is_revoked: false })).toBe(false)
+  })
+
+  it('converts an active card balance without importing card details', () => {
+    expect(convertCard({
+      card: { id: 'card-id', status: 'ACTIVE', is_revoked: false },
+      balance: { available_balance: '159.25', card_currency: 'USD' }
+    })).toEqual({
+      id: 'q-pay:card:card-id',
+      type: 'ccard',
+      title: 'Q-Pay Card',
+      instrument: 'USD',
+      balance: 159.25,
+      available: 159.25,
+      creditLimit: 0,
+      syncIds: ['q-pay:card:card-id', 'card-id'],
+      savings: false
+    })
+  })
+})

--- a/src/plugins/q-pay/__tests__/converters.test.ts
+++ b/src/plugins/q-pay/__tests__/converters.test.ts
@@ -1,4 +1,5 @@
-import { convertCard, convertWallets, isOpenCard } from '../converters'
+import { convertCard, convertTransactions, convertWallets, isOpenCard } from '../converters'
+import { Account, AccountType } from '../../../types/zenmoney'
 
 describe('Q-Pay account conversion', () => {
   it('keeps each opened network and asset as a separate wallet account', () => {
@@ -85,6 +86,244 @@ describe('Q-Pay account conversion', () => {
       creditLimit: 0,
       syncIds: ['q-pay:card:card-id', 'card-id'],
       savings: false
+    })
+  })
+})
+
+describe('Q-Pay transaction conversion', () => {
+  const wallets = [{
+    address: '0x-wallet',
+    network: 'evm:56',
+    balances: [{ asset: 'USDT', value: '100' }]
+  }]
+  const cardAccounts: Account[] = [{
+    id: 'q-pay:card:card-id',
+    type: AccountType.ccard,
+    title: 'Q-Pay Card',
+    instrument: 'USD',
+    balance: 50,
+    available: 50,
+    creditLimit: 0,
+    syncIds: ['q-pay:card:card-id', 'card-id']
+  }]
+
+  it('converts confirmed wallet income and outcome with the API direction and fee', () => {
+    expect(convertTransactions([
+      {
+        id: 'deposit-id',
+        amount: '100',
+        system_fee: '0',
+        asset: 'USDT',
+        network: 'evm:56',
+        status: 'CONFIRMED',
+        type: 'PAYMENT_GATEWAY_DEPOSIT',
+        created_at: 1767225600
+      },
+      {
+        id: 'purchase-id',
+        amount: '45',
+        system_fee: '2',
+        asset: 'USDT',
+        network: 'evm:56',
+        status: 'CONFIRMED',
+        type: 'CARD_PURCHASE',
+        created_at: 1767225660,
+        in_wallet_address: '0x-wallet'
+      },
+      {
+        id: 'pending-id',
+        amount: '5',
+        asset: 'USDT',
+        network: 'evm:56',
+        status: 'PENDING',
+        type: 'WITHDRAW',
+        created_at: 1767225720
+      }
+    ], [], wallets, cardAccounts)).toEqual([
+      {
+        hold: false,
+        date: new Date('2026-01-01T00:00:00.000Z'),
+        movements: [{
+          id: 'q-pay:wallet-tx:deposit-id',
+          account: { id: 'q-pay:wallet:evm:56:0x-wallet:USDT' },
+          sum: 100,
+          fee: 0,
+          invoice: null
+        }],
+        merchant: null,
+        comment: 'Пополнение Q-Pay'
+      },
+      {
+        hold: false,
+        date: new Date('2026-01-01T00:01:00.000Z'),
+        movements: [{
+          id: 'q-pay:wallet-tx:purchase-id',
+          account: { id: 'q-pay:wallet:evm:56:0x-wallet:USDT' },
+          sum: -45,
+          fee: -2,
+          invoice: null
+        }],
+        merchant: null,
+        comment: 'Покупка карты Q-Pay'
+      }
+    ])
+  })
+
+  it('merges wallet card deposit and card top-up into one transfer', () => {
+    const result = convertTransactions([{
+      id: 'wallet-top-up',
+      amount: '260.01',
+      full_amount: '270',
+      system_fee: '9.99',
+      asset: 'USDT',
+      network: 'evm:56',
+      status: 'CONFIRMED',
+      type: 'CARD_DEPOSIT',
+      created_at: 1767225600,
+      in_wallet_address: '0x-wallet'
+    }], [{
+      cardId: 'card-id',
+      transactions: [{
+        id: 'card-top-up',
+        amount: '260.01',
+        fee: '9.99',
+        currency: 'USD',
+        status: 'POSTED',
+        type: 'TOP_UP',
+        created_at: 1767225682
+      }]
+    }], wallets, cardAccounts)
+
+    expect(result).toEqual([{
+      hold: false,
+      date: new Date('2026-01-01T00:00:00.000Z'),
+      movements: [
+        {
+          id: 'q-pay:wallet-tx:wallet-top-up',
+          account: { id: 'q-pay:wallet:evm:56:0x-wallet:USDT' },
+          sum: -260.01,
+          fee: -9.99,
+          invoice: null
+        },
+        {
+          id: 'q-pay:card-tx:card-top-up',
+          account: { id: 'q-pay:card:card-id' },
+          sum: 260.01,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: null,
+      comment: 'Пополнение карты Q-Pay'
+    }])
+  })
+
+  it('converts a card authorization with merchant and foreign-currency invoice', () => {
+    const result = convertTransactions([], [{
+      cardId: 'card-id',
+      transactions: [{
+        id: 'record-id',
+        x_id: 'canonical-id',
+        amount: '23.23',
+        fee: '0',
+        currency: 'USD',
+        original_amount: '7078.74',
+        original_currency: 'HUF',
+        status: 'SUCCESS',
+        type: 'CHARGE',
+        lifecycle_stage: 'AUTHORIZATION',
+        created_at: 1767225600,
+        merchant: { name: 'Example Shop', mcc: '5411', city: 'Budapest', country: 'HU' }
+      }]
+    }], wallets, cardAccounts)
+
+    expect(result).toEqual([{
+      hold: true,
+      date: new Date('2026-01-01T00:00:00.000Z'),
+      movements: [{
+        id: 'q-pay:card-tx:canonical-id',
+        account: { id: 'q-pay:card:card-id' },
+        sum: -23.23,
+        fee: -0,
+        invoice: { sum: -7078.74, instrument: 'HUF' }
+      }],
+      merchant: {
+        title: 'Example Shop',
+        mcc: 5411,
+        city: 'Budapest',
+        country: 'HU',
+        location: null
+      },
+      comment: null
+    }])
+  })
+
+  it('merges a purchased card initial balance and records the issue cost as a fee', () => {
+    const result = convertTransactions([{
+      id: 'card-id',
+      amount: '45',
+      full_amount: '45',
+      system_fee: '0',
+      asset: 'USDT',
+      network: 'evm:56',
+      status: 'CONFIRMED',
+      type: 'CARD_PURCHASE',
+      created_at: 1767225600,
+      in_wallet_address: '0x-wallet'
+    }], [{
+      cardId: 'card-id',
+      transactions: [{
+        id: 'initial-balance',
+        amount: '10',
+        currency: 'USD',
+        status: 'POSTED',
+        type: 'TOP_UP',
+        created_at: 1767225678
+      }]
+    }], wallets, cardAccounts)
+
+    expect(result).toEqual([{
+      hold: false,
+      date: new Date('2026-01-01T00:00:00.000Z'),
+      movements: [
+        {
+          id: 'q-pay:wallet-tx:card-id',
+          account: { id: 'q-pay:wallet:evm:56:0x-wallet:USDT' },
+          sum: -10,
+          fee: -35,
+          invoice: null
+        },
+        {
+          id: 'q-pay:card-tx:initial-balance',
+          account: { id: 'q-pay:card:card-id' },
+          sum: 10,
+          fee: 0,
+          invoice: null
+        }
+      ],
+      merchant: null,
+      comment: 'Покупка карты Q-Pay'
+    }])
+  })
+
+  it('keeps an unmatched posted card top-up as card income', () => {
+    const result = convertTransactions([], [{
+      cardId: 'card-id',
+      transactions: [{
+        id: 'external-top-up',
+        amount: '10',
+        currency: 'USD',
+        status: 'POSTED',
+        type: 'TOP_UP',
+        created_at: 1767225600
+      }]
+    }], wallets, cardAccounts)
+
+    expect(result[0].movements[0]).toMatchObject({
+      account: { id: 'q-pay:card:card-id' },
+      sum: 10,
+      fee: 0,
+      invoice: null
     })
   })
 })

--- a/src/plugins/q-pay/__tests__/fetchApi.test.ts
+++ b/src/plugins/q-pay/__tests__/fetchApi.test.ts
@@ -13,8 +13,16 @@ const response = (status: number, body: unknown): unknown => ({
 
 describe('Q-Pay API', () => {
   // Require after jest.mock: esbuild does not hoist the mock ahead of static imports.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { fetchCards, fetchCurrentUser, login, SessionExpiredError } = require('../fetchApi') as typeof import('../fetchApi')
+  /* eslint-disable @typescript-eslint/no-var-requires */
+  const {
+    fetchCards,
+    fetchCardTransactions,
+    fetchCurrentUser,
+    fetchWalletTransactions,
+    login,
+    SessionExpiredError
+  } = require('../fetchApi') as typeof import('../fetchApi')
+  /* eslint-enable @typescript-eslint/no-var-requires */
 
   beforeEach(() => {
     mockFetchJson.mockReset()
@@ -66,5 +74,57 @@ describe('Q-Pay API', () => {
       headers: { Authorization: true },
       body: true
     })
+  })
+
+  it('paginates wallet history and keeps only the requested date interval', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `wallet-${index}`,
+      created_at: index === 0 ? 1735689599 : 1767225600
+    }))
+    mockFetchJson
+      .mockResolvedValueOnce(response(200, { total: 101, items: firstPage }))
+      .mockResolvedValueOnce(response(200, {
+        total: 101,
+        items: [{ id: 'wallet-100', created_at: 1798761600 }]
+      }))
+
+    const session = { email: 'user@example.com', accessToken: 'token' }
+    const transactions = await fetchWalletTransactions(
+      session,
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-12-31T23:59:59Z')
+    )
+
+    expect(transactions).toHaveLength(99)
+    expect(mockFetchJson.mock.calls.map(call => call[0])).toEqual([
+      'https://pay.quantera.pro/api/v1/miniapp/transactions?limit=100&offset=0',
+      'https://pay.quantera.pro/api/v1/miniapp/transactions?limit=100&offset=100'
+    ])
+  })
+
+  it('uses the observed card transaction endpoint and encodes the card id', async () => {
+    mockFetchJson.mockResolvedValue(response(200, {
+      total: 1,
+      items: [{ id: 'card-transaction', created_at: 1767225600 }]
+    }))
+
+    await expect(fetchCardTransactions(
+      { email: 'user@example.com', accessToken: 'token' },
+      'card/id',
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-12-31T23:59:59Z')
+    )).resolves.toHaveLength(1)
+    expect(mockFetchJson.mock.calls[0][0]).toBe(
+      'https://pay.quantera.pro/api/v1/miniapp/cards/card%2Fid/transactions?limit=100&offset=0'
+    )
+  })
+
+  it('rejects a malformed transaction page instead of silently returning no history', async () => {
+    mockFetchJson.mockResolvedValue(response(200, { total: 1, results: [] }))
+    await expect(fetchWalletTransactions(
+      { email: 'user@example.com', accessToken: 'token' },
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-12-31T23:59:59Z')
+    )).rejects.toBeInstanceOf(TemporaryError)
   })
 })

--- a/src/plugins/q-pay/__tests__/fetchApi.test.ts
+++ b/src/plugins/q-pay/__tests__/fetchApi.test.ts
@@ -1,0 +1,70 @@
+import { InvalidLoginOrPasswordError, TemporaryError } from '../../../errors'
+
+const mockFetchJson = jest.fn()
+
+jest.mock('../../../common/network', () => ({ fetchJson: mockFetchJson }))
+
+const response = (status: number, body: unknown): unknown => ({
+  status,
+  url: 'https://pay.quantera.pro/api/test',
+  headers: {},
+  body
+})
+
+describe('Q-Pay API', () => {
+  // Require after jest.mock: esbuild does not hoist the mock ahead of static imports.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { fetchCards, fetchCurrentUser, login, SessionExpiredError } = require('../fetchApi') as typeof import('../fetchApi')
+
+  beforeEach(() => {
+    mockFetchJson.mockReset()
+  })
+
+  it('uses the observed multipart login contract and redacts secrets', async () => {
+    mockFetchJson.mockResolvedValue(response(200, { access_token: 'secret', intercom_jwt_token: 'other-secret' }))
+
+    await expect(login({ email: ' User@Example.com ', password: 'Password!1' })).resolves.toEqual({
+      email: 'User@Example.com',
+      accessToken: 'secret'
+    })
+
+    const [url, options] = mockFetchJson.mock.calls[0]
+    expect(url).toBe('https://pay.quantera.pro/api/v1/web/auth/login')
+    expect(options.method).toBe('POST')
+    expect(options.headers['Content-Type']).toMatch(/^multipart\/form-data; boundary=/)
+    expect(options.body).toContain('name="username"\r\n\r\nUser@Example.com')
+    expect(options.body).toContain('name="password"\r\n\r\nPassword!1')
+    expect(options.body).toContain('name="utm_last"\r\n\r\n{}')
+    expect(options.sanitizeRequestLog).toEqual({ headers: { Authorization: true }, body: true })
+    expect(options.sanitizeResponseLog).toEqual({ body: true })
+  })
+
+  it('rejects values that could break the observed form contract before making a request', async () => {
+    await expect(login({ email: 'user@example.com\r\nX-Evil: 1', password: 'Password!1' }))
+      .rejects.toBeInstanceOf(InvalidLoginOrPasswordError)
+    expect(mockFetchJson).not.toHaveBeenCalled()
+  })
+
+  it('maps rejected credentials to a settings error', async () => {
+    mockFetchJson.mockResolvedValue(response(422, { detail: 'rejected' }))
+    await expect(login({ email: 'user@example.com', password: 'wrong-pass' }))
+      .rejects.toBeInstanceOf(InvalidLoginOrPasswordError)
+  })
+
+  it('distinguishes an expired data session from invalid credentials', async () => {
+    mockFetchJson.mockResolvedValue(response(401, { detail: 'expired' }))
+    await expect(fetchCards({ email: 'user@example.com', accessToken: 'old' }))
+      .rejects.toBeInstanceOf(SessionExpiredError)
+  })
+
+  it('treats outages as temporary and never exposes the response body in logs', async () => {
+    mockFetchJson.mockResolvedValue(response(503, { access_token: 'must-not-be-logged' }))
+    await expect(fetchCurrentUser({ email: 'user@example.com', accessToken: 'token' }))
+      .rejects.toBeInstanceOf(TemporaryError)
+    expect(mockFetchJson.mock.calls[0][1].sanitizeResponseLog).toEqual({ body: true })
+    expect(mockFetchJson.mock.calls[0][1].sanitizeRequestLog).toEqual({
+      headers: { Authorization: true },
+      body: true
+    })
+  })
+})

--- a/src/plugins/q-pay/api.ts
+++ b/src/plugins/q-pay/api.ts
@@ -1,0 +1,63 @@
+import { TemporaryError } from '../../errors'
+import { Account, Transaction } from '../../types/zenmoney'
+import { convertCards, convertWallets, isOpenCard } from './converters'
+import {
+  fetchCardBalance,
+  fetchCards,
+  fetchCurrentUser,
+  login,
+  SessionExpiredError
+} from './fetchApi'
+import { isSessionFor, Preferences, QPayCardWithBalance, Session } from './models'
+
+export interface ScrapeOutput {
+  accounts: Account[]
+  transactions: Transaction[]
+  session: Session
+}
+
+async function loadAccounts (session: Session): Promise<Account[]> {
+  const [user, cards] = await Promise.all([
+    fetchCurrentUser(session),
+    fetchCards(session)
+  ])
+  const openCards = cards.filter(isOpenCard)
+  const cardsWithBalances: QPayCardWithBalance[] = await Promise.all(openCards.map(async card => ({
+    card,
+    balance: await fetchCardBalance(session, card.id)
+  })))
+  return [
+    ...convertWallets(user.wallets),
+    ...convertCards(cardsWithBalances)
+  ]
+}
+
+/** Load Q-Pay accounts, re-authenticating once when a persisted session has expired. */
+export async function scrapeQPay (
+  preferences: Preferences,
+  storedSession: unknown
+): Promise<ScrapeOutput> {
+  let session = isSessionFor(storedSession, preferences.email)
+    ? storedSession
+    : await login(preferences)
+
+  let accounts: Account[]
+  try {
+    accounts = await loadAccounts(session)
+  } catch (error) {
+    if (!(error instanceof SessionExpiredError)) {
+      throw error
+    }
+    session = await login(preferences)
+    try {
+      accounts = await loadAccounts(session)
+    } catch (retryError) {
+      if (retryError instanceof SessionExpiredError) {
+        throw new TemporaryError('Q-Pay отклонил новую сессию; повторите синхронизацию позже')
+      }
+      throw retryError
+    }
+  }
+
+  return { accounts, transactions: [], session }
+}

--- a/src/plugins/q-pay/api.ts
+++ b/src/plugins/q-pay/api.ts
@@ -1,14 +1,16 @@
 import { TemporaryError } from '../../errors'
 import { Account, Transaction } from '../../types/zenmoney'
-import { convertCards, convertWallets, isOpenCard } from './converters'
+import { convertCards, convertTransactions, convertWallets, isOpenCard } from './converters'
 import {
   fetchCardBalance,
+  fetchCardTransactions,
   fetchCards,
   fetchCurrentUser,
+  fetchWalletTransactions,
   login,
   SessionExpiredError
 } from './fetchApi'
-import { isSessionFor, Preferences, QPayCardWithBalance, Session } from './models'
+import { isSessionFor, Preferences, QPayCardTransactions, QPayCardWithBalance, Session } from './models'
 
 export interface ScrapeOutput {
   accounts: Account[]
@@ -16,41 +18,59 @@ export interface ScrapeOutput {
   session: Session
 }
 
-async function loadAccounts (session: Session): Promise<Account[]> {
+interface QPayData {
+  accounts: Account[]
+  transactions: Transaction[]
+}
+
+async function loadData (session: Session, fromDate: Date, toDate: Date): Promise<QPayData> {
   const [user, cards] = await Promise.all([
     fetchCurrentUser(session),
     fetchCards(session)
   ])
   const openCards = cards.filter(isOpenCard)
-  const cardsWithBalances: QPayCardWithBalance[] = await Promise.all(openCards.map(async card => ({
+  const cardBalancesPromise: Promise<QPayCardWithBalance[]> = Promise.all(openCards.map(async card => ({
     card,
     balance: await fetchCardBalance(session, card.id)
   })))
-  return [
-    ...convertWallets(user.wallets),
-    ...convertCards(cardsWithBalances)
-  ]
+  const cardTransactionsPromise: Promise<QPayCardTransactions[]> = Promise.all(openCards.map(async card => ({
+    cardId: card.id,
+    transactions: await fetchCardTransactions(session, card.id, fromDate, toDate)
+  })))
+  const [cardsWithBalances, walletTransactions, cardTransactions] = await Promise.all([
+    cardBalancesPromise,
+    fetchWalletTransactions(session, fromDate, toDate),
+    cardTransactionsPromise
+  ])
+  const walletAccounts = convertWallets(user.wallets)
+  const cardAccounts = convertCards(cardsWithBalances)
+  return {
+    accounts: [...walletAccounts, ...cardAccounts],
+    transactions: convertTransactions(walletTransactions, cardTransactions, user.wallets, cardAccounts)
+  }
 }
 
 /** Load Q-Pay accounts, re-authenticating once when a persisted session has expired. */
 export async function scrapeQPay (
   preferences: Preferences,
-  storedSession: unknown
+  storedSession: unknown,
+  fromDate: Date,
+  toDate: Date = new Date()
 ): Promise<ScrapeOutput> {
   let session = isSessionFor(storedSession, preferences.email)
     ? storedSession
     : await login(preferences)
 
-  let accounts: Account[]
+  let data: QPayData
   try {
-    accounts = await loadAccounts(session)
+    data = await loadData(session, fromDate, toDate)
   } catch (error) {
     if (!(error instanceof SessionExpiredError)) {
       throw error
     }
     session = await login(preferences)
     try {
-      accounts = await loadAccounts(session)
+      data = await loadData(session, fromDate, toDate)
     } catch (retryError) {
       if (retryError instanceof SessionExpiredError) {
         throw new TemporaryError('Q-Pay отклонил новую сессию; повторите синхронизацию позже')
@@ -59,5 +79,5 @@ export async function scrapeQPay (
     }
   }
 
-  return { accounts, transactions: [], session }
+  return { ...data, session }
 }

--- a/src/plugins/q-pay/converters.ts
+++ b/src/plugins/q-pay/converters.ts
@@ -1,0 +1,94 @@
+import { Account, AccountOrCard, AccountType } from '../../types/zenmoney'
+import { QPayCard, QPayCardWithBalance, QPayWallet } from './models'
+
+const USD_STABLECOINS = new Set(['USDT', 'USDC'])
+
+const NETWORK_TITLES: Record<string, string> = {
+  'evm:1': 'Ethereum',
+  'evm:56': 'BNB Smart Chain',
+  'tron:mainnet': 'TRON'
+}
+
+function finiteNumberOrNull (value: string | number | null | undefined): number | null {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function normalizeInstrument (asset: string): string {
+  const normalized = asset.trim().toUpperCase()
+  return USD_STABLECOINS.has(normalized) ? 'USD' : normalized
+}
+
+function walletAccountId (network: string, address: string, asset: string): string {
+  return `q-pay:wallet:${network}:${address}:${asset}`
+}
+
+/** Convert every opened Q-Pay network/asset balance into a distinct ZenMoney account. */
+export function convertWallets (wallets: QPayWallet[]): Account[] {
+  const accounts = new Map<string, AccountOrCard>()
+
+  for (const wallet of wallets) {
+    const network = wallet.network?.trim().toLowerCase()
+    const address = wallet.address?.trim()
+    // A network can gain more than one wallet. Its address is therefore part of the
+    // persistent identity; without it two genuine open wallets would overwrite each other.
+    if (network == null || network === '' || address == null || address === '' || !Array.isArray(wallet.balances)) {
+      continue
+    }
+
+    for (const walletBalance of wallet.balances) {
+      const asset = walletBalance.asset?.trim().toUpperCase()
+      if (asset == null || asset === '') {
+        continue
+      }
+      const id = walletAccountId(network, address, asset)
+      const networkTitle = NETWORK_TITLES[network] ?? network
+      accounts.set(id, {
+        id,
+        type: AccountType.checking,
+        title: `Q-Pay ${asset} · ${networkTitle}`,
+        instrument: normalizeInstrument(asset),
+        balance: finiteNumberOrNull(walletBalance.value),
+        syncIds: [id],
+        savings: false
+      })
+    }
+  }
+
+  return [...accounts.values()]
+}
+
+/** True only for cards that Q-Pay explicitly reports as currently active and not revoked. */
+export function isOpenCard (card: QPayCard): card is QPayCard & { id: string } {
+  return typeof card.id === 'string' && card.id.trim() !== '' &&
+    card.status?.trim().toUpperCase() === 'ACTIVE' &&
+    card.is_revoked === false
+}
+
+/** Convert an active Q-Pay card and its available balance into a ZenMoney card account. */
+export function convertCard ({ card, balance }: QPayCardWithBalance): AccountOrCard | null {
+  const cardId = card.id?.trim()
+  if (cardId == null || cardId === '') {
+    return null
+  }
+  const instrument = normalizeInstrument(balance.card_currency ?? 'USD')
+  const available = finiteNumberOrNull(balance.available_balance)
+  const id = `q-pay:card:${cardId}`
+
+  return {
+    id,
+    type: AccountType.ccard,
+    title: 'Q-Pay Card',
+    instrument,
+    balance: available,
+    available,
+    creditLimit: 0,
+    syncIds: [id, cardId],
+    savings: false
+  }
+}
+
+/** Convert active Q-Pay cards, dropping malformed entries without a stable card id. */
+export function convertCards (cards: QPayCardWithBalance[]): Account[] {
+  return cards.map(convertCard).filter((account): account is AccountOrCard => account != null)
+}

--- a/src/plugins/q-pay/converters.ts
+++ b/src/plugins/q-pay/converters.ts
@@ -1,5 +1,12 @@
-import { Account, AccountOrCard, AccountType } from '../../types/zenmoney'
-import { QPayCard, QPayCardWithBalance, QPayWallet } from './models'
+import { Account, AccountOrCard, AccountType, Merchant, Transaction } from '../../types/zenmoney'
+import {
+  QPayCard,
+  QPayCardTransaction,
+  QPayCardTransactions,
+  QPayCardWithBalance,
+  QPayWallet,
+  QPayWalletTransaction
+} from './models'
 
 const USD_STABLECOINS = new Set(['USDT', 'USDC'])
 
@@ -10,16 +17,17 @@ const NETWORK_TITLES: Record<string, string> = {
 }
 
 function finiteNumberOrNull (value: string | number | null | undefined): number | null {
+  if (value == null || value === '') return null
   const parsed = typeof value === 'number' ? value : Number(value)
   return Number.isFinite(parsed) ? parsed : null
 }
 
-function normalizeInstrument (asset: string): string {
+export function normalizeInstrument (asset: string): string {
   const normalized = asset.trim().toUpperCase()
   return USD_STABLECOINS.has(normalized) ? 'USD' : normalized
 }
 
-function walletAccountId (network: string, address: string, asset: string): string {
+export function walletAccountId (network: string, address: string, asset: string): string {
   return `q-pay:wallet:${network}:${address}:${asset}`
 }
 
@@ -91,4 +99,401 @@ export function convertCard ({ card, balance }: QPayCardWithBalance): AccountOrC
 /** Convert active Q-Pay cards, dropping malformed entries without a stable card id. */
 export function convertCards (cards: QPayCardWithBalance[]): Account[] {
   return cards.map(convertCard).filter((account): account is AccountOrCard => account != null)
+}
+
+const WALLET_INCOME_TYPES = new Set([
+  'DP_DEPOSIT',
+  'AK_DEPOSIT',
+  'ALTYN_DEPOSIT',
+  'BLOCKCHAIN_DEPOSIT',
+  'DEPOSIT',
+  'BONUS_CARD_PURCHASE',
+  'BONUS_CARD_DEPOSIT',
+  'TIER_BONUS_CARD_PURCHASE',
+  'TIER_BONUS_CARD_DEPOSIT',
+  'PAYMENT_GATEWAY_DEPOSIT',
+  'PAYMENT_SYSTEM_DEPOSIT',
+  'QR_PAYMENT',
+  'ADMIN_TOPUP',
+  'TIER_BONUS_QR_PAYMENT',
+  'EXCHANGE_ORDER_DEPOSIT'
+])
+
+const WALLET_OUTCOME_TYPES = new Set([
+  'WITHDRAW',
+  'CARD_PURCHASE',
+  'CARD_DEPOSIT',
+  'PHONE_NUMBER_PURCHASE',
+  'PAYMENT_GATEWAY_WITHDRAW',
+  'EXCHANGE_WITHDRAWAL',
+  'STEAM_WITHDRAWAL',
+  'PHONE_WITHDRAWAL',
+  'CARD_WITHDRAWAL'
+])
+
+const CARD_INCOME_TYPES = new Set(['TOP_UP', 'REFUND', 'REVERSAL', 'CASHBACK', 'CREDIT'])
+const CARD_OUTCOME_TYPES = new Set(['CHARGE', 'WITHDRAWAL', 'FEE'])
+const CARD_TOP_UP_MATCH_WINDOW_MS = 10 * 60 * 1000
+
+const WALLET_TYPE_TITLES: Record<string, string> = {
+  CARD_PURCHASE: 'Покупка карты Q-Pay',
+  CARD_DEPOSIT: 'Пополнение карты Q-Pay',
+  PHONE_NUMBER_PURCHASE: 'Покупка номера Q-Pay',
+  PAYMENT_GATEWAY_WITHDRAW: 'Вывод из Q-Pay',
+  PAYMENT_GATEWAY_DEPOSIT: 'Пополнение Q-Pay',
+  PAYMENT_SYSTEM_DEPOSIT: 'Пополнение Q-Pay',
+  QR_PAYMENT: 'QR-платёж Q-Pay',
+  EXCHANGE_WITHDRAWAL: 'Обмен Q-Pay',
+  EXCHANGE_ORDER_DEPOSIT: 'Обмен Q-Pay',
+  STEAM_WITHDRAWAL: 'Пополнение Steam',
+  PHONE_WITHDRAWAL: 'Пополнение телефона',
+  CARD_WITHDRAWAL: 'Вывод с карты Q-Pay'
+}
+
+function normalizedString (value: string | null | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized == null || normalized === '' ? null : normalized
+}
+
+function epochDate (value: string | number | null | undefined): Date | null {
+  if (typeof value === 'number') {
+    const date = new Date(value * 1000)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+  if (typeof value === 'string' && value !== '') {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+  return null
+}
+
+function walletTransactionAccountId (
+  transaction: QPayWalletTransaction,
+  wallets: QPayWallet[]
+): string | null {
+  const network = transaction.network?.trim().toLowerCase()
+  const asset = transaction.asset?.trim().toUpperCase()
+  if (network == null || network === '' || asset == null || asset === '') {
+    return null
+  }
+
+  const candidates = wallets.flatMap(wallet => {
+    const address = normalizedString(wallet.address)
+    const walletNetwork = wallet.network?.trim().toLowerCase()
+    const hasAsset = wallet.balances?.some(balance => balance.asset?.trim().toUpperCase() === asset) === true
+    return address != null && walletNetwork === network && hasAsset
+      ? [{ address, id: walletAccountId(network, address, asset) }]
+      : []
+  })
+  const transactionAddresses = [transaction.in_wallet_address, transaction.out_wallet_address]
+    .map(normalizedString)
+    .filter((value): value is string => value != null)
+  const exact = candidates.filter(candidate => transactionAddresses.includes(candidate.address))
+  if (exact.length === 1) {
+    return exact[0].id
+  }
+  return candidates.length === 1 ? candidates[0].id : null
+}
+
+function walletMovementId (transaction: QPayWalletTransaction): string | null {
+  const id = normalizedString(transaction.id)
+  return id == null ? null : `q-pay:wallet-tx:${id}`
+}
+
+function cardMovementId (transaction: QPayCardTransaction): string | null {
+  const id = normalizedString(transaction.x_id) ?? normalizedString(transaction.id)
+  return id == null ? null : `q-pay:card-tx:${id}`
+}
+
+function isPostedCardTransaction (transaction: QPayCardTransaction): boolean {
+  return ['POSTED', 'SUCCESS'].includes(transaction.status?.trim().toUpperCase() ?? '')
+}
+
+function cardTransactionSign (transaction: QPayCardTransaction): 1 | -1 | null {
+  const type = transaction.type?.trim().toUpperCase() ?? ''
+  if (CARD_INCOME_TYPES.has(type)) return 1
+  if (CARD_OUTCOME_TYPES.has(type)) return -1
+  return null
+}
+
+function cardMerchant (transaction: QPayCardTransaction): Merchant | null {
+  const title = normalizedString(transaction.merchant?.name)
+  if (title == null) return null
+  const mcc = finiteNumberOrNull(transaction.merchant?.mcc)
+  return {
+    title,
+    mcc: mcc == null ? null : Math.trunc(mcc),
+    city: normalizedString(transaction.merchant?.city),
+    country: normalizedString(transaction.merchant?.country),
+    location: null
+  }
+}
+
+function convertCardTransaction (
+  transaction: QPayCardTransaction,
+  cardId: string,
+  cardInstrument: string
+): Transaction | null {
+  if (!isPostedCardTransaction(transaction)) return null
+  const sign = cardTransactionSign(transaction)
+  const amount = finiteNumberOrNull(transaction.amount)
+  const date = epochDate(transaction.created_at)
+  if (sign == null || amount == null || amount === 0 || date == null) return null
+
+  const currency = normalizeInstrument(transaction.currency ?? cardInstrument)
+  const originalAmount = finiteNumberOrNull(transaction.original_amount)
+  const originalCurrency = normalizedString(transaction.original_currency)
+  const signedAmount = sign * Math.abs(amount)
+  const fee = finiteNumberOrNull(transaction.fee) ?? 0
+  const description = normalizedString(transaction.description)
+  const invoice = originalAmount != null && originalCurrency != null && normalizeInstrument(originalCurrency) !== cardInstrument
+    ? { sum: sign * Math.abs(originalAmount), instrument: normalizeInstrument(originalCurrency) }
+    : currency !== cardInstrument
+      ? { sum: signedAmount, instrument: currency }
+      : null
+
+  return {
+    hold: transaction.lifecycle_stage?.trim().toUpperCase() === 'AUTHORIZATION',
+    date,
+    movements: [{
+      id: cardMovementId(transaction),
+      account: { id: `q-pay:card:${cardId}` },
+      sum: currency === cardInstrument ? signedAmount : null,
+      fee: sign < 0 ? -Math.abs(fee) : 0,
+      invoice
+    }],
+    merchant: cardMerchant(transaction),
+    comment: description
+  }
+}
+
+interface CardTransactionEntry {
+  cardId: string
+  transaction: QPayCardTransaction
+}
+
+function cardEntries (groups: QPayCardTransactions[]): CardTransactionEntry[] {
+  return groups.flatMap(group => group.transactions.map(transaction => ({
+    cardId: group.cardId,
+    transaction
+  })))
+}
+
+function matchCardTopUp (
+  walletTransaction: QPayWalletTransaction,
+  entries: CardTransactionEntry[],
+  usedCardTransactions: Set<QPayCardTransaction>
+): CardTransactionEntry | null {
+  const walletAmount = finiteNumberOrNull(walletTransaction.amount)
+  const walletDate = epochDate(walletTransaction.created_at)
+  const walletInstrument = normalizedString(walletTransaction.asset)
+  if (walletAmount == null || walletDate == null || walletInstrument == null) return null
+
+  let closest: CardTransactionEntry | null = null
+  let closestDistance = Number.POSITIVE_INFINITY
+  for (const entry of entries) {
+    const transaction = entry.transaction
+    if (usedCardTransactions.has(transaction) || !isPostedCardTransaction(transaction) || transaction.type?.trim().toUpperCase() !== 'TOP_UP') {
+      continue
+    }
+    const cardAmount = finiteNumberOrNull(transaction.amount)
+    const cardDate = epochDate(transaction.created_at)
+    const cardInstrument = normalizedString(transaction.currency)
+    if (cardAmount == null || cardDate == null || cardInstrument == null ||
+      normalizeInstrument(cardInstrument) !== normalizeInstrument(walletInstrument) ||
+      Math.abs(cardAmount - walletAmount) > 0.000001) {
+      continue
+    }
+    const distance = Math.abs(cardDate.getTime() - walletDate.getTime())
+    if (distance <= CARD_TOP_UP_MATCH_WINDOW_MS && distance < closestDistance) {
+      closest = entry
+      closestDistance = distance
+    }
+  }
+  return closest
+}
+
+function matchCardPurchaseTopUp (
+  walletTransaction: QPayWalletTransaction,
+  entries: CardTransactionEntry[],
+  usedCardTransactions: Set<QPayCardTransaction>
+): CardTransactionEntry | null {
+  const purchasedCardId = normalizedString(walletTransaction.id)
+  const walletCost = finiteNumberOrNull(walletTransaction.full_amount) ?? finiteNumberOrNull(walletTransaction.amount)
+  const walletDate = epochDate(walletTransaction.created_at)
+  const walletInstrument = normalizedString(walletTransaction.asset)
+  if (purchasedCardId == null || walletCost == null || walletDate == null || walletInstrument == null) return null
+
+  let closest: CardTransactionEntry | null = null
+  let closestDistance = Number.POSITIVE_INFINITY
+  for (const entry of entries) {
+    const transaction = entry.transaction
+    const cardAmount = finiteNumberOrNull(transaction.amount)
+    const cardDate = epochDate(transaction.created_at)
+    const cardInstrument = normalizedString(transaction.currency)
+    if (entry.cardId !== purchasedCardId || usedCardTransactions.has(transaction) ||
+      !isPostedCardTransaction(transaction) || transaction.type?.trim().toUpperCase() !== 'TOP_UP' ||
+      cardAmount == null || cardAmount <= 0 || cardAmount > walletCost || cardDate == null || cardInstrument == null ||
+      normalizeInstrument(cardInstrument) !== normalizeInstrument(walletInstrument)) {
+      continue
+    }
+    const distance = Math.abs(cardDate.getTime() - walletDate.getTime())
+    if (distance <= CARD_TOP_UP_MATCH_WINDOW_MS && distance < closestDistance) {
+      closest = entry
+      closestDistance = distance
+    }
+  }
+  return closest
+}
+
+function convertWalletTransaction (
+  transaction: QPayWalletTransaction,
+  wallets: QPayWallet[]
+): Transaction | null {
+  if (transaction.status?.trim().toUpperCase() !== 'CONFIRMED') return null
+  const type = transaction.type?.trim().toUpperCase() ?? ''
+  const sign = WALLET_INCOME_TYPES.has(type) ? 1 : WALLET_OUTCOME_TYPES.has(type) ? -1 : null
+  const amount = finiteNumberOrNull(transaction.amount)
+  const fee = finiteNumberOrNull(transaction.system_fee) ?? 0
+  const date = epochDate(transaction.created_at)
+  const accountId = walletTransactionAccountId(transaction, wallets)
+  if (sign == null || amount == null || amount === 0 || date == null || accountId == null) return null
+
+  return {
+    hold: false,
+    date,
+    movements: [{
+      id: walletMovementId(transaction),
+      account: { id: accountId },
+      sum: sign * Math.abs(amount),
+      fee: sign < 0 ? -Math.abs(fee) : 0,
+      invoice: null
+    }],
+    merchant: null,
+    comment: WALLET_TYPE_TITLES[type] ?? `Q-Pay: ${type}`
+  }
+}
+
+function convertCardDepositTransfer (
+  walletTransaction: QPayWalletTransaction,
+  cardEntry: CardTransactionEntry,
+  wallets: QPayWallet[]
+): Transaction | null {
+  const accountId = walletTransactionAccountId(walletTransaction, wallets)
+  const amount = finiteNumberOrNull(walletTransaction.amount)
+  const fee = finiteNumberOrNull(walletTransaction.system_fee) ?? 0
+  const date = epochDate(walletTransaction.created_at)
+  if (accountId == null || amount == null || amount === 0 || date == null) return null
+
+  return {
+    hold: false,
+    date,
+    movements: [
+      {
+        id: walletMovementId(walletTransaction),
+        account: { id: accountId },
+        sum: -Math.abs(amount),
+        fee: -Math.abs(fee),
+        invoice: null
+      },
+      {
+        id: cardMovementId(cardEntry.transaction),
+        account: { id: `q-pay:card:${cardEntry.cardId}` },
+        sum: Math.abs(amount),
+        fee: 0,
+        invoice: null
+      }
+    ],
+    merchant: null,
+    comment: WALLET_TYPE_TITLES.CARD_DEPOSIT
+  }
+}
+
+function convertCardPurchaseTransfer (
+  walletTransaction: QPayWalletTransaction,
+  cardEntry: CardTransactionEntry,
+  wallets: QPayWallet[]
+): Transaction | null {
+  const accountId = walletTransactionAccountId(walletTransaction, wallets)
+  const walletCost = finiteNumberOrNull(walletTransaction.full_amount) ?? finiteNumberOrNull(walletTransaction.amount)
+  const cardAmount = finiteNumberOrNull(cardEntry.transaction.amount)
+  const date = epochDate(walletTransaction.created_at)
+  if (accountId == null || walletCost == null || cardAmount == null || cardAmount <= 0 || walletCost < cardAmount || date == null) {
+    return null
+  }
+
+  return {
+    hold: false,
+    date,
+    movements: [
+      {
+        id: walletMovementId(walletTransaction),
+        account: { id: accountId },
+        sum: -cardAmount,
+        fee: -(walletCost - cardAmount),
+        invoice: null
+      },
+      {
+        id: cardMovementId(cardEntry.transaction),
+        account: { id: `q-pay:card:${cardEntry.cardId}` },
+        sum: cardAmount,
+        fee: 0,
+        invoice: null
+      }
+    ],
+    merchant: null,
+    comment: WALLET_TYPE_TITLES.CARD_PURCHASE
+  }
+}
+
+/** Convert and reconcile wallet/card histories, merging duplicate card top-up records. */
+export function convertTransactions (
+  walletTransactions: QPayWalletTransaction[],
+  cardTransactions: QPayCardTransactions[],
+  wallets: QPayWallet[],
+  cardAccounts: Account[]
+): Transaction[] {
+  const entries = cardEntries(cardTransactions)
+  const usedCardTransactions = new Set<QPayCardTransaction>()
+  const transactions: Transaction[] = []
+
+  for (const walletTransaction of walletTransactions) {
+    const walletType = walletTransaction.type?.trim().toUpperCase()
+    if (walletTransaction.status?.trim().toUpperCase() === 'CONFIRMED' && walletType === 'CARD_DEPOSIT') {
+      const match = matchCardTopUp(walletTransaction, entries, usedCardTransactions)
+      if (match != null) {
+        const transfer = convertCardDepositTransfer(walletTransaction, match, wallets)
+        if (transfer != null) {
+          transactions.push(transfer)
+          usedCardTransactions.add(match.transaction)
+          continue
+        }
+      }
+    }
+    if (walletTransaction.status?.trim().toUpperCase() === 'CONFIRMED' && walletType === 'CARD_PURCHASE') {
+      const match = matchCardPurchaseTopUp(walletTransaction, entries, usedCardTransactions)
+      if (match != null) {
+        const transfer = convertCardPurchaseTransfer(walletTransaction, match, wallets)
+        if (transfer != null) {
+          transactions.push(transfer)
+          usedCardTransactions.add(match.transaction)
+          continue
+        }
+      }
+    }
+    const converted = convertWalletTransaction(walletTransaction, wallets)
+    if (converted != null) transactions.push(converted)
+  }
+
+  const instruments = new Map(cardAccounts.map(account => [account.id, account.instrument]))
+  for (const entry of entries) {
+    if (usedCardTransactions.has(entry.transaction)) continue
+    const accountId = `q-pay:card:${entry.cardId}`
+    const instrument = instruments.get(accountId)
+    if (instrument == null) continue
+    const converted = convertCardTransaction(entry.transaction, entry.cardId, instrument)
+    if (converted != null) transactions.push(converted)
+  }
+
+  return transactions.sort((left, right) => left.date.getTime() - right.date.getTime())
 }

--- a/src/plugins/q-pay/fetchApi.ts
+++ b/src/plugins/q-pay/fetchApi.ts
@@ -1,0 +1,144 @@
+import { fetchJson, FetchOptions, FetchResponse } from '../../common/network'
+import { InvalidLoginOrPasswordError, TemporaryError } from '../../errors'
+import { generateRandomString } from '../../common/utils'
+import {
+  normalizeEmail,
+  Preferences,
+  QPayCard,
+  QPayCardBalance,
+  QPayUser,
+  QPAY_BASE_URL,
+  QPAY_ENDPOINTS,
+  Session
+} from './models'
+
+const COMMON_HEADERS = {
+  Accept: 'application/json, text/plain, */*',
+  Origin: 'https://pay.quantera.pro',
+  Referer: 'https://pay.quantera.pro/',
+  locale: 'ru'
+}
+
+const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const PASSWORD_REGEXP = /^[\w!@#$%^&*()\-_+.]{8,}$/
+
+const LOG_REDACTION: Pick<FetchOptions, 'sanitizeRequestLog' | 'sanitizeResponseLog'> = {
+  // Login uses a serialized multipart body, so redact it as one opaque value. The same
+  // policy also protects the Bearer header on subsequent requests.
+  sanitizeRequestLog: { headers: { Authorization: true }, body: true },
+  // /users/self contains personal data and wallet addresses; auth responses contain two
+  // tokens. Redacting every response body is the smallest policy that covers both.
+  sanitizeResponseLog: { body: true }
+}
+
+/** Internal control-flow error used to trigger one credential re-login. */
+export class SessionExpiredError extends Error {
+  constructor () {
+    super('Q-Pay session expired')
+    this.name = 'SessionExpiredError'
+  }
+}
+
+function multipartBody (fields: Record<string, string>): { body: string, boundary: string } {
+  const boundary = `----ZenMoneyFormBoundary${generateRandomString(24)}`
+  const body = Object.entries(fields)
+    .map(([name, value]) =>
+      `--${boundary}\r\n` +
+      `Content-Disposition: form-data; name="${name}"\r\n\r\n` +
+      `${value}\r\n`
+    )
+    .join('') + `--${boundary}--\r\n`
+  return { body, boundary }
+}
+
+async function request (
+  path: string,
+  session?: Session,
+  options: FetchOptions = {},
+  isLogin = false
+): Promise<FetchResponse> {
+  const response = await fetchJson(QPAY_BASE_URL + path, {
+    ...options,
+    ...LOG_REDACTION,
+    headers: {
+      ...COMMON_HEADERS,
+      ...(options.headers as Record<string, string> | undefined),
+      ...(session != null ? { Authorization: `Bearer ${session.accessToken}` } : {})
+    }
+  })
+
+  if (response.status === 429 || response.status >= 500) {
+    throw new TemporaryError(`Q-Pay временно недоступен (HTTP ${response.status})`)
+  }
+  if (response.status === 401 || response.status === 403) {
+    if (isLogin) {
+      throw new InvalidLoginOrPasswordError('Q-Pay: неверный email или пароль')
+    }
+    throw new SessionExpiredError()
+  }
+  if (response.status >= 400) {
+    if (isLogin) {
+      throw new InvalidLoginOrPasswordError('Q-Pay: неверный email или пароль')
+    }
+    throw new TemporaryError(`Q-Pay вернул ошибку HTTP ${response.status} для ${path}`)
+  }
+  return response
+}
+
+/** Authenticate with the same multipart contract as pay.quantera.pro. */
+export async function login (preferences: Preferences): Promise<Session> {
+  const email = normalizeEmail(preferences.email)
+  // Besides matching the web form, validation prevents CR/LF values from injecting a
+  // second multipart part into the serialized credential request.
+  if (!EMAIL_REGEXP.test(email) || !PASSWORD_REGEXP.test(preferences.password)) {
+    throw new InvalidLoginOrPasswordError('Q-Pay: проверьте email и пароль в настройках')
+  }
+  const { body, boundary } = multipartBody({
+    username: email,
+    password: preferences.password,
+    utm_last: '{}'
+  })
+  const response = await request(QPAY_ENDPOINTS.login, undefined, {
+    method: 'POST',
+    body,
+    // fetchJson normally serializes bodies as JSON. Multipart is already serialized.
+    stringify: (value: unknown) => value,
+    headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` }
+  }, true)
+  const data = response.body as { access_token?: unknown } | null | undefined
+  if (typeof data?.access_token !== 'string' || data.access_token === '') {
+    throw new InvalidLoginOrPasswordError('Q-Pay не вернул токен доступа')
+  }
+  return { email, accessToken: data.access_token }
+}
+
+/** Fetch the current user and their actually opened wallet networks. */
+export async function fetchCurrentUser (session: Session): Promise<QPayUser> {
+  const response = await request(QPAY_ENDPOINTS.currentUser, session)
+  const data = response.body as { wallets?: unknown } | null | undefined
+  const wallets = data?.wallets
+  if (!Array.isArray(wallets)) {
+    throw new TemporaryError('Q-Pay вернул неожиданный список кошельков')
+  }
+  return { wallets: wallets as QPayUser['wallets'] }
+}
+
+/** Fetch all card records; lifecycle filtering is applied separately. */
+export async function fetchCards (session: Session): Promise<QPayCard[]> {
+  const response = await request(QPAY_ENDPOINTS.cards, session)
+  const data = response.body as { results?: unknown } | null | undefined
+  const results = data?.results
+  if (!Array.isArray(results)) {
+    throw new TemporaryError('Q-Pay вернул неожиданный список карт')
+  }
+  return results as QPayCard[]
+}
+
+/** Fetch the available balance for one active card. */
+export async function fetchCardBalance (session: Session, cardId: string): Promise<QPayCardBalance> {
+  const response = await request(`${QPAY_ENDPOINTS.cards}/${encodeURIComponent(cardId)}/balance`, session)
+  if (response.body == null || typeof response.body !== 'object') {
+    throw new TemporaryError('Q-Pay вернул неожиданный баланс карты')
+  }
+  return response.body as QPayCardBalance
+}

--- a/src/plugins/q-pay/fetchApi.ts
+++ b/src/plugins/q-pay/fetchApi.ts
@@ -6,7 +6,9 @@ import {
   Preferences,
   QPayCard,
   QPayCardBalance,
+  QPayCardTransaction,
   QPayUser,
+  QPayWalletTransaction,
   QPAY_BASE_URL,
   QPAY_ENDPOINTS,
   Session
@@ -21,6 +23,7 @@ const COMMON_HEADERS = {
 
 const EMAIL_REGEXP = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const PASSWORD_REGEXP = /^[\w!@#$%^&*()\-_+.]{8,}$/
+const PAGE_SIZE = 100
 
 const LOG_REDACTION: Pick<FetchOptions, 'sanitizeRequestLog' | 'sanitizeResponseLog'> = {
   // Login uses a serialized multipart body, so redact it as one opaque value. The same
@@ -141,4 +144,82 @@ export async function fetchCardBalance (session: Session, cardId: string): Promi
     throw new TemporaryError('Q-Pay вернул неожиданный баланс карты')
   }
   return response.body as QPayCardBalance
+}
+
+function transactionDate (value: string | number | null | undefined): Date | null {
+  if (typeof value === 'number') {
+    const date = new Date(value * 1000)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+  if (typeof value === 'string' && value !== '') {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+  return null
+}
+
+async function fetchTransactionPages<T extends { created_at?: string | number | null }> (
+  session: Session,
+  path: string,
+  fromDate: Date,
+  toDate: Date
+): Promise<T[]> {
+  const result: T[] = []
+  let offset = 0
+
+  while (true) {
+    const separator = path.includes('?') ? '&' : '?'
+    const response = await request(`${path}${separator}limit=${PAGE_SIZE}&offset=${offset}`, session)
+    const body = response.body as { items?: unknown, total?: unknown } | null | undefined
+    const responseItems = body?.items
+    if (!Array.isArray(responseItems)) {
+      throw new TemporaryError('Q-Pay вернул неожиданную историю операций')
+    }
+
+    const items = responseItems as T[]
+    result.push(...items.filter(item => {
+      const date = transactionDate(item.created_at)
+      return date != null && date >= fromDate && date <= toDate
+    }))
+
+    offset += items.length
+    const responseTotal = body?.total
+    const total = typeof responseTotal === 'number' && Number.isFinite(responseTotal)
+      ? responseTotal
+      : null
+    if (items.length === 0 || (total != null ? offset >= total : items.length < PAGE_SIZE)) {
+      break
+    }
+  }
+
+  return result
+}
+
+/** Fetch wallet operations in the requested ZenMoney date interval. */
+export async function fetchWalletTransactions (
+  session: Session,
+  fromDate: Date,
+  toDate: Date
+): Promise<QPayWalletTransaction[]> {
+  return await fetchTransactionPages<QPayWalletTransaction>(
+    session,
+    QPAY_ENDPOINTS.transactions,
+    fromDate,
+    toDate
+  )
+}
+
+/** Fetch operations for one active Q-Pay card in the requested date interval. */
+export async function fetchCardTransactions (
+  session: Session,
+  cardId: string,
+  fromDate: Date,
+  toDate: Date
+): Promise<QPayCardTransaction[]> {
+  return await fetchTransactionPages<QPayCardTransaction>(
+    session,
+    `${QPAY_ENDPOINTS.cards}/${encodeURIComponent(cardId)}/transactions`,
+    fromDate,
+    toDate
+  )
 }

--- a/src/plugins/q-pay/index.ts
+++ b/src/plugins/q-pay/index.ts
@@ -2,11 +2,13 @@ import { ScrapeFunc } from '../../types/zenmoney'
 import { scrapeQPay } from './api'
 import { Preferences } from './models'
 
-/** Q-Pay plugin entrypoint: balances only, intentionally no transaction history. */
-export const scrape: ScrapeFunc<Preferences> = async ({ preferences }) => {
+/** Q-Pay plugin entrypoint. */
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences, fromDate, toDate }) => {
   const { accounts, transactions, session } = await scrapeQPay(
     preferences,
-    ZenMoney.getData('session')
+    ZenMoney.getData('session'),
+    fromDate,
+    toDate ?? new Date()
   )
   ZenMoney.setData('session', session)
   ZenMoney.saveData()

--- a/src/plugins/q-pay/index.ts
+++ b/src/plugins/q-pay/index.ts
@@ -1,0 +1,14 @@
+import { ScrapeFunc } from '../../types/zenmoney'
+import { scrapeQPay } from './api'
+import { Preferences } from './models'
+
+/** Q-Pay plugin entrypoint: balances only, intentionally no transaction history. */
+export const scrape: ScrapeFunc<Preferences> = async ({ preferences }) => {
+  const { accounts, transactions, session } = await scrapeQPay(
+    preferences,
+    ZenMoney.getData('session')
+  )
+  ZenMoney.setData('session', session)
+  ZenMoney.saveData()
+  return { accounts, transactions }
+}

--- a/src/plugins/q-pay/models.ts
+++ b/src/plugins/q-pay/models.ts
@@ -1,0 +1,67 @@
+/** User-configured Q-Pay credentials. */
+export interface Preferences {
+  email: string
+  password: string
+}
+
+/** Bearer session persisted between synchronizations. */
+export interface Session {
+  email: string
+  accessToken: string
+}
+
+/** Return a normalized email for authentication and persisted-session matching. */
+export function normalizeEmail (email: string): string {
+  return email.trim()
+}
+
+/** Validate untrusted session data loaded from ZenMoney storage. */
+export function isSessionFor (value: unknown, email: string): value is Session {
+  if (value == null || typeof value !== 'object') {
+    return false
+  }
+  const session = value as Partial<Session>
+  return typeof session.email === 'string' &&
+    normalizeEmail(session.email).toLowerCase() === normalizeEmail(email).toLowerCase() &&
+    typeof session.accessToken === 'string' &&
+    session.accessToken !== ''
+}
+
+export interface QPayWalletBalance {
+  asset?: string | null
+  value?: string | number | null
+}
+
+export interface QPayWallet {
+  address?: string | null
+  network?: string | null
+  balances?: QPayWalletBalance[] | null
+}
+
+export interface QPayUser {
+  wallets: QPayWallet[]
+}
+
+export interface QPayCard {
+  id?: string | null
+  status?: string | null
+  is_revoked?: boolean | null
+}
+
+export interface QPayCardBalance {
+  available_balance?: string | number | null
+  card_currency?: string | null
+}
+
+export interface QPayCardWithBalance {
+  card: QPayCard
+  balance: QPayCardBalance
+}
+
+export const QPAY_BASE_URL = 'https://pay.quantera.pro/api'
+
+export const QPAY_ENDPOINTS = {
+  login: '/v1/web/auth/login',
+  currentUser: '/v1/web/users/self',
+  cards: '/v1/miniapp/cards'
+}

--- a/src/plugins/q-pay/models.ts
+++ b/src/plugins/q-pay/models.ts
@@ -2,6 +2,8 @@
 export interface Preferences {
   email: string
   password: string
+  // Required by the shared ZenPlugins date adapter and exposed in preferences.xml.
+  startDate?: string
 }
 
 /** Bearer session persisted between synchronizations. */
@@ -58,10 +60,55 @@ export interface QPayCardWithBalance {
   balance: QPayCardBalance
 }
 
+export interface QPayWalletTransaction {
+  id?: string | null
+  amount?: string | number | null
+  full_amount?: string | number | null
+  system_fee?: string | number | null
+  asset?: string | null
+  network?: string | null
+  status?: string | null
+  type?: string | null
+  created_at?: string | number | null
+  completed_at?: string | number | null
+  in_wallet_address?: string | null
+  out_wallet_address?: string | null
+  transaction_hash?: string | null
+}
+
+export interface QPayCardMerchant {
+  name?: string | null
+  mcc?: string | number | null
+  city?: string | null
+  country?: string | null
+}
+
+export interface QPayCardTransaction {
+  id?: string | null
+  x_id?: string | null
+  amount?: string | number | null
+  fee?: string | number | null
+  currency?: string | null
+  original_amount?: string | number | null
+  original_currency?: string | null
+  status?: string | null
+  type?: string | null
+  lifecycle_stage?: string | null
+  created_at?: string | number | null
+  description?: string | null
+  merchant?: QPayCardMerchant | null
+}
+
+export interface QPayCardTransactions {
+  cardId: string
+  transactions: QPayCardTransaction[]
+}
+
 export const QPAY_BASE_URL = 'https://pay.quantera.pro/api'
 
 export const QPAY_ENDPOINTS = {
   login: '/v1/web/auth/login',
   currentUser: '/v1/web/users/self',
-  cards: '/v1/miniapp/cards'
+  cards: '/v1/miniapp/cards',
+  transactions: '/v1/miniapp/transactions'
 }

--- a/src/plugins/q-pay/preferences.xml
+++ b/src/plugins/q-pay/preferences.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen>
+    <EditTextPreference
+        key="email"
+        obligatory="true"
+        inputType="textEmailAddress"
+        title="Email Q-Pay"
+        dialogTitle="Email Q-Pay"
+        dialogMessage="Введите email, который используется для входа на pay.quantera.pro."
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||{@s}"
+    />
+    <EditTextPreference
+        key="password"
+        obligatory="true"
+        inputType="textPassword"
+        title="Пароль Q-Pay"
+        dialogTitle="Пароль Q-Pay"
+        dialogMessage="Введите пароль от pay.quantera.pro."
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="||********"
+    />
+</PreferenceScreen>

--- a/src/plugins/q-pay/preferences.xml
+++ b/src/plugins/q-pay/preferences.xml
@@ -22,4 +22,16 @@
         negativeButtonText="Отмена"
         summary="||********"
     />
+    <EditTextPreference
+        key="startDate"
+        obligatory="true"
+        inputType="date"
+        title="Начальная дата"
+        defaultValue="2026-01-01T00:00:00.000Z"
+        dialogTitle="Начальная дата"
+        dialogMessage="Операции Q-Pay будут загружены начиная с этой даты."
+        positiveButtonText="ОК"
+        negativeButtonText="Отмена"
+        summary="|startDate|{@s}"
+    />
 </PreferenceScreen>


### PR DESCRIPTION
Это один из мелких финтех сервисов, которым я пользуюсь. Можете пожалуйста вмержить и рассказать, что нужно, чтобы отображалась картинка на картах + счетах
Добавляет синхронизацию [Q-Pay](https://pay.quantera.pro/) для открытых кошельков и активных карт.

- Импортирует балансы и историю операций
- Обрабатывает покупки, пополнения, комиссии, данные продавцов и суммы в исходной валюте
- Переиспользует авторизованную сессию и скрывает чувствительные данные API в логах